### PR TITLE
fix(cloud-rag,async-task): partition naming, vectorize idempotency, task pool GC

### DIFF
--- a/app/repository/async_task_repository.py
+++ b/app/repository/async_task_repository.py
@@ -5,7 +5,7 @@ AsyncTask CRUD repository — typed operations for async_tasks table.
 from datetime import datetime, timezone
 from typing import Optional
 
-from sqlalchemy import select, func
+from sqlalchemy import delete, select, func
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models import AsyncTask
@@ -127,6 +127,26 @@ class AsyncTaskRepository:
             select(func.count()).where(AsyncTask.uid == uid)
         )
         return result.scalar() or 0
+
+    async def delete_completed_before(
+        self, cutoff: datetime, db: AsyncSession,
+    ) -> int:
+        """Delete fully-resolved tasks older than ``cutoff``.
+
+        Only rows in terminal states ('done' / 'failed') are removed so
+        in-flight work is never touched. Returns the row count purged.
+
+        Transaction is owned by the caller — pair with
+        ``transactional_scope`` (main process) or ``async with
+        session.begin()`` (subprocess engine).
+        """
+        stmt = delete(AsyncTask).where(
+            AsyncTask.status.in_(["done", "failed"]),
+            AsyncTask.completed_at.isnot(None),
+            AsyncTask.completed_at < cutoff,
+        )
+        result = await db.execute(stmt)
+        return result.rowcount or 0
 
 
 _repo: Optional[AsyncTaskRepository] = None

--- a/app/repository/vector_store_milvus.py
+++ b/app/repository/vector_store_milvus.py
@@ -78,7 +78,7 @@ class MilvusVectorStore:
 
         partition_name: str | None = None
         if partition_dt is not None:
-            partition_name = partition_dt.strftime("%Y-%m")
+            partition_name = partition_dt.strftime("_%Y_%m")
             self._ensure_partition(partition_name)
 
         total = 0
@@ -154,7 +154,7 @@ class MilvusVectorStore:
             cur = partition_dt_start.replace(day=1)
             end = partition_dt_end.replace(day=1)
             while cur <= end:
-                names.append(cur.strftime("%Y-%m"))
+                names.append(cur.strftime("_%Y_%m"))
                 # next month
                 if cur.month == 12:
                     cur = cur.replace(year=cur.year + 1, month=1)
@@ -263,12 +263,22 @@ class MilvusVectorStore:
 
     def count_by_page(self, bvid: str, page_index: int) -> int:
         expr = f'bvid == "{_escape_expr(bvid)}" && page_index == {page_index}'
-        result = self._collection.query(expr=expr, output_fields=["id"], limit=10000)
+        result = self._collection.query(
+            expr=expr,
+            output_fields=["id"],
+            limit=10000,
+            consistency_level="Strong",
+        )
         return len(result)
 
     def count_by_upload_uuid(self, upload_uuid: str) -> int:
         expr = f'upload_uuid == "{_escape_expr(upload_uuid)}"'
-        result = self._collection.query(expr=expr, output_fields=["id"], limit=10000)
+        result = self._collection.query(
+            expr=expr,
+            output_fields=["id"],
+            limit=10000,
+            consistency_level="Strong",
+        )
         return len(result)
 
     def get_stats(self) -> dict:

--- a/app/routers/cloud.py
+++ b/app/routers/cloud.py
@@ -41,6 +41,18 @@ from app.response.cloud import (
 
 router = APIRouter(prefix="/cloud", tags=["cloud-drive"])
 
+# Strong refs for fire-and-forget background tasks. Without this, asyncio
+# may garbage-collect the task object mid-flight and the pipeline silently
+# disappears (see CPython docs on asyncio.create_task).
+_background_tasks: set[asyncio.Task] = set()
+
+
+def _spawn(coro) -> asyncio.Task:
+    task = asyncio.create_task(coro)
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
+    return task
+
 
 def _milvus_escape(value: str) -> str:
     """Escape double-quote and backslash in Milvus expression strings."""
@@ -572,7 +584,7 @@ async def delete_video(
                         exc,
                     )
 
-        asyncio.create_task(_cleanup_storage())
+        _spawn(_cleanup_storage())
 
         return {"deleted": True, "uploadUuid": upload_uuid}
     except HTTPException:
@@ -615,7 +627,7 @@ async def trigger_processing(
 
         from app.routers.tasks_ws import broadcast_cloud_status
 
-        asyncio.create_task(broadcast_cloud_status(uid, upload_uuid, "processing", 0))
+        _spawn(broadcast_cloud_status(uid, upload_uuid, "processing", 0))
 
         # Capture primitive values before spawning background task
         # (the request-scoped session + ORM object are invalid after response)
@@ -665,7 +677,7 @@ async def trigger_processing(
                             f"[CLOUD] failed to mark vector_status=failed for {_upload_uuid}",
                         )
 
-        asyncio.create_task(_run_pipeline())
+        _spawn(_run_pipeline())
 
         return VideoProcessResponse(uploadUuid=upload_uuid)
     except HTTPException:
@@ -760,9 +772,8 @@ async def reprocess_document(
         task_id = str(_uuid.uuid4())
         tracker = TaskTracker()
         await tracker.start(task_id, task_type="cloud_doc")
-        import asyncio as _asyncio
 
-        _asyncio.create_task(_run_doc_reprocess(task_id, upload_uuid, uid))
+        _spawn(_run_doc_reprocess(task_id, upload_uuid, uid))
         return {"uploadUuid": upload_uuid, "taskId": task_id}
     except HTTPException:
         raise

--- a/app/services/async_task/cache.py
+++ b/app/services/async_task/cache.py
@@ -1,9 +1,9 @@
 """
-Shared-memory cache for async tasks, refreshed by a subprocess every 5 minutes.
+Shared-memory cache for async tasks, refreshed by a subprocess every 30 seconds.
 
 Design:
   - multiprocessing.Manager().dict() for cross-process shared state
-  - Subprocess: SELECT * FROM async_tasks → write to shared dict → sleep 300s
+  - Subprocess: SELECT * FROM async_tasks → write to shared dict → sleep 30s
   - Main process: WebSocket reads shared dict directly (no DB query)
 
 Cache structure:
@@ -18,17 +18,27 @@ from __future__ import annotations
 
 import multiprocessing
 import time
+from datetime import datetime, timedelta, timezone
+from multiprocessing.managers import SyncManager
 from typing import Any
 
 from loguru import logger
 
 # Shared state — populated by subprocess, read by main process
-_manager: multiprocessing.Manager | None = None
+_manager: SyncManager | None = None
 _shared_cache: Any = None  # multiprocessing.Manager().dict()
 _refresher_process: multiprocessing.Process | None = None
 
 CACHE_KEY = "async_tasks_cache"
 REFRESH_INTERVAL = 30  # 30 seconds
+
+# Cache visibility window for finished tasks. Older done/failed rows stay
+# in MySQL (audit trail) but are not pushed to WebSocket clients.
+RECENT_DONE_WINDOW = timedelta(hours=1)
+
+# Daily prune of fully-resolved rows so async_tasks doesn't grow forever.
+PRUNE_INTERVAL_SEC = 24 * 3600
+PRUNE_RETENTION = timedelta(days=7)
 
 
 def _refresher_worker(
@@ -36,77 +46,123 @@ def _refresher_worker(
     database_url: str,
     interval: int = REFRESH_INTERVAL,
 ) -> None:
-    """Subprocess entry point: query DB periodically and write cache."""
+    """Subprocess entry point: query DB periodically and write cache.
 
-    # Re-initialize logging in the subprocess
+    Runs a single event loop with a single engine for the lifetime of the
+    subprocess — recreating either on every tick would churn the
+    connection pool unnecessarily.
+    """
+    import asyncio
+
     logger.info("[TaskCache] refresher subprocess started")
 
-    while True:
-        try:
-            _refresh_from_db(shared_dict, database_url)
-        except Exception as e:
-            logger.error(f"[TaskCache] refresh failed: {e}")
-        time.sleep(interval)
-
-
-def _refresh_from_db(shared_dict: Any, database_url: str) -> None:
-    """Query MySQL and update the shared dict."""
-    import asyncio as _asyncio
-
-    async def _query():
+    async def _loop() -> None:
         from sqlalchemy.ext.asyncio import (
             create_async_engine,
             AsyncSession,
             async_sessionmaker,
         )
-        from app.repository.async_task_repository import AsyncTaskRepository
 
         engine = create_async_engine(database_url, echo=False)
         factory = async_sessionmaker(
             engine, class_=AsyncSession, expire_on_commit=False
         )
 
-        async with factory() as db:
-            AsyncTaskRepository()
-            # Query all tasks, newest first (no uid filter — subprocess reads all)
-            from sqlalchemy import select
-            from app.models import AsyncTask
+        last_prune_at = 0.0
+        try:
+            while True:
+                try:
+                    await _refresh_from_db(factory, shared_dict)
+                except Exception as e:
+                    logger.error(f"[TaskCache] refresh failed: {e}")
 
-            result = await db.execute(
-                select(AsyncTask).order_by(AsyncTask.updated_at.desc()).limit(200)
+                now = time.time()
+                if now - last_prune_at >= PRUNE_INTERVAL_SEC:
+                    last_prune_at = now
+                    try:
+                        await _prune(factory)
+                    except Exception as e:
+                        logger.error(f"[TaskCache] prune failed: {e}")
+
+                await asyncio.sleep(interval)
+        finally:
+            await engine.dispose()
+
+    asyncio.run(_loop())
+
+
+async def _refresh_from_db(factory, shared_dict: Any) -> None:
+    """Query MySQL and update the shared dict (read-only)."""
+    from sqlalchemy import select, or_
+    from app.models import AsyncTask
+
+    # Only push tasks the UI actually cares about: anything still in
+    # flight, plus anything that finished within the visibility window.
+    # Older finished rows stay in MySQL as audit trail and are pruned
+    # separately.
+    recent_cutoff = datetime.now(timezone.utc) - RECENT_DONE_WINDOW
+    stmt = (
+        select(AsyncTask)
+        .where(
+            or_(
+                AsyncTask.status.in_(["pending", "processing"]),
+                AsyncTask.completed_at >= recent_cutoff,
             )
-            tasks = result.scalars().all()
+        )
+        .order_by(AsyncTask.updated_at.desc())
+        .limit(200)
+    )
 
-            data = [
-                {
-                    "task_id": t.task_id,
-                    "uid": t.uid,
-                    "task_type": t.task_type,
-                    "target": t.target,
-                    "status": t.status,
-                    "progress": t.progress,
-                    "steps": t.steps,
-                    "result": t.result,
-                    "error": t.error,
-                    "created_at": t.created_at.isoformat() if t.created_at else None,
-                    "updated_at": t.updated_at.isoformat() if t.updated_at else None,
-                    "completed_at": (
-                        t.completed_at.isoformat() if t.completed_at else None
-                    ),
-                }
-                for t in tasks
-            ]
+    async with factory() as db:
+        result = await db.execute(stmt)
+        tasks = result.scalars().all()
 
-            shared_dict[CACHE_KEY] = {
-                "tasks": data,
-                "updated_at": time.time(),
-                "count": len(data),
+        data = [
+            {
+                "task_id": t.task_id,
+                "uid": t.uid,
+                "task_type": t.task_type,
+                "target": t.target,
+                "status": t.status,
+                "progress": t.progress,
+                "steps": t.steps,
+                "result": t.result,
+                "error": t.error,
+                "created_at": t.created_at.isoformat() if t.created_at else None,
+                "updated_at": t.updated_at.isoformat() if t.updated_at else None,
+                "completed_at": (
+                    t.completed_at.isoformat() if t.completed_at else None
+                ),
             }
+            for t in tasks
+        ]
 
-        await engine.dispose()
-        logger.info(f"[TaskCache] refreshed {len(data)} tasks")
+    shared_dict[CACHE_KEY] = {
+        "tasks": data,
+        "updated_at": time.time(),
+        "count": len(data),
+    }
+    logger.info(f"[TaskCache] refreshed {len(data)} tasks")
 
-    _asyncio.run(_query())
+
+async def _prune(factory) -> None:
+    """Delete fully-resolved tasks older than PRUNE_RETENTION."""
+    from app.repository.async_task_repository import AsyncTaskRepository
+
+    cutoff = datetime.now(timezone.utc) - PRUNE_RETENTION
+    # Subprocess owns its own engine, so app.infra.transaction (which
+    # binds to the main-process factory) cannot be reused. session.begin()
+    # gives the same commit-on-success / rollback-on-error semantics with
+    # the subprocess engine.
+    async with factory() as db:
+        async with db.begin():
+            purged = await AsyncTaskRepository().delete_completed_before(cutoff, db)
+    if purged:
+        logger.info(
+            "[TaskCache] pruned {} finished tasks older than {}",
+            purged,
+            cutoff.isoformat(),
+        )
 
 
 # ── Public API (called from main process) ──────────────────────────

--- a/app/services/doc_parser/vectorize.py
+++ b/app/services/doc_parser/vectorize.py
@@ -76,7 +76,9 @@ async def vectorize_cloud_document(
             await db.commit()
             return 0
 
-        # Content hash for idempotency
+        # Content hash for idempotency.
+        # Hash is only persisted *after* the pipeline succeeds, so a crash
+        # mid-flight cannot poison the dedup check on retry.
         content_hash = hashlib.sha256(content_bytes).hexdigest()
         if file.vector_status == "done" and file.content_hash == content_hash:
             logger.info(
@@ -85,7 +87,6 @@ async def vectorize_cloud_document(
             return file.vector_chunk_count or 0
 
         file.vector_status = "processing"
-        file.content_hash = content_hash
         await db.commit()
         await _push_status(uid, upload_uuid, "processing", 0)
 
@@ -128,9 +129,26 @@ async def vectorize_cloud_document(
         rag = get_rag_service()
         if rag.cloud_backend is None:
             raise RuntimeError("cloud_backend not available (Milvus not configured)")
-        chunk_count = rag.cloud_backend.add(
-            docs, partition_dt=datetime.now(timezone.utc)
-        )
+
+        # Clean residual chunks from prior failed runs before re-adding,
+        # otherwise the consistency check would see stale data and the
+        # collection would accumulate orphan vectors across retries.
+        try:
+            rag.cloud_backend.delete_by_upload_uuid(upload_uuid)
+        except Exception:
+            logger.warning(
+                "[VECTORIZE] failed to delete stale chunks for %s (continuing)",
+                upload_uuid,
+                exc_info=True,
+            )
+
+        # Use file.created_at (not now()) so retries always land in the
+        # same partition — required for idempotent verification and
+        # to keep partition count bounded.
+        partition_dt = file.created_at or datetime.now(timezone.utc)
+        if partition_dt.tzinfo is None:
+            partition_dt = partition_dt.replace(tzinfo=timezone.utc)
+        chunk_count = rag.cloud_backend.add(docs, partition_dt=partition_dt)
 
         # ── Phase 4: Update MySQL metadata ──
         file.doc_parser = source
@@ -147,13 +165,27 @@ async def vectorize_cloud_document(
         # ── Phase 5: Three-layer consistency check ──
         verified = await _verify_consistency(upload_uuid, uid, chunk_count, db)
         if not verified:
+            # Roll back Milvus so MySQL `failed` status reflects reality.
+            # Otherwise the next retry's idempotency check would compare
+            # against stale Milvus data and the collection would accumulate
+            # orphan vectors that still leak into search results.
+            try:
+                rag.cloud_backend.delete_by_upload_uuid(upload_uuid)
+            except Exception:
+                logger.exception(
+                    "[VECTORIZE] failed to roll back Milvus for %s after verify miss",
+                    upload_uuid,
+                )
             raise RuntimeError(
                 f"Consistency check failed for {upload_uuid}: "
                 "data mismatch across MongoDB / Milvus / MySQL"
             )
 
         # ── Phase 6: Mark done ──
+        # Persist content_hash only on success — a half-finished run must not
+        # poison future idempotency checks.
         file.vector_status = "done"
+        file.content_hash = content_hash
         file.vector_chunk_count = chunk_count
         await db.commit()
         logger.info(
@@ -263,7 +295,9 @@ async def _verify_consistency(
     rag = get_rag_service()
     if rag.cloud_backend is not None:
         actual = rag.cloud_backend.count_by_upload_uuid(upload_uuid)
-        ok_milvus = actual >= expected_chunks
+        # Strict equality: stale chunks must be cleaned before add(),
+        # so any drift means the write didn't land cleanly.
+        ok_milvus = actual == expected_chunks
         if not ok_milvus:
             logger.error(
                 "[VERIFY] Milvus mismatch for %s: expected=%s actual=%s",


### PR DESCRIPTION

  ## Summary

  修复云盘文档向量化流水线长期不可用的根因，并解决 `async_tasks` 表只增不减导致的任务池膨胀问题。共 5 个独立
  commit，可按需 revert。

  ## 背景

  线上日志反复出现两类报错：
  1. `MilvusException: Invalid partition name: 2026-06` — 任何按月分区的 cloud_drive 写入 100% 失败。
  2. `[TaskCache] refreshed N tasks` 中的 N 持续增长，从未下降 — 任务池只 INSERT/UPDATE，没有任何 DELETE 路径。

  排查后发现还有几个关联性问题（一致性校验假阴性、后台 task 被 GC、子进程 engine 反复创建/销毁），一并在本 PR 收口。

  ---

  ## 改动详情

  ### 1. `[rag] fix: sanitize milvus partition names and harden count consistency` (`29b6637`)
  - 分区名从 `"%Y-%m"`（含 `-`，被 Milvus 服务端拒绝）改为 `"_%Y_%m"`，符合 Milvus "字母/数字/下划线、不以数字开头"
  的命名规则。
  - `count_by_upload_uuid` / `count_by_page` 加 `consistency_level="Strong"`，避免 verify-after-add
  读到陈旧数据导致一致性误判。

  ### 2. `[rag] fix: make cloud document vectorize pipeline idempotent` (`325ce0d`)
  - `add()` 之前先 `delete_by_upload_uuid` 清残留，重试不再累积孤儿 chunk。
  - `partition_dt` 改用 `file.created_at`，同一 upload_uuid 永远落同一分区，避免分区数膨胀，也让一致性校验有意义。
  - `content_hash` 改为 **成功后**才落库,中途崩溃不会污染下次重跑的幂等判断。
  - `_verify_consistency` 改用严格相等;失败时先 `delete_by_upload_uuid` 回滚 Milvus 再 raise,保证 MySQL `failed` 状态与
   Milvus 真实数据一致。

  ### 3. `[cloud] fix: hold strong refs to fire-and-forget background tasks` (`3bcf3b1`)
  - 所有 `asyncio.create_task` 收口到 `_spawn()`,放进模块级 `set` 持有引用,避免 task 被 GC 中途丢失。
  - 覆盖 3 处 fire-and-forget:`_cleanup_storage` / `broadcast_cloud_status` / `_run_pipeline` / `_run_doc_reprocess`。

  ### 4. `[async-task] feat: add delete_completed_before for finished-task pruning` (`7d12346`)
  - `AsyncTaskRepository` 新增 `delete_completed_before(cutoff, db)`,只删 `status in ('done','failed')` 且
  `completed_at < cutoff` 的行。
  - **事务由调用方持有**,与 `app/infra/transaction.py` 的约定保持一致,repo 内不做隐式 commit。

  ### 5. `[async-task] refactor: single-engine refresher loop with bounded visibility and daily prune` (`787ec80`)
  - 子进程从"每 30s 新建/销毁一次 engine"改为单 engine + 单 event loop 复用,`engine.dispose()` 仅在 finally 中执行。
  - Refresh 查询过滤为"活跃 + 完成 ≤ 1h",前端 WS 不再被 200 条历史 done 任务塞满。
  - 每日 prune 在同一循环内执行,`async with db.begin()` 包裹保证事务原子性。
  - 修正类型注解:`multiprocessing.Manager` → `SyncManager`。
  - 公共 API(`start_cache_refresher` / `stop_cache_refresher` / `get_cached_*`)签名不变。

  ---

  ## 行为变化

  | 维度 | 修复前 | 修复后 |
  |-----|------|------|
  | 云盘按月分区写入 | 100% 失败 | 正常 |
  | Verify 失败时 Milvus 状态 | 残留向量,MySQL 标 failed | Milvus 已回滚,状态一致 |
  | 重试场景 | 残留旧 chunk + content_hash 错位 | 完全幂等,可任意重试 |
  | WebSocket 推送任务数 | 单调增长直到 limit=200 后截断 | 稳定在"活跃 + 1h 内完成" |
  | `async_tasks` 表行数 | 无限增长 | 每日清理 7 天前 done/failed 行 |
  | Fire-and-forget pipeline | 偶发被 GC 丢失 | 100% 持有引用 |

  ## 不在本 PR 范围

  - `async_task_repository.py` 中其他写方法(`create` / `update_fields` / `update_steps`)仍保留手动 commit 风格 —
  这是历史遗留技术债,统一迁移到 `transactional_scope` 涉及 `tracker.py` 8 个方法及所有调用方,应作为单独的重构 PR。