### PR TITLE
fix: cloud upload data integrity, multi-file support, and delete-folder MinIO cleanup

### DIFF
--- a/app/routers/cloud.py
+++ b/app/routers/cloud.py
@@ -272,10 +272,60 @@ async def delete_folder(
     uid: int = Depends(get_current_uid),
     db: AsyncSession = Depends(get_db),
 ):
-    """Soft-delete a folder.  When ``force=true``, also deletes the subtree."""
+    """Soft-delete a folder and its files (DB + MinIO).  When ``force=true``,
+    also deletes the subtree."""
     try:
+        from sqlalchemy import select
+        from app.models import CloudFile, CloudFolder
+
         folder_repo = _get_folder_repo()
+        _FOLDER_ALIVE = CloudFolder.deleted_at == None  # noqa: E711
+        _FILE_ALIVE = CloudFile.deleted_at == None  # noqa: E711
+
+        # ---- collect folder IDs in subtree (for force mode) ----
+        folder_ids = [folder_id]
+        if force:
+            # BFS/DFS to collect all descendant folder IDs
+            queue = [folder_id]
+            while queue:
+                parent = queue.pop(0)
+                child_result = await db.execute(
+                    select(CloudFolder.id).where(
+                        CloudFolder.parent_id == parent,
+                        CloudFolder.uid == uid,
+                        _FOLDER_ALIVE,
+                    )
+                )
+                for (cid,) in child_result.all():
+                    folder_ids.append(cid)
+                    queue.append(cid)
+
+        # ---- collect object_keys from all affected files ----
+        result = await db.execute(
+            select(CloudFile.object_key).where(
+                CloudFile.folder_id.in_(folder_ids),
+                CloudFile.uid == uid,
+                _FILE_ALIVE,
+            )
+        )
+        object_keys = [row[0] for row in result.all()]
+
+        # ---- soft-delete in DB ----
         affected = await folder_repo.soft_delete(folder_id, uid, force, db)
+
+        # ---- clean up MinIO objects ----
+        if config.minio.enabled and object_keys:
+            from app.services.cloud.minio_client import get_minio_client
+            minio_cli = get_minio_client()
+            for ok in object_keys:
+                try:
+                    await minio_cli.delete_object(ok)
+                except Exception as exc:
+                    logger.warning(
+                        "[CLOUD] delete_folder minio cleanup failed "
+                        "object_key=%s err=%s", ok, exc,
+                    )
+
         return FolderDeleteResponse(deleted=True, affectedFiles=affected)
     except PermissionError as e:
         raise HTTPException(status_code=403, detail=str(e))

--- a/app/services/cloud/upload_service.py
+++ b/app/services/cloud/upload_service.py
@@ -279,35 +279,20 @@ class CloudUploadService:
     ) -> dict:
         """Finalise a multipart upload.
 
-        Creates the CloudFile DB row only after MinIO confirms the
-        multipart upload — no permanent DB record exists until this
-        method succeeds.
+        Reads metadata from Redis (ownership + object_key + minio_upload_id
+        in one place).  Creates the CloudFile DB row only after MinIO
+        confirms the multipart upload — no permanent DB record exists
+        until this method succeeds.
         """
-        # ---- validate ownership ----
-        file = await self._file_repo.get_by_uuid(upload_uuid, uid, db)
-        if file is None:
-            raise ValueError(
-                f"CloudFile {upload_uuid} not found for user {uid}"
-            )
+        # ---- read metadata from Redis ----
+        meta = await self._get_upload_meta(upload_uuid)
+        if meta["uid"] != uid:
+            raise ValueError(f"Upload {upload_uuid} does not belong to user {uid}")
 
-        # ---- guard: only proceed if still uploading ----
-        if file.upload_status != "uploading":
-            raise ValueError(
-                f"Upload {upload_uuid} is already {file.upload_status}, "
-                f"cannot complete"
-            )
-
-        # ---- get minio_upload_id ----
-        minio_upload_id = await self._chunk_repo.get_minio_upload_id(
-            upload_uuid, db
-        )
-        if not minio_upload_id:
-            raise ValueError(
-                f"No minio_upload_id found for upload_uuid={upload_uuid}"
-            )
+        object_key: str = meta["object_key"]
+        minio_upload_id: str = meta["minio_upload_id"]
 
         # ---- complete MinIO multipart ----
-        object_key = file.object_key
         try:
             etag = await self._minio.complete_multipart_upload(
                 object_key, minio_upload_id, parts,
@@ -318,31 +303,30 @@ class CloudUploadService:
             )
             raise
 
-        # ---- mark DB completed ----
+        # ---- create DB row ----
         try:
+            await self._file_repo.create(
+                upload_uuid=upload_uuid,
+                uid=uid,
+                original_name=meta["original_name"],
+                file_size=meta["file_size"],
+                mime_type=meta["mime_type"],
+                folder_id=meta["folder_id"],
+                bucket=meta["bucket"],
+                object_key=object_key,
+                db=db,
+            )
             await self._file_repo.update_upload_completed(upload_uuid, etag, db)
         except Exception:
             logger.critical(
-                "[CLOUD_UPLOAD] DB update failed after MinIO complete "
+                "[CLOUD_UPLOAD] DB create/update failed after MinIO complete "
                 "upload_uuid=%s etag=%s — manual fix required!",
                 upload_uuid, etag,
             )
             raise
 
-        # ---- clean up chunk rows ----
-        await self._chunk_repo.delete_by_upload(upload_uuid, db)
-
-        # ---- update session (lookup by minio_upload_id) ----
-        try:
-            await self._session_repo.mark_completed_by_minio_upload_id(
-                minio_upload_id, db,
-            )
-        except Exception:
-            logger.debug(
-                "[CLOUD_UPLOAD] session mark_completed skipped "
-                "upload_uuid=%s minio_upload_id=%s",
-                upload_uuid, minio_upload_id,
-            )
+        # ---- clean up Redis ----
+        await self._delete_upload_meta(upload_uuid)
 
         logger.info(
             "[CLOUD_UPLOAD] complete_upload done upload_uuid=%s etag=%s",

--- a/app/services/cloud/upload_service.py
+++ b/app/services/cloud/upload_service.py
@@ -1,6 +1,10 @@
 """
 Cloud upload orchestration — multipart upload lifecycle with resumable
 chunks, heartbeat tracking, and ASR+vector pipeline trigger.
+
+Upload metadata is stored in Redis during the upload window (1 h TTL).
+CloudFile DB rows are only created on successful completion — if the
+client abandons the upload, no permanent DB garbage is left behind.
 """
 
 from __future__ import annotations
@@ -16,18 +20,10 @@ from loguru import logger
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.infra.config import config
-from app.infra.redis import client as redis_client, is_enabled as redis_enabled
+from app.infra.redis import client as redis_client, is_enabled as redis_enabled, k, jset, jget
 from app.repository.cloud.file_repository import (
     get_cloud_file_repository,
     CloudFileRepository,
-)
-from app.repository.cloud.chunk_repository import (
-    get_cloud_chunk_repository,
-    CloudChunkRepository,
-)
-from app.repository.cloud.session_repository import (
-    get_cloud_session_repository,
-    CloudSessionRepository,
 )
 from app.services.cloud.minio_client import get_minio_client, MinioClient
 
@@ -38,7 +34,57 @@ from app.services.cloud.minio_client import get_minio_client, MinioClient
 CHUNK_SIZE: int = 10 * 1024 * 1024       # 10 MB
 MAX_FILE_SIZE: int = 5 * 1024 * 1024 * 1024  # 5 GB
 HEARTBEAT_TTL: int = 300                  # 5 minutes in seconds
-VALID_MIME_PREFIX: str = "video/"
+
+_MIME_TO_EXT: dict[str, str] = {
+    "video/": ".mp4",
+    "text/plain": ".txt",
+    "text/markdown": ".md",
+    "text/x-markdown": ".md",
+    "text/csv": ".csv",
+    "text/html": ".html",
+    "application/pdf": ".pdf",
+    "application/zip": ".zip",
+    "application/x-rar-compressed": ".rar",
+    "application/x-7z-compressed": ".7z",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml": ".docx",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml": ".xlsx",
+    "application/vnd.openxmlformats-officedocument.presentationml": ".pptx",
+    "image/png": ".png",
+    "image/jpeg": ".jpg",
+    "image/gif": ".gif",
+    "image/webp": ".webp",
+    "image/bmp": ".bmp",
+}
+
+
+def _ext_from_mime(mime_type: str) -> str:
+    for prefix, ext in _MIME_TO_EXT.items():
+        if mime_type.startswith(prefix):
+            return ext
+    return ".bin"
+
+
+ALLOWED_MIME_PREFIXES: list[str] = [
+    "video/",
+    "text/plain",
+    "text/markdown",
+    "text/x-markdown",
+    "text/csv",
+    "text/html",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml",
+    "application/vnd.openxmlformats-officedocument.presentationml",
+    "application/pdf",
+    "application/zip",
+    "application/x-rar-compressed",
+    "application/x-7z-compressed",
+    "image/png",
+    "image/jpeg",
+    "image/gif",
+    "image/webp",
+    "image/bmp",
+    "image/tiff",
+]
 
 # ---------------------------------------------------------------------------
 # UUID7 generator (time-ordered)
@@ -48,15 +94,9 @@ _UUID7_EPOCH_MS: int = 0
 
 
 def _uuid7_timestamp() -> int:
-    """Return the current UUID7 epoch-adjusted timestamp in milliseconds.
-
-    UUID7 uses the number of milliseconds since 2020-01-01T00:00:00Z
-    (the UUID version 15 epoch), rolled over so that the 48-bit counter
-    does not overflow until ~8907 CE.
-    """
+    """Return the current UUID7 epoch-adjusted timestamp in milliseconds."""
     global _UUID7_EPOCH_MS
     if _UUID7_EPOCH_MS == 0:
-        # 2020-01-01T00:00:00.000Z in Unix milliseconds
         import datetime as _dt
         _UUID7_EPOCH_MS = int(
             _dt.datetime(2020, 1, 1, tzinfo=_dt.timezone.utc).timestamp() * 1000
@@ -66,28 +106,17 @@ def _uuid7_timestamp() -> int:
 
 
 def _generate_uuid7() -> str:
-    """Generate a time-ordered UUIDv7 string.
-
-    Format: 48-bit Unix timestamp (ms) | 4-bit version (0x7) | 12-bit
-    rand_a | 2-bit variant (10) | 62-bit rand_b.
-    """
+    """Generate a time-ordered UUIDv7 string."""
     ts = _uuid7_timestamp() & 0xFFFFFFFFFFFF  # 48 bits
-
     r = int.from_bytes(os.urandom(10), "big")
-
-    # rand_a: upper 12 bits of r
     rand_a = (r >> 50) & 0xFFF
-    # rand_b: lower 62 bits of r
     rand_b = r & 0x3FFFFFFFFFFFFFFF
-
-    # Assemble fields
     time_low = ts & 0xFFFFFFFF
     time_mid = (ts >> 32) & 0xFFFF
-    time_hi = ((ts >> 48) & 0xFFF) | 0x7000  # version 7
-    clock_seq = (rand_a >> 2) | 0x8000        # variant 10xx
+    time_hi = ((ts >> 48) & 0xFFF) | 0x7000
+    clock_seq = (rand_a >> 2) | 0x8000
     clock_seq_low = rand_a & 0xFF
     node = rand_b
-
     return (
         f"{time_low:08x}-{time_mid:04x}-{time_hi:04x}-"
         f"{clock_seq:04x}-{clock_seq_low:02x}{node:012x}"
@@ -102,27 +131,45 @@ def _generate_uuid7() -> str:
 class CloudUploadService:
     """Orchestrate the full multipart-upload lifecycle.
 
-    Responsibilities
-    ----------------
-    - Validate inputs (file size, mime type)
-    - Create MinIO multipart upload + presigned chunk URLs
-    - Persist file / chunk / session rows via repositories
-    - Track heartbeat in Redis for session liveness
-    - Resume interrupted uploads
-    - Fire-and-forget ASR + vector pipeline on completion
+    Redis stores in-progress upload metadata (key ``cloud:upload:{uuid}``,
+    TTL 1 h).  The DB CloudFile row is only created on successful
+    ``complete_upload`` — abandoned uploads expire from Redis and leave
+    no permanent garbage.
     """
 
     def __init__(
         self,
         minio_client: MinioClient | None = None,
         file_repo: CloudFileRepository | None = None,
-        chunk_repo: CloudChunkRepository | None = None,
-        session_repo: CloudSessionRepository | None = None,
     ) -> None:
         self._minio = minio_client or get_minio_client()
         self._file_repo = file_repo or get_cloud_file_repository()
-        self._chunk_repo = chunk_repo or get_cloud_chunk_repository()
-        self._session_repo = session_repo or get_cloud_session_repository()
+
+    # ------------------------------------------------------------------
+    # Redis helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _upload_key(upload_uuid: str) -> str:
+        return k("cloud", "upload", upload_uuid)
+
+    async def _get_upload_meta(self, upload_uuid: str) -> dict:
+        """Fetch upload metadata from Redis.  Raises ValueError on miss."""
+        if not redis_enabled() or redis_client is None:
+            raise ValueError("Redis is required for cloud uploads")
+        meta = await jget(self._upload_key(upload_uuid))
+        if meta is None:
+            raise ValueError(f"Upload session expired or not found: {upload_uuid}")
+        return meta
+
+    async def _set_upload_meta(self, upload_uuid: str, meta: dict) -> None:
+        if not redis_enabled() or redis_client is None:
+            raise ValueError("Redis is required for cloud uploads")
+        await jset(self._upload_key(upload_uuid), meta, ex=UPLOAD_META_TTL)
+
+    async def _delete_upload_meta(self, upload_uuid: str) -> None:
+        if redis_client is not None:
+            await redis_client.delete(self._upload_key(upload_uuid))
 
     # ------------------------------------------------------------------
     # init_upload
@@ -139,24 +186,22 @@ class CloudUploadService:
     ) -> dict:
         """Start a new multipart upload.
 
-        Returns a dict with *uploadUuid*, *sessionUuid*, *minioUploadId*,
-        *chunkCount*, *chunkSize*, and *presignedUrls* (one per chunk).
+        Only creates the MinIO multipart upload + presigned URLs.
+        The DB record is deferred until :meth:`complete_upload`.
         """
         # ---- validation ----
-        if not mime_type.startswith(VALID_MIME_PREFIX):
+        if not any(mime_type.startswith(p) for p in ALLOWED_MIME_PREFIXES):
             raise ValueError(
-                f"Invalid mime_type={mime_type!r}; must start with 'video/'"
+                f"Unsupported mime_type={mime_type!r}"
             )
         if file_size <= 0:
             raise ValueError(f"file_size must be positive, got {file_size}")
         if file_size > MAX_FILE_SIZE:
-            raise ValueError(
-                f"File too large: {file_size} bytes (max {MAX_FILE_SIZE})"
-            )
+            raise ValueError(f"File too large: {file_size} bytes (max {MAX_FILE_SIZE})")
 
         upload_uuid = _generate_uuid7()
         session_uuid = _generate_uuid7()
-        object_key = f"{uid}/{upload_uuid}/video.mp4"
+        object_key = f"{uid}/{upload_uuid}/file{_ext_from_mime(mime_type)}"
         chunk_count = math.ceil(file_size / CHUNK_SIZE)
 
         logger.info(
@@ -169,42 +214,8 @@ class CloudUploadService:
         try:
             minio_upload_id = await self._minio.create_multipart_upload(object_key)
         except Exception:
-            logger.exception(
-                "[CLOUD_UPLOAD] minio create_multipart_upload failed"
-            )
+            logger.exception("[CLOUD_UPLOAD] minio create_multipart_upload failed")
             raise
-
-        # ---- DB rows ----
-        # 1. CloudFile
-        await self._file_repo.create(
-            upload_uuid=upload_uuid,
-            uid=uid,
-            original_name=filename,
-            file_size=file_size,
-            mime_type=mime_type,
-            folder_id=folder_id,
-            bucket=config.minio.bucket,
-            object_key=object_key,
-            db=db,
-        )
-
-        # 2. CloudUploadChunk batch
-        await self._chunk_repo.batch_create(
-            upload_uuid=upload_uuid,
-            chunk_count=chunk_count,
-            chunk_size=CHUNK_SIZE,
-            minio_upload_id=minio_upload_id,
-            db=db,
-        )
-
-        # 3. CloudUploadSession (one session groups this batch)
-        await self._session_repo.create(
-            session_uuid=session_uuid,
-            uid=uid,
-            minio_upload_id=minio_upload_id,
-            total_files=1,
-            db=db,
-        )
 
         # ---- presigned URLs ----
         presigned_urls: list[str] = []
@@ -220,6 +231,22 @@ class CloudUploadService:
             )
             await self._minio.abort_multipart_upload(object_key, minio_upload_id)
             raise
+
+        # ---- store metadata in Redis (DB record deferred) ----
+        meta = {
+            "uid": uid,
+            "original_name": filename,
+            "file_size": file_size,
+            "mime_type": mime_type,
+            "folder_id": folder_id,
+            "bucket": config.minio.bucket,
+            "object_key": object_key,
+            "minio_upload_id": minio_upload_id,
+            "chunk_count": chunk_count,
+            "chunk_size": CHUNK_SIZE,
+            "session_uuid": session_uuid,
+        }
+        await self._set_upload_meta(upload_uuid, meta)
 
         # ---- heartbeat ----
         await self._set_heartbeat(session_uuid)
@@ -251,14 +278,22 @@ class CloudUploadService:
     ) -> dict:
         """Finalise a multipart upload.
 
-        *parts* must be a list of dicts with ``PartNumber`` (int) and
-        ``ETag`` (str), sorted by part number.
+        Creates the CloudFile DB row only after MinIO confirms the
+        multipart upload — no permanent DB record exists until this
+        method succeeds.
         """
         # ---- validate ownership ----
         file = await self._file_repo.get_by_uuid(upload_uuid, uid, db)
         if file is None:
             raise ValueError(
                 f"CloudFile {upload_uuid} not found for user {uid}"
+            )
+
+        # ---- guard: only proceed if still uploading ----
+        if file.upload_status != "uploading":
+            raise ValueError(
+                f"Upload {upload_uuid} is already {file.upload_status}, "
+                f"cannot complete"
             )
 
         # ---- get minio_upload_id ----
@@ -271,7 +306,6 @@ class CloudUploadService:
             )
 
         # ---- complete MinIO multipart ----
-        object_key = file.object_key
         try:
             etag = await self._minio.complete_multipart_upload(
                 object_key, minio_upload_id, parts,
@@ -280,23 +314,32 @@ class CloudUploadService:
             logger.exception(
                 "[CLOUD_UPLOAD] minio complete_multipart_upload failed"
             )
-            await self._file_repo.update_upload_failed(upload_uuid, db)
             raise
 
         # ---- mark DB completed ----
-        await self._file_repo.update_upload_completed(upload_uuid, etag, db)
+        try:
+            await self._file_repo.update_upload_completed(upload_uuid, etag, db)
+        except Exception:
+            logger.critical(
+                "[CLOUD_UPLOAD] DB update failed after MinIO complete "
+                "upload_uuid=%s etag=%s — manual fix required!",
+                upload_uuid, etag,
+            )
+            raise
 
         # ---- clean up chunk rows ----
         await self._chunk_repo.delete_by_upload(upload_uuid, db)
 
-        # ---- update session ----
+        # ---- update session (lookup by minio_upload_id) ----
         try:
-            await self._session_repo.mark_completed(file.upload_uuid, db)
+            await self._session_repo.mark_completed_by_minio_upload_id(
+                minio_upload_id, db,
+            )
         except Exception:
-            # session may not exist (legacy uploads); non-fatal
             logger.debug(
-                "[CLOUD_UPLOAD] session mark_completed skipped for upload_uuid=%s",
-                upload_uuid,
+                "[CLOUD_UPLOAD] session mark_completed skipped "
+                "upload_uuid=%s minio_upload_id=%s",
+                upload_uuid, minio_upload_id,
             )
 
         logger.info(
@@ -318,22 +361,17 @@ class CloudUploadService:
     # ------------------------------------------------------------------
 
     async def heartbeat(self, session_uuid: str) -> dict:
-        """Write a heartbeat entry to Redis (SETEX, 300s TTL).
-
-        Returns a status dict; graceful degradation when Redis is disabled.
-        """
+        """Write a heartbeat entry to Redis (SETEX, 300s TTL)."""
         await self._set_heartbeat(session_uuid)
         return {"sessionUuid": session_uuid, "status": "alive"}
 
     async def _set_heartbeat(self, session_uuid: str) -> None:
         """Internal: Redis SETEX heartbeat key."""
         if not redis_enabled() or redis_client is None:
-            logger.debug(
-                "[CLOUD_UPLOAD] heartbeat skipped — Redis disabled"
-            )
+            logger.debug("[CLOUD_UPLOAD] heartbeat skipped — Redis disabled")
             return
         try:
-            key = f"{config.redis.key_prefix}cloud:heartbeat:{session_uuid}"
+            key = k("cloud", "heartbeat", session_uuid)
             await redis_client.setex(key, HEARTBEAT_TTL, "alive")
             logger.debug(
                 "[CLOUD_UPLOAD] heartbeat set session_uuid=%s ttl=%d",
@@ -357,46 +395,27 @@ class CloudUploadService:
     ) -> dict:
         """Resume an interrupted upload.
 
-        Returns a dict with *uploadUuid*, *minioUploadId*, and
-        *pendingChunks* (list of dicts with chunk_index, chunk_size,
-        presigned_url).
+        Reads metadata from Redis and generates fresh presigned URLs
+        for all chunks.
         """
-        file = await self._file_repo.get_by_uuid(upload_uuid, uid, db)
-        if file is None:
-            raise ValueError(
-                f"CloudFile {upload_uuid} not found for user {uid}"
-            )
+        meta = await self._get_upload_meta(upload_uuid)
+        if meta["uid"] != uid:
+            raise ValueError(f"Upload {upload_uuid} does not belong to user {uid}")
 
-        if file.upload_status == "completed":
-            return {
-                "uploadUuid": upload_uuid,
-                "status": "already_completed",
-                "pendingChunks": [],
-            }
+        object_key = meta["object_key"]
+        minio_upload_id = meta["minio_upload_id"]
+        chunk_count = meta["chunk_count"]
 
-        minio_upload_id = await self._chunk_repo.get_minio_upload_id(
-            upload_uuid, db
-        )
-        if not minio_upload_id:
-            raise ValueError(
-                f"Upload is not resumable — no minio_upload_id for {upload_uuid}"
-            )
-
-        pending = await self._chunk_repo.get_pending_chunks(upload_uuid, db)
-
-        # Generate fresh presigned URLs for each pending chunk
-        object_key = file.object_key
+        # Generate fresh presigned URLs for every chunk
         pending_chunks: list[dict] = []
         try:
-            for chunk in pending:
+            for part_number in range(1, chunk_count + 1):
                 url = await self._minio.presigned_upload_part(
-                    object_key,
-                    minio_upload_id,
-                    chunk["chunk_index"] + 1,  # part_number is 1-indexed
+                    object_key, minio_upload_id, part_number,
                 )
                 pending_chunks.append({
-                    "chunkIndex": chunk["chunk_index"],
-                    "chunkSize": chunk["chunk_size"],
+                    "chunkIndex": part_number - 1,
+                    "chunkSize": meta["chunk_size"],
                     "presignedUrl": url,
                 })
         except Exception:
@@ -406,7 +425,7 @@ class CloudUploadService:
             raise
 
         logger.info(
-            "[CLOUD_UPLOAD] resume_upload upload_uuid=%s pending=%d",
+            "[CLOUD_UPLOAD] resume_upload upload_uuid=%s chunks=%d",
             upload_uuid, len(pending_chunks),
         )
 
@@ -422,24 +441,15 @@ class CloudUploadService:
     # ------------------------------------------------------------------
 
     async def _trigger_pipeline(self, upload_uuid: str, uid: int) -> None:
-        """Fire-and-forget ASR + vector pipeline.
+        """Fire-and-forget ASR + vector pipeline."""
 
-        Called after a successful upload completion.  Failure here should
-        never propagate to the upload response.
-        """
         async def _run():
             try:
                 logger.info(
                     "[CLOUD_UPLOAD] pipeline triggered upload_uuid=%s uid=%d",
                     upload_uuid, uid,
                 )
-                # TODO: wire up actual ASR + vectorisation when those
-                # modules are cloud-aware.
-                # For now the file is stored; ASR / vector status remain
-                # "pending" and a background worker picks them up.
-                #
-                # from app.services.asr import asr_service
-                # await asr_service.process_cloud_file(upload_uuid, uid)
+                # TODO: wire up actual ASR + vectorisation
             except Exception:
                 logger.exception(
                     "[CLOUD_UPLOAD] pipeline failed upload_uuid=%s",

--- a/app/services/cloud/upload_service.py
+++ b/app/services/cloud/upload_service.py
@@ -34,6 +34,7 @@ from app.services.cloud.minio_client import get_minio_client, MinioClient
 CHUNK_SIZE: int = 10 * 1024 * 1024       # 10 MB
 MAX_FILE_SIZE: int = 5 * 1024 * 1024 * 1024  # 5 GB
 HEARTBEAT_TTL: int = 300                  # 5 minutes in seconds
+UPLOAD_META_TTL: int = 3600               # 1 hour — upload window
 
 _MIME_TO_EXT: dict[str, str] = {
     "video/": ".mp4",
@@ -306,6 +307,7 @@ class CloudUploadService:
             )
 
         # ---- complete MinIO multipart ----
+        object_key = file.object_key
         try:
             etag = await self._minio.complete_multipart_upload(
                 object_key, minio_upload_id, parts,

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -19,7 +19,7 @@ const body = Noto_Sans_SC({
 });
 
 export const metadata: Metadata = {
-  title: "BiliMind - 收藏夹知识库",
+  title: "MindBase - 知识库系统",
   description: "将你的 B站收藏夹变成可对话的知识库",
   icons: {
     icon: [

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -249,7 +249,7 @@ export default function Home() {
               </svg>
             </div>
             <div>
-              <span className="brand-title">BiliMind·收藏夹知识库</span>
+              <span className="brand-title">MindBase</span>
               <span className="brand-subtitle">Save • Learn • Ask</span>
             </div>
           </div>

--- a/frontend/components/PasswordLoginModal.tsx
+++ b/frontend/components/PasswordLoginModal.tsx
@@ -177,7 +177,7 @@ export default function PasswordLoginModal({ isOpen, onClose, onSuccess, onSwitc
 
         {/* ── Brand ── */}
         <div className="flex items-center gap-2 mb-8">
-          <span className="text-xl font-bold tracking-tight text-[var(--accent)]">BiliMind</span>
+          <span className="text-xl font-bold tracking-tight text-[var(--accent)]">MindBase</span>
           <span className="text-[10px] px-2 py-0.5 rounded-full bg-[var(--accent)]/10 text-[var(--accent)] border border-[var(--accent)]/20 font-semibold tracking-wider uppercase">
             Account
           </span>

--- a/frontend/components/dock-modules/cloud-drive.tsx
+++ b/frontend/components/dock-modules/cloud-drive.tsx
@@ -338,9 +338,13 @@ export default function CloudDrivePanel({ isOpen }: DockPanelProps) {
 
       {/* Upload progress bar */}
       {uploading && (
-        <div className="cd-upload-bar">
-          <div className="cd-upload-bar-inner" style={{ width: `${uploadProgress}%` }} />
-          <span className="cd-upload-bar-text">{uploadFileName} — {uploadProgress}%</span>
+        <div className="cd-upload-bar-wrap">
+          <div className="cd-upload-bar-track">
+            <div className="cd-upload-bar-fill" style={{ width: `${uploadProgress}%` }} />
+          </div>
+          <span className="cd-upload-bar-label">
+            {uploadFileName} — {uploadProgress}%
+          </span>
         </div>
       )}
 
@@ -491,16 +495,23 @@ export default function CloudDrivePanel({ isOpen }: DockPanelProps) {
         }
         .cd-input:focus { border-color: rgba(6, 182, 212, 0.6); }
 
-        .cd-upload-bar {
-          position: relative; height: 4px; background: rgba(48, 54, 61, 0.5); flex-shrink: 0;
+        .cd-upload-bar-wrap {
+          display: flex; align-items: center; gap: 12px; padding: 8px 18px;
+          border-bottom: 1px solid rgba(48, 54, 61, 0.88);
+          background: rgba(6, 182, 212, 0.04); flex-shrink: 0;
         }
-        .cd-upload-bar-inner {
-          height: 100%; background: linear-gradient(90deg, #06b6d4, #22d3ee);
-          transition: width .2s ease;
+        .cd-upload-bar-track {
+          flex: 1; height: 8px; border-radius: 4px;
+          background: rgba(48, 54, 61, 0.5); overflow: hidden;
         }
-        .cd-upload-bar-text {
-          position: absolute; top: 6px; left: 50%; transform: translateX(-50%);
-          font-size: 11px; color: #22d3ee; white-space: nowrap;
+        .cd-upload-bar-fill {
+          height: 100%; border-radius: 4px;
+          background: linear-gradient(90deg, #06b6d4, #22d3ee);
+          transition: width .3s ease;
+        }
+        .cd-upload-bar-label {
+          font-size: 12px; color: #22d3ee; white-space: nowrap; font-weight: 500;
+          min-width: 160px; text-align: right;
         }
 
         .cd-create-folder {

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1627,32 +1627,44 @@ export const cloudApi = {
             folderId,
         });
 
-        // 2. Upload each chunk with presigned URLs
+        // 2. Upload each chunk to MinIO with real-time byte progress via XHR
         const parts: CloudUploadPart[] = [];
         const heartbeatInterval = setInterval(() => {
             cloudApi.heartbeat(init.sessionUuid).catch(() => {});
         }, 60_000);
 
         try {
+            let totalUploaded = 0;
             for (const chunk of init.presignedUrls) {
                 const start = chunk.chunkIndex * init.chunkSize;
                 const end = Math.min(start + chunk.chunkSize, file.size);
                 const blob = file.slice(start, end);
 
-                const res = await fetch(chunk.url, {
-                    method: "PUT",
-                    body: blob,
+                await new Promise<void>((resolve, reject) => {
+                    const xhr = new XMLHttpRequest();
+                    xhr.open("PUT", chunk.url);
+                    // Track real-time bytes uploaded within this chunk
+                    xhr.upload.onprogress = (e) => {
+                        if (e.lengthComputable) {
+                            const uploaded = totalUploaded + e.loaded;
+                            const pct = Math.round((uploaded / file.size) * 100);
+                            onProgress?.(pct);
+                        }
+                    };
+                    xhr.onload = () => {
+                        if (xhr.status >= 200 && xhr.status < 300) {
+                            const etag = xhr.getResponseHeader("ETag") ?? "";
+                            parts.push({ PartNumber: chunk.chunkIndex + 1, ETag: etag });
+                            totalUploaded += blob.size;
+                            resolve();
+                        } else {
+                            reject(new Error(`Chunk ${chunk.chunkIndex} upload failed: ${xhr.status}`));
+                        }
+                    };
+                    xhr.onerror = () => reject(new Error(`Chunk ${chunk.chunkIndex} network error`));
+                    xhr.ontimeout = () => reject(new Error(`Chunk ${chunk.chunkIndex} timeout`));
+                    xhr.send(blob);
                 });
-
-                if (!res.ok) {
-                    throw new Error(`Chunk ${chunk.chunkIndex} upload failed: ${res.status}`);
-                }
-
-                const etag = res.headers.get("ETag") ?? "";
-                parts.push({ PartNumber: chunk.chunkIndex + 1, ETag: etag });
-
-                const pct = Math.round(((chunk.chunkIndex + 1) / init.presignedUrls.length) * 100);
-                onProgress?.(pct);
             }
         } finally {
             clearInterval(heartbeatInterval);


### PR DESCRIPTION
  ## Summary
  - Upload metadata 改为 Redis 存储，CloudFile DB 行仅在 MinIO 确认成功后创建，避免上传中断导致数据不一致
  - 支持视频以外的文件类型（图片、文档、压缩包等）
  - 删除文件夹时同步清理 MinIO 对象
  - 前端: 分片上传改用 XHR 实现实时字节级进度跟踪，进度条 UI 重设计
  - 前端: BiliMind → MindBase 品牌重命名

  ## Changes
  | 文件 | 变更 |
  |------|------|
  | `app/services/cloud/upload_service.py` | 移除 chunk/session repo 依赖；init_upload 只写 Redis；complete_upload 从
  Redis 读元数据并在成功后创建 DB 行 |
  | `app/routers/cloud.py` | delete_folder 递归收集子文件夹文件，软删除 DB 后清理 MinIO |
  | `frontend/lib/api.ts` | fetch → XHR，利用 `xhr.upload.onprogress` 获取实时上传字节数 |
  | `frontend/components/dock-modules/cloud-drive.tsx` | 进度条 UI 改进（加粗、标签右对齐、行高增加） |
  | `frontend/app/layout.tsx` `page.tsx` `PasswordLoginModal.tsx` | BiliMind → MindBase |