### PR TITLE
[frontend] feat: 聊天对话 UI 重构 — 消息气泡 / 输入框 / 空状态 / 历史侧栏

### DIFF
--- a/frontend/app/chat/page.tsx
+++ b/frontend/app/chat/page.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import ChatPanel from "@/components/chat/ChatPanel";
+
+export default function ChatPage() {
+  return (
+    <div className="min-h-screen bg-[var(--gemini-surface)]">
+      <ChatPanel />
+    </div>
+  );
+}

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -22,6 +22,26 @@
   --shadow: rgba(0, 0, 0, 0.08);
   --radius: 0.625rem;
   --radius-lg: 20px;
+
+  /* Google Gemini Style Colors */
+  --gemini-primary: #4285F4;
+  --gemini-primary-hover: #3367D6;
+  --gemini-surface: #FFFFFF;
+  --gemini-surface-variant: #F8F9FA;
+  --gemini-border: #DADCE0;
+  --gemini-border-subtle: #F1F3F4;
+  --gemini-text-primary: #202124;
+  --gemini-text-secondary: #5F6368;
+  --gemini-text-tertiary: #70757A;
+  --gemini-user-bubble: #E8F0FE;
+  --gemini-user-text: #1967D2;
+  --gemini-assistant-bubble: #F8F9FA;
+  --gemini-assistant-text: #202124;
+  --gemini-shadow: 0 1px 2px rgba(0,0,0,0.08);
+  --gemini-shadow-md: 0 2px 8px rgba(0,0,0,0.1);
+  --gemini-shadow-lg: 0 4px 16px rgba(0,0,0,0.12);
+  --gemini-radius: 24px;
+  --gemini-radius-sm: 12px;
   /* shadcn/ui theme vars - light */
   --background: #f8f9fa;
   --foreground: #1a1a2e;
@@ -76,6 +96,25 @@
   --warning-bg: rgba(251, 191, 36, 0.1);
   --glow: rgba(6, 182, 212, 0.35);
   --shadow: rgba(0, 0, 0, 0.4);
+
+  /* Google Gemini Style Colors - Dark Mode */
+  --gemini-primary: #8AB4F8;
+  --gemini-primary-hover: #AECBFA;
+  --gemini-surface: #1F1F1F;
+  --gemini-surface-variant: #2D2D2D;
+  --gemini-border: #3C4043;
+  --gemini-border-subtle: #282828;
+  --gemini-text-primary: #E8EAED;
+  --gemini-text-secondary: #9AA0A6;
+  --gemini-text-tertiary: #80868B;
+  --gemini-user-bubble: #3D5361;
+  --gemini-user-text: #AECBFA;
+  --gemini-assistant-bubble: #2D2D2D;
+  --gemini-assistant-text: #E8EAED;
+  --gemini-shadow: 0 1px 2px rgba(0,0,0,0.3);
+  --gemini-shadow-md: 0 2px 8px rgba(0,0,0,0.4);
+  --gemini-shadow-lg: 0 4px 16px rgba(0,0,0,0.5);
+
   /* shadcn/ui */
   --background: #0d1117;
   --foreground: #e2e8f0;
@@ -839,6 +878,1417 @@ html.dark * {
   border-top: 1px solid var(--border);
 }
 
+/* Chat content — robust flex filling for both full-page and dock contexts.
+   panel-inner alone uses height:100% which fails inside a flex column parent
+   whose height is flex-driven; add flex:1 to guarantee vertical fill. */
+.chat-content.panel-inner {
+  flex: 1 1 0%;
+  height: auto;
+  background: var(--gemini-surface);
+}
+
+/* In chat context, panel-body should not double-scroll — the inner
+   centered wrapper handles layout. Keep panel-body as the flex scroller. */
+.chat-content .panel-body {
+  padding: 24px 16px;
+}
+
+.chat-content .panel-footer {
+  padding: 8px 16px 16px;
+  border-top: none;
+  background: transparent;
+}
+
+/* ============================================ */
+/* Chat Input — Refined Editorial Gemini        */
+/* ============================================ */
+.chat-input-root {
+  position: relative;
+  width: 100%;
+}
+
+.chat-input-card {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 10px 7px 16px;
+  background: var(--gemini-surface);
+  border: 1px solid var(--gemini-border);
+  border-radius: 16px;
+  box-shadow:
+    var(--gemini-shadow),
+    inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  transition:
+    border-color 0.25s cubic-bezier(0.4, 0, 0.2, 1),
+    box-shadow 0.25s cubic-bezier(0.4, 0, 0.2, 1),
+    transform 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* Hover: subtle lift + border warm-up */
+.chat-input-card:hover {
+  border-color: color-mix(in srgb, var(--gemini-primary) 35%, var(--gemini-border));
+  box-shadow:
+    var(--gemini-shadow-md),
+    inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+/* Focus-within: layered halo — outer soft glow + inner crisp ring */
+.chat-input-card:focus-within {
+  border-color: var(--gemini-primary);
+  box-shadow:
+    0 0 0 4px color-mix(in srgb, var(--gemini-primary) 12%, transparent),
+    0 2px 12px color-mix(in srgb, var(--gemini-primary) 18%, transparent),
+    inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+/* Ready state (has content): faint accent tint on the card edge */
+.chat-input-card.is-ready {
+  border-color: color-mix(in srgb, var(--gemini-primary) 50%, var(--gemini-border));
+}
+
+/* Streaming: pulsing red-tinted border */
+.chat-input-card.is-streaming {
+  border-color: color-mix(in srgb, #ef4444 45%, var(--gemini-border));
+  animation: chat-input-streaming-pulse 1.6s ease-in-out infinite;
+}
+
+@keyframes chat-input-streaming-pulse {
+  0%, 100% {
+    box-shadow:
+      0 0 0 0 color-mix(in srgb, #ef4444 0%, transparent),
+      var(--gemini-shadow);
+  }
+  50% {
+    box-shadow:
+      0 0 0 3px color-mix(in srgb, #ef4444 15%, transparent),
+      var(--gemini-shadow-md);
+  }
+}
+
+.chat-input-textarea {
+  flex: 1 1 0%;
+  min-width: 0;
+  resize: none;
+  overflow: hidden;
+  background: transparent;
+  border: none;
+  outline: none;
+  padding: 8px 2px;
+  font-size: 15px;
+  line-height: 1.5;
+  color: var(--gemini-text-primary);
+  font-family: inherit;
+}
+
+.chat-input-textarea::placeholder {
+  color: var(--gemini-text-tertiary);
+  font-style: italic;
+  letter-spacing: 0.01em;
+  transition: color 0.2s ease;
+}
+
+.chat-input-textarea:focus::placeholder {
+  color: color-mix(in srgb, var(--gemini-text-tertiary) 70%, transparent);
+}
+
+.chat-input-action {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+}
+
+/* Send button — gradient sphere with gloss + depth */
+.chat-input-send {
+  width: 38px;
+  height: 38px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 50%;
+  cursor: pointer;
+  color: #fff;
+  background:
+    radial-gradient(circle at 30% 25%, rgba(255, 255, 255, 0.35) 0%, transparent 45%),
+    linear-gradient(135deg, var(--gemini-primary) 0%, var(--gemini-primary-hover) 100%);
+  box-shadow:
+    0 4px 12px color-mix(in srgb, var(--gemini-primary) 40%, transparent),
+    inset 0 1px 0 rgba(255, 255, 255, 0.3),
+    inset 0 -1px 1px rgba(0, 0, 0, 0.15);
+  transform: translateZ(0);
+  transition:
+    transform 0.18s cubic-bezier(0.34, 1.56, 0.64, 1),
+    box-shadow 0.25s ease,
+    opacity 0.2s ease;
+}
+
+.chat-input-send:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow:
+    0 6px 18px color-mix(in srgb, var(--gemini-primary) 55%, transparent),
+    inset 0 1px 0 rgba(255, 255, 255, 0.4),
+    inset 0 -1px 1px rgba(0, 0, 0, 0.18);
+}
+
+.chat-input-send:active:not(:disabled) {
+  transform: translateY(0) scale(0.94);
+  box-shadow:
+    0 2px 6px color-mix(in srgb, var(--gemini-primary) 35%, transparent),
+    inset 0 1px 0 rgba(255, 255, 255, 0.25);
+}
+
+/* Disabled send: low-saturation relief, no shadow life */
+.chat-input-send:disabled {
+  cursor: not-allowed;
+  background: var(--gemini-surface-variant);
+  color: var(--gemini-text-tertiary);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.03),
+    inset 0 -1px 1px rgba(0, 0, 0, 0.1);
+  opacity: 0.7;
+}
+
+/* Subtle send-arrow nudge when becoming ready */
+.chat-input-card.is-ready .chat-input-send:not(:disabled) svg {
+  animation: chat-input-send-nudge 0.4s ease-out;
+}
+
+@keyframes chat-input-send-nudge {
+  0% { transform: translateX(0); }
+  40% { transform: translateX(2px); }
+  100% { transform: translateX(0); }
+}
+
+/* Stop button — red sphere, gentler than send, breathing */
+.chat-input-stop {
+  width: 38px;
+  height: 38px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 50%;
+  cursor: pointer;
+  color: #fff;
+  background:
+    radial-gradient(circle at 30% 25%, rgba(255, 255, 255, 0.3) 0%, transparent 45%),
+    linear-gradient(135deg, #ef4444 0%, #dc2626 100%);
+  box-shadow:
+    0 4px 12px rgba(239, 68, 68, 0.4),
+    inset 0 1px 0 rgba(255, 255, 255, 0.3),
+    inset 0 -1px 1px rgba(0, 0, 0, 0.15);
+  animation: chat-input-stop-breath 1.8s ease-in-out infinite;
+  transition: transform 0.18s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.chat-input-stop:hover {
+  transform: scale(1.05);
+}
+
+.chat-input-stop:active {
+  transform: scale(0.94);
+}
+
+@keyframes chat-input-stop-breath {
+  0%, 100% {
+    box-shadow:
+      0 4px 12px rgba(239, 68, 68, 0.4),
+      inset 0 1px 0 rgba(255, 255, 255, 0.3),
+      inset 0 -1px 1px rgba(0, 0, 0, 0.15);
+  }
+  50% {
+    box-shadow:
+      0 4px 18px rgba(239, 68, 68, 0.6),
+      inset 0 1px 0 rgba(255, 255, 255, 0.35),
+      inset 0 -1px 1px rgba(0, 0, 0, 0.15);
+  }
+}
+
+/* Hint row under input */
+.chat-input-hint {
+  margin-top: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 0 6px;
+  font-size: 11.5px;
+  color: var(--gemini-text-tertiary);
+}
+
+.chat-input-hint-keys {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  letter-spacing: 0.02em;
+}
+
+.chat-input-hint-keys kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  margin-right: 4px;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 10.5px;
+  font-weight: 600;
+  color: var(--gemini-text-secondary);
+  background: var(--gemini-surface-variant);
+  border: 1px solid var(--gemini-border);
+  border-radius: 5px;
+  box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.08);
+}
+
+.chat-input-hint-disclaimer {
+  font-style: italic;
+  opacity: 0.85;
+}
+
+@media (max-width: 540px) {
+  .chat-input-hint {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
+  }
+}
+
+/* ============================================ */
+/* Chat Empty State — Editorial Welcome         */
+/* ============================================ */
+.chat-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  padding: 8px 4px 24px;
+  animation: chat-empty-fade 0.5s ease backwards;
+}
+
+@keyframes chat-empty-fade {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.chat-empty-kicker {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--gemini-text-tertiary);
+  margin-bottom: 14px;
+  animation: chat-empty-fade 0.5s 0.02s ease backwards;
+}
+
+.chat-empty-kicker::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--gemini-primary);
+  box-shadow: 0 0 8px color-mix(in srgb, var(--gemini-primary) 60%, transparent);
+  animation: chat-empty-dot-pulse 2s ease-in-out infinite;
+}
+
+@keyframes chat-empty-dot-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.4; transform: scale(0.85); }
+}
+
+.chat-empty-heading {
+  font-size: 30px;
+  line-height: 1.2;
+  letter-spacing: -0.02em;
+  margin-bottom: 12px;
+  animation: chat-empty-fade 0.5s 0.05s ease backwards;
+}
+
+.chat-empty-heading-light {
+  font-weight: 300;
+  color: var(--gemini-text-secondary);
+}
+
+.chat-empty-heading-bold {
+  font-weight: 700;
+  color: var(--gemini-text-primary);
+}
+
+.chat-empty-subtitle {
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--gemini-text-tertiary);
+  max-width: 460px;
+  margin-bottom: 32px;
+  animation: chat-empty-fade 0.5s 0.1s ease backwards;
+}
+
+.chat-suggestion-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+  width: 100%;
+}
+
+.chat-suggestion-card {
+  position: relative;
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  padding: 18px 20px;
+  background: var(--gemini-surface);
+  border: 1px solid var(--gemini-border);
+  border-radius: 14px;
+  cursor: pointer;
+  text-align: left;
+  overflow: hidden;
+  font-family: inherit;
+  transition:
+    transform 0.25s cubic-bezier(0.4, 0, 0.2, 1),
+    border-color 0.25s ease,
+    background 0.25s ease,
+    box-shadow 0.25s ease;
+  animation: chat-suggestion-enter 0.5s cubic-bezier(0.4, 0, 0.2, 1) backwards;
+}
+
+.chat-suggestion-card:nth-child(1) { animation-delay: 0.15s; }
+.chat-suggestion-card:nth-child(2) { animation-delay: 0.22s; }
+.chat-suggestion-card:nth-child(3) { animation-delay: 0.29s; }
+.chat-suggestion-card:nth-child(4) { animation-delay: 0.36s; }
+
+@keyframes chat-suggestion-enter {
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* Per-card accent theming — gives each suggestion a visual identity */
+.chat-suggestion-card[data-accent="blue"]   { --card-accent: var(--gemini-primary); }
+.chat-suggestion-card[data-accent="teal"]   { --card-accent: #06b6d4; }
+.chat-suggestion-card[data-accent="amber"]  { --card-accent: #f59e0b; }
+.chat-suggestion-card[data-accent="violet"] { --card-accent: #8b5cf6; }
+
+.chat-suggestion-index {
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--card-accent);
+  line-height: 1;
+  flex-shrink: 0;
+  letter-spacing: -0.02em;
+  font-variant-numeric: tabular-nums;
+  padding-top: 1px;
+  transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.chat-suggestion-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.chat-suggestion-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--gemini-text-primary);
+  margin-bottom: 4px;
+  letter-spacing: -0.005em;
+}
+
+.chat-suggestion-prompt {
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: var(--gemini-text-tertiary);
+  font-style: italic;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.chat-suggestion-arrow {
+  position: absolute;
+  bottom: 14px;
+  right: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transform: translate(-4px, 4px);
+  color: var(--card-accent);
+  transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* Bottom accent line that grows from left on hover */
+.chat-suggestion-card::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 2px;
+  background: var(--card-accent);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.35s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.chat-suggestion-card:hover {
+  border-color: color-mix(in srgb, var(--card-accent) 40%, var(--gemini-border));
+  background: color-mix(in srgb, var(--card-accent) 4%, var(--gemini-surface));
+  transform: translateY(-2px);
+  box-shadow: 0 8px 24px color-mix(in srgb, var(--card-accent) 14%, transparent);
+}
+
+.chat-suggestion-card:hover::after {
+  transform: scaleX(1);
+}
+
+.chat-suggestion-card:hover .chat-suggestion-arrow {
+  opacity: 1;
+  transform: translate(0, 0);
+}
+
+.chat-suggestion-card:hover .chat-suggestion-index {
+  transform: scale(1.12);
+}
+
+.chat-suggestion-card:focus-visible {
+  outline: none;
+  border-color: var(--card-accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--card-accent) 25%, transparent);
+}
+
+@media (max-width: 540px) {
+  .chat-suggestion-grid {
+    grid-template-columns: 1fr;
+  }
+  .chat-empty-heading {
+    font-size: 26px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chat-empty,
+  .chat-empty-kicker,
+  .chat-empty-heading,
+  .chat-empty-subtitle,
+  .chat-suggestion-card {
+    animation: none;
+  }
+  .chat-suggestion-card:hover {
+    transform: none;
+  }
+}
+
+/* ============================================ */
+/* Chat History Sidebar — Editorial Archive     */
+/* ============================================ */
+.chat-sidebar-scrim {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(2px);
+  z-index: 40;
+}
+
+.chat-sidebar {
+  position: fixed;
+  inset: 0 auto 0 0;
+  z-index: 50;
+  width: 288px;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  background: var(--gemini-surface);
+  border-right: 1px solid var(--gemini-border);
+  transform: translateX(-100%);
+  transition: transform 0.32s cubic-bezier(0.4, 0, 0.2, 1);
+  font-family: inherit;
+}
+
+.chat-sidebar.is-open {
+  transform: translateX(0);
+}
+
+@media (min-width: 768px) {
+  .chat-sidebar {
+    position: relative;
+  }
+  .chat-sidebar-scrim {
+    display: none;
+  }
+}
+
+/* Header */
+.chat-sidebar-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px 20px 16px;
+  border-bottom: 1px solid var(--gemini-border-subtle);
+}
+
+.chat-sidebar-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.chat-sidebar-brand-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--gemini-primary);
+  box-shadow: 0 0 10px color-mix(in srgb, var(--gemini-primary) 55%, transparent);
+}
+
+.chat-sidebar-brand-label {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--gemini-text-tertiary);
+}
+
+.chat-sidebar-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--gemini-text-tertiary);
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.chat-sidebar-close:hover {
+  background: var(--gemini-surface-variant);
+  color: var(--gemini-text-primary);
+}
+
+@media (min-width: 768px) {
+  .chat-sidebar-close {
+    display: none;
+  }
+}
+
+/* New chat CTA */
+.chat-sidebar-cta {
+  padding: 14px 16px 4px;
+}
+
+.chat-sidebar-new {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid var(--gemini-border);
+  border-radius: 12px;
+  background: var(--gemini-surface);
+  color: var(--gemini-text-primary);
+  font-family: inherit;
+  font-size: 13.5px;
+  font-weight: 500;
+  cursor: pointer;
+  overflow: hidden;
+  transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.chat-sidebar-new::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: var(--gemini-primary);
+  transform: scaleY(0);
+  transform-origin: top;
+  transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.chat-sidebar-new:hover {
+  border-color: color-mix(in srgb, var(--gemini-primary) 50%, var(--gemini-border));
+  background: color-mix(in srgb, var(--gemini-primary) 5%, var(--gemini-surface));
+  transform: translateY(-1px);
+  box-shadow: 0 4px 14px color-mix(in srgb, var(--gemini-primary) 18%, transparent);
+}
+
+.chat-sidebar-new:hover::before {
+  transform: scaleY(1);
+}
+
+.chat-sidebar-new-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 7px;
+  background: linear-gradient(135deg, var(--gemini-primary), var(--gemini-primary-hover));
+  color: #fff;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.3),
+    0 2px 6px color-mix(in srgb, var(--gemini-primary) 35%, transparent);
+  flex-shrink: 0;
+}
+
+.chat-sidebar-new-text {
+  flex: 1;
+  text-align: left;
+}
+
+.chat-sidebar-new-kbd {
+  display: inline-flex;
+  align-items: center;
+  height: 18px;
+  padding: 0 5px;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 10.5px;
+  font-weight: 600;
+  color: var(--gemini-text-tertiary);
+  background: var(--gemini-surface-variant);
+  border: 1px solid var(--gemini-border);
+  border-radius: 5px;
+}
+
+/* Session list */
+.chat-sidebar-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px 12px 16px;
+}
+
+.chat-sidebar-empty {
+  padding: 32px 16px;
+  text-align: center;
+  font-size: 13px;
+  color: var(--gemini-text-tertiary);
+  font-style: italic;
+}
+
+.chat-sidebar-group {
+  margin-bottom: 18px;
+}
+
+.chat-sidebar-group-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 8px 6px;
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--gemini-text-tertiary);
+}
+
+.chat-sidebar-group-label::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--gemini-border-subtle);
+}
+
+.chat-sidebar-group-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--gemini-text-tertiary);
+  background: var(--gemini-surface-variant);
+  border-radius: 8px;
+  letter-spacing: 0;
+}
+
+.chat-sidebar-group-items {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+/* Session item */
+.chat-session {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px 10px 14px;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  animation: chat-session-enter 0.4s cubic-bezier(0.4, 0, 0.2, 1) backwards;
+}
+
+.chat-sidebar-group-items .chat-session:nth-child(1) { animation-delay: 0.04s; }
+.chat-sidebar-group-items .chat-session:nth-child(2) { animation-delay: 0.08s; }
+.chat-sidebar-group-items .chat-session:nth-child(3) { animation-delay: 0.12s; }
+.chat-sidebar-group-items .chat-session:nth-child(4) { animation-delay: 0.16s; }
+.chat-sidebar-group-items .chat-session:nth-child(5) { animation-delay: 0.2s; }
+
+@keyframes chat-session-enter {
+  from { opacity: 0; transform: translateX(-6px); }
+  to { opacity: 1; transform: translateX(0); }
+}
+
+.chat-session-rail {
+  position: absolute;
+  left: 4px;
+  top: 50%;
+  width: 3px;
+  height: 0;
+  background: var(--gemini-primary);
+  border-radius: 0 2px 2px 0;
+  transform: translateY(-50%);
+  transition: height 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.chat-session:hover {
+  background: var(--gemini-surface-variant);
+}
+
+.chat-session:hover .chat-session-rail {
+  height: 16px;
+  background: color-mix(in srgb, var(--gemini-primary) 45%, transparent);
+}
+
+.chat-session.is-active {
+  background: color-mix(in srgb, var(--gemini-primary) 9%, var(--gemini-surface));
+}
+
+.chat-session.is-active .chat-session-rail {
+  height: 22px;
+  background: var(--gemini-primary);
+  box-shadow: 0 0 8px color-mix(in srgb, var(--gemini-primary) 50%, transparent);
+}
+
+.chat-session-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.chat-session-title {
+  font-size: 13.5px;
+  font-weight: 500;
+  line-height: 1.35;
+  color: var(--gemini-text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  transition: color 0.2s ease;
+}
+
+.chat-session:hover .chat-session-title {
+  color: var(--gemini-text-primary);
+}
+
+.chat-session.is-active .chat-session-title {
+  color: var(--gemini-primary);
+  font-weight: 600;
+}
+
+.chat-session-meta {
+  margin-top: 2px;
+  font-size: 11px;
+  color: var(--gemini-text-tertiary);
+  letter-spacing: 0.01em;
+}
+
+/* Hover actions */
+.chat-session-actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  opacity: 0;
+  transform: translateX(4px);
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  flex-shrink: 0;
+}
+
+.chat-session-actions.is-visible {
+  opacity: 1;
+  transform: translateX(0);
+}
+
+.chat-session-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border: none;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--gemini-text-tertiary);
+  cursor: pointer;
+  transition: all 0.18s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.chat-session-action:hover {
+  background: var(--gemini-surface);
+  color: var(--gemini-text-primary);
+  transform: scale(1.08);
+}
+
+.chat-session-action-danger:hover {
+  background: color-mix(in srgb, #ef4444 12%, transparent);
+  color: #ef4444;
+}
+
+/* Edit mode */
+.chat-session-edit {
+  flex: 1;
+}
+
+.chat-session-edit-input {
+  width: 100%;
+  padding: 5px 8px;
+  font-family: inherit;
+  font-size: 13.5px;
+  font-weight: 500;
+  color: var(--gemini-text-primary);
+  background: var(--gemini-surface);
+  border: 1px solid var(--gemini-primary);
+  border-radius: 6px;
+  outline: none;
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--gemini-primary) 18%, transparent);
+}
+
+/* Footer */
+.chat-sidebar-footer {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 14px 20px 18px;
+  border-top: 1px solid var(--gemini-border-subtle);
+}
+
+.chat-sidebar-footer-brand {
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--gemini-text-secondary);
+}
+
+.chat-sidebar-footer-meta {
+  font-size: 10.5px;
+  letter-spacing: 0.08em;
+  color: var(--gemini-text-tertiary);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chat-sidebar,
+  .chat-session,
+  .chat-session-rail,
+  .chat-session-actions,
+  .chat-sidebar-new,
+  .chat-sidebar-new::before {
+    transition: none !important;
+    animation: none !important;
+  }
+}
+
+/* ============================================================
+   Chat message bubbles — Gemini conversation styling
+   - User: right-aligned compact pill (no asymmetric corners)
+   - Assistant: avatar-led, no bubble, full-width editorial layout
+   ============================================================ */
+
+.msg-row {
+  display: flex;
+  width: 100%;
+  gap: 14px;
+  padding: 10px 0;
+}
+
+/* Direction-aware entrance — user slides in from the right,
+   assistant slides in from the left. Reinforces the dialogue rhythm. */
+.msg-row-user {
+  justify-content: flex-end;
+  padding: 6px 0;
+  animation: msgUserIn 0.34s cubic-bezier(0.22, 0.61, 0.36, 1);
+}
+
+.msg-row-assistant {
+  justify-content: flex-start;
+  align-items: flex-start;
+  padding: 14px 0;
+  animation: msgAssistantIn 0.4s cubic-bezier(0.22, 0.61, 0.36, 1);
+}
+
+@keyframes msgUserIn {
+  from {
+    opacity: 0;
+    transform: translateX(14px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes msgAssistantIn {
+  from {
+    opacity: 0;
+    transform: translateX(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+/* ---- User message: compact pill, right-aligned ---- */
+.msg-user-pill {
+  max-width: 78%;
+  padding: 10px 16px;
+  border-radius: 18px;
+  background: var(--gemini-user-bubble, #e8f0fe);
+  color: var(--gemini-text-primary, #1f2328);
+  font-size: 15px;
+  line-height: 1.55;
+  word-wrap: break-word;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+  box-shadow: 0 1px 1.5px rgba(60, 64, 67, 0.08);
+}
+
+.msg-assistant-avatar {
+  flex-shrink: 0;
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  background: linear-gradient(135deg, #4285f4 0%, #9b72cb 50%, #d96570 100%);
+  box-shadow: 0 1px 3px rgba(60, 64, 67, 0.18), 0 0 0 0.5px rgba(60, 64, 67, 0.06);
+  margin-top: 2px;
+}
+
+.msg-assistant-body {
+  flex: 1 1 0%;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding-top: 4px;
+}
+
+/* ---- Reasoning toggle (Gemini chip) ---- */
+.msg-reasoning-toggle {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 10px 5px 8px;
+  border: 1px solid var(--gemini-border, rgba(0, 0, 0, 0.08));
+  border-radius: 999px;
+  background: transparent;
+  color: var(--gemini-text-secondary, #444746);
+  font-size: 12.5px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.msg-reasoning-toggle:hover {
+  background: var(--gemini-hover, rgba(0, 0, 0, 0.04));
+  color: var(--gemini-text-primary, #1f2328);
+}
+
+.msg-reasoning-chevron {
+  width: 14px;
+  height: 14px;
+  transition: transform 0.2s ease;
+}
+
+.msg-reasoning-chevron.is-open {
+  transform: rotate(180deg);
+}
+
+/* ---- Reasoning content ---- */
+.msg-reasoning-content {
+  width: 100%;
+  border-left: 2px solid var(--gemini-border, rgba(0, 0, 0, 0.1));
+  padding: 4px 0 4px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  margin-bottom: 4px;
+}
+
+.msg-reasoning-step {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.msg-reasoning-step-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.msg-reasoning-step-num {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  color: var(--gemini-text-tertiary, #80868b);
+  font-variant-numeric: tabular-nums;
+}
+
+.msg-reasoning-step-action {
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--gemini-text-primary, #1f2328);
+}
+
+.msg-reasoning-step-line {
+  font-size: 13px;
+  color: var(--gemini-text-secondary, #444746);
+  line-height: 1.55;
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.msg-reasoning-step-line code {
+  font-family: "SF Mono", "JetBrains Mono", ui-monospace, monospace;
+  font-size: 12.5px;
+  padding: 2px 6px;
+  border-radius: 5px;
+  background: var(--gemini-code-bg, rgba(0, 0, 0, 0.05));
+  color: var(--gemini-text-primary, #1f2328);
+}
+
+.msg-reasoning-step-kicker {
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--gemini-text-tertiary, #80868b);
+  flex-shrink: 0;
+}
+
+.msg-reasoning-verdict {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 4px 10px;
+  border-radius: 6px;
+  font-size: 12.5px;
+  font-weight: 500;
+  width: fit-content;
+}
+
+.msg-reasoning-verdict.is-ok {
+  background: rgba(52, 168, 83, 0.1);
+  color: #137333;
+}
+
+.msg-reasoning-verdict.is-warn {
+  background: rgba(251, 188, 4, 0.12);
+  color: #b06000;
+}
+
+.msg-reasoning-recall {
+  font-variant-numeric: tabular-nums;
+  font-size: 11.5px;
+  opacity: 0.85;
+  margin-left: 4px;
+}
+
+.msg-reasoning-step-sources {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 4px;
+}
+
+.msg-source-mini {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 8px;
+  border-radius: 5px;
+  font-size: 11.5px;
+  color: var(--gemini-text-secondary, #444746);
+  background: var(--gemini-hover, rgba(0, 0, 0, 0.04));
+  text-decoration: none;
+  max-width: 240px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.msg-source-mini:hover {
+  background: var(--gemini-hover-strong, rgba(0, 0, 0, 0.08));
+  color: var(--gemini-text-primary, #1f2328);
+}
+
+.msg-source-mini span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ---- Assistant content body (markdown) ---- */
+.msg-assistant-content {
+  font-size: 15px;
+  line-height: 1.7;
+  color: var(--gemini-text-primary, #1f2328);
+  word-wrap: break-word;
+  overflow-wrap: anywhere;
+}
+
+.msg-assistant-content.is-failed {
+  /* no special visual — error card renders below */
+}
+
+/* ---- Loading dots (three-dot pulse) ---- */
+.msg-loading {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 6px 0;
+}
+
+.msg-loading-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--gemini-text-tertiary, #80868b);
+  animation: msgDotPulse 1.2s ease-in-out infinite;
+}
+
+@keyframes msgDotPulse {
+  0%, 60%, 100% {
+    opacity: 0.35;
+    transform: translateY(0);
+  }
+  30% {
+    opacity: 1;
+    transform: translateY(-3px);
+  }
+}
+
+/* ---- Error card ---- */
+.msg-error {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 12px 14px;
+  border-radius: 10px;
+  background: rgba(217, 48, 37, 0.06);
+  border: 1px solid rgba(217, 48, 37, 0.18);
+  color: #b3261e;
+  margin-top: 6px;
+}
+
+.msg-error-title {
+  font-size: 13px;
+  font-weight: 600;
+  margin-bottom: 2px;
+}
+
+.msg-error-detail {
+  font-size: 12.5px;
+  opacity: 0.85;
+  line-height: 1.5;
+  word-break: break-word;
+}
+
+.msg-assistant-content.is-failed {
+  /* keep markdown empty when failed — error card shows instead */
+}
+
+/* ---- Sources citation cards ---- */
+.msg-sources {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 6px;
+}
+
+.msg-sources-label {
+  font-size: 11.5px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--gemini-text-tertiary, #80868b);
+}
+
+.msg-sources-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 8px;
+}
+
+.msg-source-card {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--gemini-border, rgba(0, 0, 0, 0.08));
+  background: var(--gemini-surface, #fff);
+  text-decoration: none;
+  color: inherit;
+  transition: transform 0.16s ease, box-shadow 0.16s ease, border-color 0.16s ease;
+  min-width: 0;
+}
+
+.msg-source-card:hover {
+  transform: translateY(-1px);
+  border-color: rgba(0, 0, 0, 0.14);
+  box-shadow: 0 2px 8px rgba(60, 64, 67, 0.1);
+}
+
+.msg-source-card-index {
+  flex-shrink: 0;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: var(--gemini-hover, rgba(0, 0, 0, 0.06));
+  color: var(--gemini-text-secondary, #444746);
+  font-size: 11px;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-variant-numeric: tabular-nums;
+}
+
+.msg-source-card-body {
+  flex: 1 1 0%;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.msg-source-card-title {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--gemini-text-primary, #1f2328);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  line-height: 1.4;
+}
+
+.msg-source-card-domain {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 11px;
+  color: var(--gemini-text-tertiary, #80868b);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.msg-source-card-favicon {
+  width: 14px;
+  height: 14px;
+  border-radius: 3px;
+  background: var(--gemini-hover-strong, rgba(0, 0, 0, 0.1));
+  color: var(--gemini-text-secondary, #444746);
+  font-size: 9px;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.msg-source-card-arrow {
+  width: 13px;
+  height: 13px;
+  flex-shrink: 0;
+  color: var(--gemini-text-tertiary, #80868b);
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+
+.msg-source-card:hover .msg-source-card-arrow {
+  opacity: 1;
+}
+
+.msg-source-more {
+  font-size: 12px;
+  color: var(--gemini-text-tertiary, #80868b);
+  padding: 10px 12px;
+  align-self: center;
+}
+
+/* ---- Action bar (ghost icon buttons) ---- */
+.msg-actions {
+  display: flex;
+  gap: 2px;
+  margin-top: 4px;
+  opacity: 0;
+  transition: opacity 0.18s ease;
+}
+
+.msg-row-assistant:hover .msg-actions {
+  opacity: 1;
+}
+
+.msg-action-btn {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  border: none;
+  background: transparent;
+  color: var(--gemini-text-secondary, #444746);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.14s ease, color 0.14s ease;
+}
+
+.msg-action-btn:hover {
+  background: var(--gemini-hover, rgba(0, 0, 0, 0.06));
+  color: var(--gemini-text-primary, #1f2328);
+}
+
+.msg-action-btn.is-active {
+  color: #1a73e8;
+  background: rgba(26, 115, 232, 0.08);
+}
+
+.msg-action-icon-ok {
+  color: #137333;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .msg-row-user,
+  .msg-row-assistant,
+  .msg-loading-dot,
+  .msg-source-card,
+  .msg-action-btn,
+  .msg-reasoning-toggle,
+  .msg-reasoning-chevron {
+    transition: none !important;
+    animation: none !important;
+  }
+}
+
 .folder-card {
   /* Google Drive / Material 3 surface card */
   border-radius: 12px;
@@ -1128,62 +2578,155 @@ html.dark * {
   position: relative;
 }
 
-.markdown {
-  font-size: 14px;
-  line-height: 1.6;
-  color: inherit;
+/* Gemini Style Markdown */
+.markdown.gemini-markdown {
+  font-size: 15px;
+  line-height: 1.75;
+  color: var(--gemini-text-primary);
 }
 
-.markdown p {
-  margin: 0 0 8px 0;
+.markdown.gemini-markdown p {
+  margin: 0 0 12px 0;
 }
 
-.markdown p:last-child {
+.markdown.gemini-markdown p:last-child {
   margin-bottom: 0;
 }
 
-.markdown ul,
-.markdown ol {
-  margin: 8px 0 8px 18px;
-  padding: 0;
+.markdown.gemini-markdown ul,
+.markdown.gemini-markdown ol {
+  margin: 12px 0;
+  padding-left: 24px;
 }
 
-.markdown li {
-  margin: 4px 0;
+.markdown.gemini-markdown li {
+  margin: 6px 0;
 }
 
-.markdown a {
-  color: var(--accent-strong);
-  text-decoration: underline;
+.markdown.gemini-markdown li::marker {
+  color: var(--gemini-primary);
 }
 
-.markdown code {
-  background: rgba(255, 255, 255, 0.1);
-  padding: 2px 5px;
+.markdown.gemini-markdown a {
+  color: var(--gemini-primary);
+  text-decoration: none;
+  border-bottom: 1px solid rgba(66, 133, 244, 0.3);
+  transition: border-color 0.15s ease, color 0.15s ease;
+}
+
+.markdown.gemini-markdown a:hover {
+  border-bottom-color: var(--gemini-primary);
+  color: var(--gemini-primary-hover);
+}
+
+.markdown.gemini-markdown strong {
+  font-weight: 600;
+}
+
+.markdown.gemini-markdown em {
+  font-style: italic;
+}
+
+.markdown.gemini-markdown code {
+  background: var(--gemini-surface-variant);
+  color: #D93025;
+  padding: 2px 8px;
   border-radius: 6px;
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-  font-size: 12.5px;
+  font-family: ui-monospace, SFMono-Regular, "Consolas", "Liberation Mono", Menlo, monospace;
+  font-size: 13px;
+  font-weight: 500;
+  border: 1px solid var(--gemini-border);
 }
 
-.markdown pre {
-  background: rgba(255, 255, 255, 0.06);
-  padding: 10px 12px;
+.dark .markdown.gemini-markdown code {
+  color: #FF8A80;
+  background: rgba(255, 138, 128, 0.1);
+  border-color: rgba(255, 138, 128, 0.2);
+}
+
+.markdown.gemini-markdown pre {
+  background: var(--gemini-surface-variant);
+  border: 1px solid var(--gemini-border);
   border-radius: 12px;
-  overflow: auto;
-  margin: 10px 0;
+  padding: 16px;
+  margin: 16px 0;
+  overflow-x: auto;
 }
 
-.markdown pre code {
+.markdown.gemini-markdown pre code {
   background: transparent;
+  color: var(--gemini-text-primary);
   padding: 0;
-  font-size: 12.5px;
+  font-size: 13px;
+  font-weight: normal;
+  border: none;
 }
 
-.markdown blockquote {
-  margin: 10px 0;
-  padding-left: 12px;
-  border-left: 3px solid rgba(255, 255, 255, 0.12);
-  color: var(--muted-foreground);
+.markdown.gemini-markdown blockquote {
+  margin: 16px 0;
+  padding: 12px 16px;
+  border-left: 4px solid var(--gemini-primary);
+  color: var(--gemini-text-secondary);
+  font-style: normal;
+  background: var(--gemini-surface-variant);
+  border-radius: 0 8px 8px 0;
+}
+
+.markdown.gemini-markdown blockquote p {
+  margin: 0;
+}
+
+.markdown.gemini-markdown h1,
+.markdown.gemini-markdown h2,
+.markdown.gemini-markdown h3,
+.markdown.gemini-markdown h4 {
+  margin: 20px 0 10px 0;
+  font-weight: 600;
+  color: var(--gemini-text-primary);
+  line-height: 1.4;
+}
+
+.markdown.gemini-markdown h1 { font-size: 22px; }
+.markdown.gemini-markdown h2 { font-size: 19px; }
+.markdown.gemini-markdown h3 { font-size: 17px; }
+.markdown.gemini-markdown h4 { font-size: 15px; }
+
+.markdown.gemini-markdown table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin: 16px 0;
+  font-size: 14px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid var(--gemini-border);
+}
+
+.markdown.gemini-markdown th,
+.markdown.gemini-markdown td {
+  padding: 10px 14px;
+  text-align: left;
+  border-bottom: 1px solid var(--gemini-border);
+}
+
+.markdown.gemini-markdown th {
+  background: var(--gemini-surface-variant);
+  font-weight: 600;
+  color: var(--gemini-text-primary);
+}
+
+.markdown.gemini-markdown tr:last-child td {
+  border-bottom: none;
+}
+
+.markdown.gemini-markdown tr:hover td {
+  background: var(--gemini-surface-variant);
+}
+
+.markdown.gemini-markdown hr {
+  border: none;
+  border-top: 1px solid var(--gemini-border);
+  margin: 20px 0;
 }
 
 .message.assistant .message-bubble {
@@ -1544,6 +3087,48 @@ html.dark * {
     opacity: 1;
     transform: translateY(0);
   }
+}
+
+/* Message bubble slide-up animation */
+@keyframes messageSlideIn {
+  from {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.message {
+  animation: messageSlideIn 0.35s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* Staggered animation for message sequences */
+.message:nth-child(1) { animation-delay: 0ms; }
+.message:nth-child(2) { animation-delay: 40ms; }
+.message:nth-child(3) { animation-delay: 80ms; }
+.message:nth-child(4) { animation-delay: 120ms; }
+.message:nth-child(5) { animation-delay: 160ms; }
+
+/* Floating animation for empty state icon */
+@keyframes float {
+  0%, 100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-8px);
+  }
+}
+
+.empty-state-icon {
+  animation: float 3s ease-in-out infinite;
+}
+
+/* Input focus glow enhancement */
+.input:focus {
+  box-shadow: 0 0 0 3px rgba(6, 182, 212, 0.15), 0 0 20px rgba(6, 182, 212, 0.1);
 }
 
 /* ========== 侧边栏弹窗（参考收藏夹弹窗设计） ========== */

--- a/frontend/components/chat-sidebar/ChatSidebarEmpty.tsx
+++ b/frontend/components/chat-sidebar/ChatSidebarEmpty.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { MessageSquarePlus } from "lucide-react";
+import { MessageSquarePlus, ArrowUp } from "lucide-react";
 
 interface ChatSidebarEmptyProps {
   onCreateSession: () => void;
@@ -11,6 +11,11 @@ export function ChatSidebarEmpty({
   onCreateSession,
   isCreating,
 }: ChatSidebarEmptyProps) {
+  // The header already renders the primary "新建对话" CTA, so this empty
+  // state only guides the user toward it — no duplicate button here.
+  void onCreateSession;
+  void isCreating;
+
   return (
     <div className="sidebar-empty">
       <div className="sidebar-empty-icon">
@@ -18,16 +23,12 @@ export function ChatSidebarEmpty({
       </div>
       <div className="space-y-1">
         <p className="sidebar-empty-title">还没有历史对话</p>
-        <p className="sidebar-empty-hint">点击上方按钮开始新对话</p>
+        <p className="sidebar-empty-hint">
+          点击上方
+          <ArrowUp className="inline mx-1 size-3 align-middle" />
+          按钮开启新对话
+        </p>
       </div>
-      <button
-        type="button"
-        onClick={onCreateSession}
-        disabled={isCreating}
-        className="sidebar-new-btn"
-      >
-        新建对话
-      </button>
     </div>
   );
 }

--- a/frontend/components/chat/ChatContent.tsx
+++ b/frontend/components/chat/ChatContent.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import ChatMessage from "./ChatMessage";
+import ChatInput from "./ChatInput";
+import EmptyState from "./EmptyState";
+import type { ChatMessageData } from "./types";
+
+interface ChatContentProps {
+  messages: ChatMessageData[];
+  isStreaming: boolean;
+  onSend: (message: string) => void;
+  onStop: () => void;
+  onSuggestionClick?: (suggestion: string) => void;
+  // Max width in px for messages area.
+  // Default 768 (Gemini full-page style). Use 576 for narrower dock contexts.
+  maxWidth?: number;
+  // Max width in px for the input area. Defaults to maxWidth.
+  // Set smaller to make the input narrower than the messages (Gemini style).
+  inputMaxWidth?: number;
+  hideDisclaimer?: boolean;
+  className?: string;
+}
+
+export default function ChatContent({
+  messages,
+  isStreaming,
+  onSend,
+  onStop,
+  onSuggestionClick,
+  maxWidth = 768,
+  inputMaxWidth,
+  hideDisclaimer = false,
+  className = "",
+}: ChatContentProps) {
+  // Input area is narrower than the messages area by default (Gemini style).
+  const effectiveInputWidth = inputMaxWidth ?? maxWidth;
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages]);
+
+  // Centered content wrapper for messages.
+  // Inline style guarantees the max-width is applied regardless of Tailwind
+  // class generation quirks.
+  const messagesStyle: React.CSSProperties = {
+    width: "100%",
+    maxWidth,
+    marginLeft: "auto",
+    marginRight: "auto",
+  };
+
+  // Centered content wrapper for input — can be narrower than messages.
+  const inputStyle: React.CSSProperties = {
+    width: "100%",
+    maxWidth: effectiveInputWidth,
+    marginLeft: "auto",
+    marginRight: "auto",
+  };
+
+  return (
+    <div className={`panel-inner chat-content ${className}`}>
+      {/* 消息滚动区域 — panel-body 自带 flex:1 + overflow-y:auto */}
+      <div className="panel-body">
+        <div style={messagesStyle}>
+          {messages.length === 0 ? (
+            <EmptyState onSuggestionClick={onSuggestionClick ?? onSend} />
+          ) : (
+            <div className="chat-window">
+              {messages.map((message) => (
+                <ChatMessage
+                  key={message.id}
+                  role={message.role}
+                  content={message.content}
+                  sources={message.sources}
+                  reasoningSteps={message.reasoningSteps}
+                  status={message.status}
+                  error={message.error}
+                  timestamp={message.timestamp}
+                />
+              ))}
+              <div ref={messagesEndRef} />
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* 底部输入区域 - 比消息区略窄居中（Gemini 风格） */}
+      <div className="panel-footer">
+        <div style={inputStyle}>
+          <ChatInput
+            onSend={onSend}
+            disabled={isStreaming}
+            isStreaming={isStreaming}
+            onStop={onStop}
+            hideDisclaimer={hideDisclaimer}
+            placeholder="输入你的问题..."
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/chat/ChatDockPanel.tsx
+++ b/frontend/components/chat/ChatDockPanel.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import ChatContent from "./ChatContent";
+import { chatApi, type ChatMessage as ApiChatMessage } from "@/lib/api";
+import { useDockContext } from "@/lib/dock-context";
+import { streamChat, type ChatSource } from "@/lib/chat-stream";
+import type { ChatMessageData } from "./types";
+
+interface ChatDockPanelProps {
+  isOpen?: boolean;
+  onClose?: () => void;
+}
+
+// Map backend ChatMessage → local ChatMessageData
+function toUIMessage(m: ApiChatMessage): ChatMessageData {
+  return {
+    id: m.msg_id,
+    role: m.role === "system" ? "assistant" : m.role,
+    content: m.content,
+    // Backend may return null; normalize to array.
+    sources: Array.isArray(m.sources) ? m.sources : undefined,
+    status: m.status,
+    error: m.error,
+    timestamp: m.created_at,
+  };
+}
+
+export default function ChatDockPanel({ isOpen, onClose }: ChatDockPanelProps) {
+  const ctx = useDockContext();
+  const activeChatSessionId = ctx.activeChatSessionId;
+
+  const [messages, setMessages] = useState<ChatMessageData[]>([]);
+  const [isStreaming, setIsStreaming] = useState(false);
+  const [isLoadingHistory, setIsLoadingHistory] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  // isOpen/onClose are handled by the FloatingPanel wrapper; keep the
+  // prop signature for the dock registry contract but no-op here.
+  void isOpen;
+  void onClose;
+
+  // Load history when active session changes — this is the fix for
+  // "can't load history" in the chat dock panel.
+  useEffect(() => {
+    if (!activeChatSessionId) {
+      setMessages([]);
+      setLoadError(null);
+      return;
+    }
+
+    let cancelled = false;
+    setIsLoadingHistory(true);
+    setLoadError(null);
+    // Clear immediately so switching sessions doesn't show stale messages.
+    setMessages([]);
+
+    (async () => {
+      try {
+        const res = await chatApi.getHistory(activeChatSessionId);
+        if (cancelled) return;
+        setMessages(res.messages.map(toUIMessage));
+      } catch (e) {
+        if (cancelled) return;
+        const msg = e instanceof Error ? e.message : "加载历史消息失败";
+        setLoadError(msg);
+      } finally {
+        if (!cancelled) setIsLoadingHistory(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activeChatSessionId]);
+
+  const handleSend = async (userMessage: string) => {
+    if (!activeChatSessionId) {
+      setLoadError("当前没有活动会话，请先在「历史会话」中创建或选择一个");
+      return;
+    }
+
+    const userMsgId = `user-${Date.now()}`;
+    const assistantMsgId = `assistant-${Date.now() + 1}`;
+    const timestamp = new Date().toISOString();
+
+    setMessages((prev) => [
+      ...prev,
+      {
+        id: userMsgId,
+        role: "user",
+        content: userMessage,
+        status: "completed",
+        timestamp,
+      },
+      {
+        id: assistantMsgId,
+        role: "assistant",
+        content: "",
+        status: "pending",
+        timestamp,
+      },
+    ]);
+
+    setIsStreaming(true);
+
+    try {
+      const stream = await chatApi.askStream({
+        question: userMessage,
+        chat_session_id: activeChatSessionId,
+      });
+
+      await streamChat(stream, {
+        onChunk: (accumulated) => {
+          setMessages((prev) =>
+            prev.map((m) =>
+              m.id === assistantMsgId ? { ...m, content: accumulated } : m
+            )
+          );
+        },
+        onSources: (sources: ChatSource[]) => {
+          setMessages((prev) =>
+            prev.map((m) =>
+              m.id === assistantMsgId ? { ...m, sources } : m
+            )
+          );
+        },
+        onError: (message) => {
+          setMessages((prev) =>
+            prev.map((m) =>
+              m.id === assistantMsgId
+                ? { ...m, status: "failed", error: message }
+                : m
+            )
+          );
+        },
+        onComplete: () => {
+          setMessages((prev) =>
+            prev.map((m) =>
+              m.id === assistantMsgId && m.status === "pending"
+                ? { ...m, status: "completed" }
+                : m
+            )
+          );
+        },
+      });
+
+      // Notify sidebar to refresh (backend may auto-generate title)
+      ctx.refreshSessions();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "请求失败";
+      setMessages((prev) =>
+        prev.map((m) =>
+          m.id === assistantMsgId
+            ? { ...m, status: "failed", error: message }
+            : m
+        )
+      );
+    } finally {
+      setIsStreaming(false);
+    }
+  };
+
+  const handleStop = () => {
+    setIsStreaming(false);
+    setMessages((prev) =>
+      prev.map((m) =>
+        m.status === "pending" ? { ...m, status: "completed" } : m
+      )
+    );
+  };
+
+  // Surface load error as a failed assistant message so it renders inline.
+  const displayMessages: ChatMessageData[] =
+    loadError && messages.length === 0
+      ? [
+          {
+            id: "load-err",
+            role: "assistant",
+            content: "",
+            status: "failed",
+            error: loadError,
+            timestamp: new Date().toISOString(),
+          },
+        ]
+      : messages;
+
+  return (
+    <ChatContent
+      messages={displayMessages}
+      isStreaming={isStreaming || isLoadingHistory}
+      onSend={handleSend}
+      onStop={handleStop}
+      onSuggestionClick={handleSend}
+      maxWidth={768}
+      inputMaxWidth={614}
+      hideDisclaimer
+      className="h-full"
+    />
+  );
+}

--- a/frontend/components/chat/ChatHeader.tsx
+++ b/frontend/components/chat/ChatHeader.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { Menu, Sparkles, Settings, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface ChatHeaderProps {
+  onMenuClick?: () => void;
+  onClearChat?: () => void;
+  title?: string;
+  hasMessages?: boolean;
+}
+
+export default function ChatHeader({
+  onMenuClick,
+  onClearChat,
+  title = "BiliRag",
+  hasMessages = false,
+}: ChatHeaderProps) {
+  return (
+    <header className="sticky top-0 z-10 flex items-center justify-between px-4 py-3 bg-[var(--gemini-surface)]/95 backdrop-blur-sm border-b border-[var(--gemini-border-subtle)]">
+      {/* 左侧：菜单按钮 + 标题 */}
+      <div className="flex items-center gap-3">
+        <Button
+          variant="ghost"
+          size="icon"
+          className="md:hidden rounded-full hover:bg-[var(--gemini-surface-variant)]"
+          onClick={onMenuClick}
+        >
+          <Menu className="w-5 h-5 text-[var(--gemini-text-secondary)]" />
+        </Button>
+
+        <div className="flex items-center gap-2">
+          <div className="w-8 h-8 rounded-full bg-gradient-to-br from-[var(--gemini-primary)] to-[#9c27b0] flex items-center justify-center">
+            <Sparkles className="w-4 h-4 text-white" />
+          </div>
+          <h1 className="text-lg font-medium text-[var(--gemini-text-primary)]">{title}</h1>
+        </div>
+      </div>
+
+      {/* 右侧：操作按钮 */}
+      <div className="flex items-center gap-1">
+        {hasMessages && (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="rounded-full hover:bg-[var(--gemini-surface-variant)]"
+            onClick={onClearChat}
+            title="清空对话"
+          >
+            <Trash2 className="w-5 h-5 text-[var(--gemini-text-secondary)]" />
+          </Button>
+        )}
+        <Button
+          variant="ghost"
+          size="icon"
+          className="rounded-full hover:bg-[var(--gemini-surface-variant)]"
+          title="设置"
+        >
+          <Settings className="w-5 h-5 text-[var(--gemini-text-secondary)]" />
+        </Button>
+      </div>
+    </header>
+  );
+}

--- a/frontend/components/chat/ChatHistorySidebar.tsx
+++ b/frontend/components/chat/ChatHistorySidebar.tsx
@@ -1,0 +1,254 @@
+"use client";
+
+import { useState } from "react";
+import { Plus, Pencil, Trash2, X } from "lucide-react";
+
+interface ChatSession {
+  id: string;
+  title: string;
+  lastMessageAt: string;
+  isActive?: boolean;
+}
+
+interface ChatHistorySidebarProps {
+  sessions?: ChatSession[];
+  activeSessionId?: string;
+  onSessionSelect?: (sessionId: string) => void;
+  onNewChat?: () => void;
+  onDeleteSession?: (sessionId: string) => void;
+  onRenameSession?: (sessionId: string, newTitle: string) => void;
+  isOpen?: boolean;
+  onClose?: () => void;
+}
+
+// Relative-time formatter (zh-CN) — keeps the sidebar self-contained.
+function formatRelative(iso: string): string {
+  const now = Date.now();
+  const then = new Date(iso).getTime();
+  const diff = Math.max(0, now - then);
+  const min = Math.floor(diff / 60000);
+  if (min < 1) return "刚刚";
+  if (min < 60) return `${min} 分钟前`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr} 小时前`;
+  const day = Math.floor(hr / 24);
+  if (day < 7) return `${day} 天前`;
+  return new Date(iso).toLocaleDateString("zh-CN", { month: "short", day: "numeric" });
+}
+
+const groupSessionsByDate = (sessions: ChatSession[]) => {
+  const today: ChatSession[] = [];
+  const yesterday: ChatSession[] = [];
+  const lastWeek: ChatSession[] = [];
+  const earlier: ChatSession[] = [];
+
+  const now = new Date();
+  const todayStr = now.toDateString();
+  const yesterdayStr = new Date(now.getTime() - 86400000).toDateString();
+
+  sessions.forEach((session) => {
+    const date = new Date(session.lastMessageAt).toDateString();
+    if (date === todayStr) {
+      today.push(session);
+    } else if (date === yesterdayStr) {
+      yesterday.push(session);
+    } else {
+      const daysDiff = Math.floor((now.getTime() - new Date(session.lastMessageAt).getTime()) / 86400000);
+      if (daysDiff <= 7) {
+        lastWeek.push(session);
+      } else {
+        earlier.push(session);
+      }
+    }
+  });
+
+  return [
+    { label: "今天", items: today },
+    { label: "昨天", items: yesterday },
+    { label: "上周", items: lastWeek },
+    { label: "更早", items: earlier },
+  ].filter((g) => g.items.length > 0);
+};
+
+export default function ChatHistorySidebar({
+  sessions = [
+    { id: "1", title: "如何学习 React?", lastMessageAt: new Date().toISOString() },
+    { id: "2", title: "总结机器学习视频要点", lastMessageAt: new Date(Date.now() - 86400000).toISOString() },
+    { id: "3", title: "前端学习路径规划", lastMessageAt: new Date(Date.now() - 86400000 * 3).toISOString() },
+  ],
+  activeSessionId,
+  onSessionSelect,
+  onNewChat,
+  onDeleteSession,
+  onRenameSession,
+  isOpen = true,
+  onClose,
+}: ChatHistorySidebarProps) {
+  const [hoveredSession, setHoveredSession] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editTitle, setEditTitle] = useState("");
+
+  const grouped = groupSessionsByDate(sessions);
+
+  const handleStartEdit = (session: ChatSession, e: React.MouseEvent) => {
+    e.stopPropagation();
+    setEditingId(session.id);
+    setEditTitle(session.title);
+  };
+
+  const handleSaveEdit = (sessionId: string) => {
+    if (editTitle.trim()) {
+      onRenameSession?.(sessionId, editTitle.trim());
+    }
+    setEditingId(null);
+  };
+
+  return (
+    <>
+      {isOpen && (
+        <div
+          className="chat-sidebar-scrim"
+          onClick={onClose}
+          aria-hidden="true"
+        />
+      )}
+
+      <aside
+        className={`chat-sidebar ${isOpen ? "is-open" : ""}`}
+        aria-label="历史会话"
+      >
+        {/* Header */}
+        <div className="chat-sidebar-header">
+          <div className="chat-sidebar-brand">
+            <span className="chat-sidebar-brand-dot" aria-hidden="true" />
+            <span className="chat-sidebar-brand-label">会话档案</span>
+          </div>
+          <button
+            type="button"
+            className="chat-sidebar-close"
+            onClick={onClose}
+            aria-label="关闭侧边栏"
+          >
+            <X className="w-4 h-4" aria-hidden="true" />
+          </button>
+        </div>
+
+        {/* New chat CTA */}
+        <div className="chat-sidebar-cta">
+          <button
+            type="button"
+            onClick={onNewChat}
+            className="chat-sidebar-new"
+          >
+            <span className="chat-sidebar-new-icon" aria-hidden="true">
+              <Plus className="w-4 h-4" />
+            </span>
+            <span className="chat-sidebar-new-text">开启新对话</span>
+            <kbd className="chat-sidebar-new-kbd">⌘N</kbd>
+          </button>
+        </div>
+
+        {/* Session list */}
+        <div className="chat-sidebar-list">
+          {grouped.length === 0 ? (
+            <div className="chat-sidebar-empty">暂无历史会话</div>
+          ) : (
+            grouped.map((group) => (
+              <section key={group.label} className="chat-sidebar-group">
+                <div className="chat-sidebar-group-label">
+                  <span>{group.label}</span>
+                  <span className="chat-sidebar-group-count">{group.items.length}</span>
+                </div>
+                <div className="chat-sidebar-group-items">
+                  {group.items.map((session) => {
+                    const isActive = session.id === activeSessionId;
+                    const isEditing = editingId === session.id;
+                    return (
+                      <div
+                        key={session.id}
+                        className={`chat-session ${isActive ? "is-active" : ""}`}
+                        onClick={() => !isEditing && onSessionSelect?.(session.id)}
+                        onMouseEnter={() => setHoveredSession(session.id)}
+                        onMouseLeave={() => setHoveredSession(null)}
+                        role="button"
+                        tabIndex={0}
+                        onKeyDown={(e) =>
+                          e.key === "Enter" && !isEditing && onSessionSelect?.(session.id)
+                        }
+                        aria-selected={isActive}
+                        aria-label={`会话：${session.title}${isActive ? "（当前）" : ""}`}
+                      >
+                        <span className="chat-session-rail" aria-hidden="true" />
+
+                        {isEditing ? (
+                          <div className="chat-session-edit">
+                            <input
+                              type="text"
+                              value={editTitle}
+                              onChange={(e) => setEditTitle(e.target.value)}
+                              onBlur={() => handleSaveEdit(session.id)}
+                              onKeyDown={(e) =>
+                                e.key === "Enter" && handleSaveEdit(session.id)
+                              }
+                              autoFocus
+                              className="chat-session-edit-input"
+                              onClick={(e) => e.stopPropagation()}
+                              aria-label={`重命名会话：${session.title}`}
+                            />
+                          </div>
+                        ) : (
+                          <>
+                            <div className="chat-session-body">
+                              <div className="chat-session-title">{session.title}</div>
+                              <div className="chat-session-meta">
+                                {formatRelative(session.lastMessageAt)}
+                              </div>
+                            </div>
+
+                            <div
+                              className={`chat-session-actions ${
+                                hoveredSession === session.id ? "is-visible" : ""
+                              }`}
+                              role="group"
+                              aria-label="会话操作"
+                            >
+                              <button
+                                type="button"
+                                onClick={(e) => handleStartEdit(session, e)}
+                                className="chat-session-action"
+                                aria-label={`重命名：${session.title}`}
+                              >
+                                <Pencil className="w-3.5 h-3.5" aria-hidden="true" />
+                              </button>
+                              <button
+                                type="button"
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  onDeleteSession?.(session.id);
+                                }}
+                                className="chat-session-action chat-session-action-danger"
+                                aria-label={`删除：${session.title}`}
+                              >
+                                <Trash2 className="w-3.5 h-3.5" aria-hidden="true" />
+                              </button>
+                            </div>
+                          </>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              </section>
+            ))
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="chat-sidebar-footer">
+          <div className="chat-sidebar-footer-brand">BiliRag</div>
+          <div className="chat-sidebar-footer-meta">收藏夹知识库 · v1.0</div>
+        </div>
+      </aside>
+    </>
+  );
+}

--- a/frontend/components/chat/ChatInput.tsx
+++ b/frontend/components/chat/ChatInput.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import { Send, StopCircle, Square } from "lucide-react";
+
+interface ChatInputProps {
+  onSend: (message: string) => void;
+  disabled?: boolean;
+  isStreaming?: boolean;
+  onStop?: () => void;
+  placeholder?: string;
+  hideDisclaimer?: boolean;
+}
+
+// Gemini-style chat input — refined editorial direction.
+// Single rounded card that grows with content up to MAX_HEIGHT, then scrolls.
+const MIN_HEIGHT = 44;
+const MAX_HEIGHT = 360;
+
+export default function ChatInput({
+  onSend,
+  disabled = false,
+  isStreaming = false,
+  onStop,
+  placeholder = "问我任何关于你收藏的视频…",
+  hideDisclaimer = false,
+}: ChatInputProps) {
+  const [input, setInput] = useState("");
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // Auto-resize: reset to auto first so scrollHeight reflects content,
+  // then clamp between MIN and MAX. Beyond MAX the textarea scrolls internally.
+  useEffect(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    const next = Math.max(MIN_HEIGHT, Math.min(el.scrollHeight, MAX_HEIGHT));
+    el.style.height = `${next}px`;
+  }, [input]);
+
+  const canSend = input.trim().length > 0 && !disabled;
+
+  const handleSend = () => {
+    const trimmed = input.trim();
+    if (!trimmed || disabled) return;
+    onSend(trimmed);
+    setInput("");
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  };
+
+  return (
+    <div className="chat-input-root" role="form" aria-label="聊天输入框">
+      <div
+        className={`chat-input-card ${canSend ? "is-ready" : ""} ${
+          isStreaming ? "is-streaming" : ""
+        }`}
+      >
+        {/* Textarea */}
+        <textarea
+          ref={textareaRef}
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder={placeholder}
+          disabled={disabled}
+          rows={1}
+          className="chat-input-textarea"
+          style={{ minHeight: `${MIN_HEIGHT}px`, maxHeight: `${MAX_HEIGHT}px` }}
+          aria-label="聊天消息输入"
+          aria-disabled={disabled}
+        />
+
+        {/* Send / Stop button */}
+        <div className="chat-input-action">
+          {isStreaming ? (
+            <button
+              type="button"
+              onClick={onStop}
+              className="chat-input-stop"
+              aria-label="停止生成"
+            >
+              <Square className="w-3.5 h-3.5 fill-current" aria-hidden="true" />
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={handleSend}
+              disabled={!canSend}
+              className="chat-input-send"
+              aria-label="发送消息"
+            >
+              <Send className="w-4 h-4" aria-hidden="true" />
+            </button>
+          )}
+        </div>
+      </div>
+
+      {!hideDisclaimer && (
+        <div className="chat-input-hint" aria-live="polite">
+          <span className="chat-input-hint-keys">
+            <kbd>⏎</kbd> 发送
+            <kbd>⇧ ⏎</kbd> 换行
+          </span>
+          <span className="chat-input-hint-disclaimer">
+            AI 可能出错，重要信息请核实
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/chat/ChatMessage.tsx
+++ b/frontend/components/chat/ChatMessage.tsx
@@ -1,0 +1,284 @@
+"use client";
+
+import { useState } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import {
+  ChevronDown,
+  ExternalLink,
+  Copy,
+  Check,
+  ThumbsUp,
+  ThumbsDown,
+  RefreshCw,
+  AlertCircle,
+  Sparkles,
+} from "lucide-react";
+
+interface Source {
+  title: string;
+  url?: string;
+  bvid?: string;
+}
+
+interface ReasoningStep {
+  step: number;
+  action: string;
+  query?: string;
+  reasoning?: string;
+  verdict?: string;
+  recall_score?: number;
+  sources: Source[];
+}
+
+interface ChatMessageProps {
+  role: "user" | "assistant";
+  content: string;
+  sources?: Source[] | null;
+  reasoningSteps?: ReasoningStep[] | null;
+  status?: "pending" | "completed" | "failed";
+  error?: string;
+  timestamp?: string;
+}
+
+// Extract a readable domain from a source URL for the citation card.
+function domainOf(url?: string): string {
+  if (!url) return "bilibili.com";
+  try {
+    const u = new URL(url);
+    return u.hostname.replace(/^www\./, "");
+  } catch {
+    return url.slice(0, 40);
+  }
+}
+
+export default function ChatMessage({
+  role,
+  content,
+  sources,
+  reasoningSteps,
+  status = "completed",
+  error,
+}: ChatMessageProps) {
+  // Normalize null/undefined → [] so .length and .map are always safe.
+  const safeSources = Array.isArray(sources) ? sources : [];
+  const safeReasoningSteps = Array.isArray(reasoningSteps) ? reasoningSteps : [];
+
+  const [showReasoning, setShowReasoning] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [feedback, setFeedback] = useState<"up" | "down" | null>(null);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(content);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
+
+  const isUser = role === "user";
+  const isPending = status === "pending";
+  const isFailed = status === "failed";
+  const showActions = !isUser && status === "completed" && !!content;
+
+  // ---- User message: right-aligned compact pill ----
+  if (isUser) {
+    return (
+      <div className="msg-row msg-row-user" role="article" aria-roledescription="用户消息">
+        <div className="msg-user-pill">{content}</div>
+      </div>
+    );
+  }
+
+  // ---- Assistant message: full-width, no bubble, avatar-led ----
+  return (
+    <div
+      className="msg-row msg-row-assistant"
+      role="article"
+      aria-roledescription="助手消息"
+      aria-live={isPending ? "polite" : "off"}
+    >
+      <div className="msg-assistant-avatar" aria-hidden="true">
+        <Sparkles className="w-4 h-4" />
+      </div>
+
+      <div className="msg-assistant-body">
+        {/* Reasoning toggle — Gemini style chip, above content */}
+        {safeReasoningSteps.length > 0 && (
+          <button
+            type="button"
+            onClick={() => setShowReasoning((v) => !v)}
+            className="msg-reasoning-toggle"
+            aria-expanded={showReasoning}
+            aria-controls="reasoning-content"
+          >
+            <ChevronDown
+              className={`msg-reasoning-chevron ${showReasoning ? "is-open" : ""}`}
+              aria-hidden="true"
+            />
+            <span>{showReasoning ? "收起思考过程" : `展示思考过程 · ${safeReasoningSteps.length} 步`}</span>
+          </button>
+        )}
+
+        {showReasoning && (
+          <div
+            id="reasoning-content"
+            className="msg-reasoning-content"
+            role="region"
+            aria-label="思考过程详情"
+          >
+            {safeReasoningSteps.map((step, i) => {
+              const stepSources = Array.isArray(step.sources) ? step.sources : [];
+              return (
+                <div key={i} className="msg-reasoning-step">
+                  <div className="msg-reasoning-step-head">
+                    <span className="msg-reasoning-step-num">{String(step.step).padStart(2, "0")}</span>
+                    <span className="msg-reasoning-step-action">{step.action}</span>
+                  </div>
+                  {step.query && (
+                    <div className="msg-reasoning-step-line">
+                      <span className="msg-reasoning-step-kicker">检索</span>
+                      <code>{step.query}</code>
+                    </div>
+                  )}
+                  {step.reasoning && (
+                    <div className="msg-reasoning-step-line">{step.reasoning}</div>
+                  )}
+                  {step.verdict && (
+                    <div
+                      className={`msg-reasoning-verdict ${
+                        step.verdict === "sufficient" ? "is-ok" : "is-warn"
+                      }`}
+                    >
+                      结论：{step.verdict}
+                      {step.recall_score != null && (
+                        <span className="msg-reasoning-recall">
+                          召回 {step.recall_score.toFixed(3)}
+                        </span>
+                      )}
+                    </div>
+                  )}
+                  {stepSources.length > 0 && (
+                    <div className="msg-reasoning-step-sources">
+                      {stepSources.map((src, j) => (
+                        <a
+                          key={j}
+                          href={src.url || `https://www.bilibili.com/video/${src.bvid}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="msg-source-mini"
+                        >
+                          <ExternalLink className="w-3 h-3" aria-hidden="true" />
+                          <span>{src.title}</span>
+                        </a>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        {/* Content / loading / error */}
+        <div className={`msg-assistant-content ${isFailed ? "is-failed" : ""}`}>
+          {isPending && !content ? (
+            <div className="msg-loading" role="status" aria-label="助手思考中">
+              <span className="msg-loading-dot" style={{ animationDelay: "0ms" }} />
+              <span className="msg-loading-dot" style={{ animationDelay: "180ms" }} />
+              <span className="msg-loading-dot" style={{ animationDelay: "360ms" }} />
+            </div>
+          ) : (
+            <ReactMarkdown className="markdown gemini-markdown" remarkPlugins={[remarkGfm]}>
+              {content || ""}
+            </ReactMarkdown>
+          )}
+
+          {isFailed && error && (
+            <div className="msg-error">
+              <AlertCircle className="w-4 h-4 shrink-0" aria-hidden="true" />
+              <div>
+                <div className="msg-error-title">生成失败</div>
+                <div className="msg-error-detail">{error}</div>
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Sources — citation cards, not pills */}
+        {safeSources.length > 0 && (
+          <div className="msg-sources">
+            <div className="msg-sources-label">引用来源</div>
+            <div className="msg-sources-grid">
+              {safeSources.slice(0, 6).map((source, i) => {
+                const domain = domainOf(source.url);
+                return (
+                  <a
+                    key={i}
+                    href={source.url || `https://www.bilibili.com/video/${source.bvid}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="msg-source-card"
+                  >
+                    <span className="msg-source-card-index">{i + 1}</span>
+                    <span className="msg-source-card-body">
+                      <span className="msg-source-card-title">{source.title}</span>
+                      <span className="msg-source-card-domain">
+                        <span className="msg-source-card-favicon" aria-hidden="true">
+                          {domain.charAt(0).toUpperCase()}
+                        </span>
+                        {domain}
+                      </span>
+                    </span>
+                    <ExternalLink className="msg-source-card-arrow" aria-hidden="true" />
+                  </a>
+                );
+              })}
+              {safeSources.length > 6 && (
+                <div className="msg-source-more">+{safeSources.length - 6} 个来源</div>
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* Action bar — ghost icon buttons, reveal on row hover */}
+        {showActions && (
+          <div className="msg-actions" role="group" aria-label="消息操作">
+            <button
+              type="button"
+              onClick={handleCopy}
+              className="msg-action-btn"
+              aria-label={copied ? "已复制" : "复制消息"}
+              aria-live="polite"
+            >
+              {copied ? (
+                <Check className="w-4 h-4 msg-action-icon-ok" aria-hidden="true" />
+              ) : (
+                <Copy className="w-4 h-4" aria-hidden="true" />
+              )}
+            </button>
+            <button
+              type="button"
+              onClick={() => setFeedback(feedback === "up" ? null : "up")}
+              className={`msg-action-btn ${feedback === "up" ? "is-active" : ""}`}
+              aria-label="有帮助"
+              aria-pressed={feedback === "up"}
+            >
+              <ThumbsUp className="w-4 h-4" aria-hidden="true" />
+            </button>
+            <button
+              type="button"
+              onClick={() => setFeedback(feedback === "down" ? null : "down")}
+              className={`msg-action-btn ${feedback === "down" ? "is-active" : ""}`}
+              aria-label="无帮助"
+              aria-pressed={feedback === "down"}
+            >
+              <ThumbsDown className="w-4 h-4" aria-hidden="true" />
+            </button>
+            <button type="button" className="msg-action-btn" aria-label="重新生成">
+              <RefreshCw className="w-4 h-4" aria-hidden="true" />
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/chat/ChatPanel.tsx
+++ b/frontend/components/chat/ChatPanel.tsx
@@ -1,0 +1,358 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import ChatContent from "./ChatContent";
+import ChatHeader from "./ChatHeader";
+import ChatHistorySidebar from "./ChatHistorySidebar";
+import { chatApi, type ChatSession, type ChatMessage } from "@/lib/api";
+import { streamChat, type ChatSource } from "@/lib/chat-stream";
+import type { ChatMessageData } from "./types";
+
+// Local UI session shape — maps backend ChatSession + holds loaded messages.
+interface UISession {
+  id: string; // chat_session_id from backend
+  title: string;
+  lastMessageAt: string;
+  messages: ChatMessageData[];
+  historyLoaded: boolean;
+}
+
+// Map backend ChatMessage → local ChatMessageData
+function toUIMessage(m: ChatMessage): ChatMessageData {
+  return {
+    id: m.msg_id,
+    role: m.role === "system" ? "assistant" : m.role,
+    content: m.content,
+    // Backend may return null; normalize to array.
+    sources: Array.isArray(m.sources) ? m.sources : undefined,
+    status: m.status,
+    error: m.error,
+    timestamp: m.created_at,
+  };
+}
+
+// Map backend ChatSession → local UISession (without messages until loaded)
+function toUISession(s: ChatSession): UISession {
+  return {
+    id: s.chat_session_id,
+    title: s.title || "新对话",
+    lastMessageAt: s.last_message_at || s.updated_at || s.created_at,
+    messages: [],
+    historyLoaded: false,
+  };
+}
+
+export default function ChatPanel() {
+  const [sidebarOpen, setSidebarOpen] = useState(true);
+  const [sessions, setSessions] = useState<UISession[]>([]);
+  const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
+  const [isStreaming, setIsStreaming] = useState(false);
+  const [isLoadingSessions, setIsLoadingSessions] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const activeSession = sessions.find((s) => s.id === activeSessionId);
+  const messages = activeSession?.messages ?? [];
+
+  // ---- Backend session list loading ----
+  const refreshSessions = useCallback(async () => {
+    setIsLoadingSessions(true);
+    setLoadError(null);
+    try {
+      const res = await chatApi.listSessions();
+      const mapped = res.sessions.map(toUISession);
+      // Preserve any already-loaded messages by merging on id.
+      setSessions((prev) => {
+        const byId = new Map(prev.map((s) => [s.id, s]));
+        return mapped.map((s) => {
+          const existing = byId.get(s.id);
+          return existing ? { ...s, messages: existing.messages, historyLoaded: existing.historyLoaded } : s;
+        });
+      });
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : "加载会话列表失败";
+      setLoadError(msg);
+    } finally {
+      setIsLoadingSessions(false);
+    }
+  }, []);
+
+  // ---- On mount: load sessions, auto-create first one if empty ----
+  useEffect(() => {
+    (async () => {
+      await refreshSessions();
+      // If no sessions exist, create one. Need to read fresh state via callback form.
+      let created: ChatSession | null = null;
+      setSessions((prev) => {
+        if (prev.length === 0) {
+          // Trigger creation outside the updater (avoid setState-in-setState).
+          chatApi
+            .createSession()
+            .then((res) => {
+              created = res;
+              setSessions([toUISession(res)]);
+              setActiveSessionId(res.chat_session_id);
+            })
+            .catch((e) => {
+              setLoadError(e instanceof Error ? e.message : "创建会话失败");
+            });
+        }
+        return prev;
+      });
+      // Fallback: if sessions exist, activate the first.
+      setSessions((prev) => {
+        if (prev.length > 0 && !activeSessionId) {
+          setActiveSessionId(prev[0].id);
+        }
+        return prev;
+      });
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // ---- Load message history when active session changes ----
+  useEffect(() => {
+    if (!activeSessionId) return;
+    const sess = sessions.find((s) => s.id === activeSessionId);
+    if (!sess || sess.historyLoaded) return;
+
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await chatApi.getHistory(activeSessionId);
+        if (cancelled) return;
+        setSessions((prev) =>
+          prev.map((s) =>
+            s.id === activeSessionId
+              ? {
+                  ...s,
+                  messages: res.messages.map(toUIMessage),
+                  historyLoaded: true,
+                }
+              : s
+          )
+        );
+      } catch (e) {
+        if (cancelled) return;
+        const msg = e instanceof Error ? e.message : "加载历史消息失败";
+        setSessions((prev) =>
+          prev.map((s) =>
+            s.id === activeSessionId ? { ...s, historyLoaded: true, messages: [{ id: "load-err", role: "assistant", content: "", status: "failed", error: msg, timestamp: new Date().toISOString() }] } : s
+          )
+        );
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [activeSessionId, sessions]);
+
+  const updateActiveSession = (updater: (s: UISession) => UISession) => {
+    setSessions((prev) =>
+      prev.map((s) => (s.id === activeSessionId ? updater(s) : s))
+    );
+  };
+
+  // ---- Send a message ----
+  const handleSend = async (userMessage: string) => {
+    if (!activeSessionId) return;
+
+    const userMsgId = `user-${Date.now()}`;
+    const assistantMsgId = `assistant-${Date.now() + 1}`;
+    const timestamp = new Date().toISOString();
+
+    updateActiveSession((s) => ({
+      ...s,
+      lastMessageAt: timestamp,
+      messages: [
+        ...s.messages,
+        {
+          id: userMsgId,
+          role: "user",
+          content: userMessage,
+          status: "completed",
+          timestamp,
+        },
+        {
+          id: assistantMsgId,
+          role: "assistant",
+          content: "",
+          status: "pending",
+          timestamp,
+        },
+      ],
+    }));
+
+    setIsStreaming(true);
+
+    try {
+      const stream = await chatApi.askStream({
+        question: userMessage,
+        chat_session_id: activeSessionId,
+      });
+
+      await streamChat(stream, {
+        onChunk: (accumulated) => {
+          updateActiveSession((s) => ({
+            ...s,
+            messages: s.messages.map((m) =>
+              m.id === assistantMsgId ? { ...m, content: accumulated } : m
+            ),
+          }));
+        },
+        onSources: (sources: ChatSource[]) => {
+          updateActiveSession((s) => ({
+            ...s,
+            messages: s.messages.map((m) =>
+              m.id === assistantMsgId ? { ...m, sources } : m
+            ),
+          }));
+        },
+        onError: (message) => {
+          updateActiveSession((s) => ({
+            ...s,
+            messages: s.messages.map((m) =>
+              m.id === assistantMsgId
+                ? { ...m, status: "failed", error: message }
+                : m
+            ),
+          }));
+        },
+        onComplete: () => {
+          updateActiveSession((s) => ({
+            ...s,
+            messages: s.messages.map((m) =>
+              m.id === assistantMsgId && m.status === "pending"
+                ? { ...m, status: "completed" }
+                : m
+            ),
+          }));
+        },
+      });
+
+      // Refresh session list (title may be auto-generated by backend)
+      refreshSessions();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "请求失败";
+      updateActiveSession((s) => ({
+        ...s,
+        messages: s.messages.map((m) =>
+          m.id === assistantMsgId
+            ? { ...m, status: "failed", error: message }
+            : m
+        ),
+      }));
+    } finally {
+      setIsStreaming(false);
+    }
+  };
+
+  const handleStop = () => {
+    setIsStreaming(false);
+    updateActiveSession((s) => ({
+      ...s,
+      messages: s.messages.map((m) =>
+        m.status === "pending" ? { ...m, status: "completed" } : m
+      ),
+    }));
+  };
+
+  // ---- New chat: create backend session ----
+  const handleNewChat = async () => {
+    try {
+      const res = await chatApi.createSession();
+      const ui = toUISession(res);
+      ui.historyLoaded = true; // empty session, no need to fetch history
+      setSessions((prev) => [ui, ...prev]);
+      setActiveSessionId(res.chat_session_id);
+    } catch (e) {
+      setLoadError(e instanceof Error ? e.message : "创建会话失败");
+    }
+  };
+
+  const handleSessionSelect = (sessionId: string) => {
+    setActiveSessionId(sessionId);
+  };
+
+  // ---- Delete: call backend, then refresh ----
+  const handleDeleteSession = async (sessionId: string) => {
+    if (sessions.length <= 1) return;
+    try {
+      await chatApi.deleteSession(sessionId);
+      setSessions((prev) => prev.filter((s) => s.id !== sessionId));
+      if (activeSessionId === sessionId) {
+        const next = sessions.find((s) => s.id !== sessionId);
+        setActiveSessionId(next?.id ?? null);
+      }
+    } catch (e) {
+      setLoadError(e instanceof Error ? e.message : "删除会话失败");
+    }
+  };
+
+  // ---- Rename: call backend, then update local ----
+  const handleRenameSession = async (sessionId: string, newTitle: string) => {
+    try {
+      await chatApi.updateSession(sessionId, { title: newTitle });
+      setSessions((prev) =>
+        prev.map((s) => (s.id === sessionId ? { ...s, title: newTitle } : s))
+      );
+    } catch (e) {
+      setLoadError(e instanceof Error ? e.message : "重命名会话失败");
+    }
+  };
+
+  const handleClearChat = () => {
+    if (!activeSessionId) return;
+    // Clear local messages; backend history remains but UI resets.
+    updateActiveSession((s) => ({ ...s, messages: [] }));
+  };
+
+  return (
+    <div className="flex h-screen w-screen bg-[var(--gemini-surface)]">
+      <ChatHistorySidebar
+        sessions={
+          isLoadingSessions
+            ? []
+            : sessions.map((s) => ({
+                id: s.id,
+                title: s.title,
+                lastMessageAt: s.lastMessageAt,
+              }))
+        }
+        activeSessionId={activeSessionId ?? undefined}
+        onSessionSelect={handleSessionSelect}
+        onNewChat={handleNewChat}
+        onDeleteSession={handleDeleteSession}
+        onRenameSession={handleRenameSession}
+        isOpen={sidebarOpen}
+        onClose={() => setSidebarOpen(false)}
+      />
+
+      <main className="flex-1 flex flex-col h-full min-w-0">
+        <ChatHeader
+          onMenuClick={() => setSidebarOpen(true)}
+          onClearChat={handleClearChat}
+          title={activeSession?.title ?? "BiliRag"}
+          hasMessages={messages.length > 0}
+        />
+
+        {loadError && (
+          <div className="px-4 py-2 text-xs text-[var(--gemini-text-tertiary)] bg-red-500/5 border-b border-red-500/10">
+            {loadError}
+          </div>
+        )}
+
+        <div className="flex-1 min-h-0">
+          <ChatContent
+            messages={messages}
+            isStreaming={isStreaming}
+            onSend={handleSend}
+            onStop={handleStop}
+            onSuggestionClick={handleSend}
+            maxWidth={768}
+            inputMaxWidth={614}
+          />
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/frontend/components/chat/EmptyState.tsx
+++ b/frontend/components/chat/EmptyState.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+interface EmptyStateProps {
+  onSuggestionClick?: (suggestion: string) => void;
+}
+
+const suggestions = [
+  {
+    index: "01",
+    accent: "blue",
+    title: "总结收藏内容",
+    prompt: "帮我总结一下收藏夹里最有价值的视频内容",
+  },
+  {
+    index: "02",
+    accent: "teal",
+    title: "知识检索",
+    prompt: "帮我查找与机器学习相关的视频并列出关键知识点",
+  },
+  {
+    index: "03",
+    accent: "amber",
+    title: "视频对比",
+    prompt: "对比分析几个讲解同一个主题的视频，看看哪个讲得更好",
+  },
+  {
+    index: "04",
+    accent: "violet",
+    title: "学习路径",
+    prompt: "根据我的收藏视频，帮我规划一个系统的学习路径",
+  },
+];
+
+export default function EmptyState({ onSuggestionClick }: EmptyStateProps) {
+  return (
+    <div className="chat-empty">
+      <div className="chat-empty-kicker">BiliRag · 知识库已就绪</div>
+      <h1 className="chat-empty-heading">
+        <span className="chat-empty-heading-light">你好，</span>
+        <span className="chat-empty-heading-bold">有什么可以帮你？</span>
+      </h1>
+      <p className="chat-empty-subtitle">
+        把 B 站收藏夹变成可提问的知识库 — 检索、总结、对比、规划。
+      </p>
+
+      <div className="chat-suggestion-grid" role="group" aria-label="快捷建议">
+        {suggestions.map((s) => (
+          <button
+            key={s.index}
+            type="button"
+            className="chat-suggestion-card"
+            data-accent={s.accent}
+            onClick={() => onSuggestionClick?.(s.prompt)}
+            aria-label={`${s.title}：${s.prompt}`}
+          >
+            <span className="chat-suggestion-index" aria-hidden="true">
+              {s.index}
+            </span>
+            <div className="chat-suggestion-body">
+              <div className="chat-suggestion-title">{s.title}</div>
+              <div className="chat-suggestion-prompt">{s.prompt}</div>
+            </div>
+            <span className="chat-suggestion-arrow" aria-hidden="true">
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2.2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <line x1="7" y1="17" x2="17" y2="7" />
+                <polyline points="7 7 17 7 17 17" />
+              </svg>
+            </span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/chat/README.md
+++ b/frontend/components/chat/README.md
@@ -1,0 +1,120 @@
+# Google Gemini 风格聊天组件
+
+## 概述
+
+将原有的 ChatPanel 改造为类似 Google Gemini 界面风格的聊天组件，包含更现代化的视觉设计和更好的用户体验。
+
+## 组件架构
+
+```
+components/chat/
+├── ChatPanel.tsx              # 完整页面聊天面板（独立路由 /chat）
+├── ChatDockPanel.tsx          # Dock 模式聊天面板（集成到主界面）
+├── ChatMessage.tsx            # 消息气泡组件
+├── ChatInput.tsx              # 输入框组件
+├── ChatHeader.tsx             # 顶部标题栏
+├── ChatHistorySidebar.tsx     # 历史会话侧边栏
+├── EmptyState.tsx             # 空状态欢迎页
+└── index.ts                   # 统一导出
+```
+
+## 设计特点
+
+### 视觉风格
+- **配色**: 使用 Google Blue (#4285F4) 作为主色调
+- **圆角**: 大圆角设计（24px），营造柔和感
+- **阴影**: 多层级阴影系统，模拟 Material Design 3
+- **留白**: 充足的留白，提升可读性
+
+### 消息气泡
+- 用户消息: 右侧对齐，浅蓝色背景 (#E8F0FE)
+- Assistant 消息: 左侧对齐，浅灰背景 (#F8F9FA)
+- Markdown 渲染支持代码高亮、表格、引用
+
+### 交互特性
+- ✅ 流式打字效果
+- ✅ 思考过程折叠/展开
+- ✅ 来源链接展示
+- ✅ 消息复制功能
+- ✅ 快捷问题推荐（空状态）
+- ✅ 历史会话侧边栏
+- ✅ 会话分组（今天/昨天/上周/更早）
+
+## 使用方式
+
+### 1. 独立聊天页面
+访问 `/chat` 路由即可打开完整的 Gemini 风格聊天界面：
+
+```tsx
+// app/chat/page.tsx
+import ChatPanel from "@/components/chat/ChatPanel";
+
+export default function ChatPage() {
+  return (
+    <div className="min-h-screen bg-[var(--gemini-surface)]">
+      <ChatPanel />
+    </div>
+  );
+}
+```
+
+### 2. Dock 面板集成
+在主界面 Dock 栏中点击「对话」图标，弹出聊天面板：
+
+```tsx
+// dock-modules/index.ts
+import ChatDockPanel from "@/components/chat/ChatDockPanel";
+
+export const dockModules: DockModule[] = [
+  {
+    id: "chat",
+    icon: MessageCircle,
+    title: "对话",
+    panel: ChatDockPanel,
+    defaultSize: { width: 1156, height: 680 },
+  },
+  // ...
+];
+```
+
+## CSS 变量
+
+新增 Gemini 风格 CSS 变量（位于 `app/globals.css`）：
+
+```css
+:root {
+  --gemini-primary: #4285F4;           /* Google Blue */
+  --gemini-primary-hover: #3367D6;
+  --gemini-surface: #FFFFFF;
+  --gemini-surface-variant: #F8F9FA;
+  --gemini-border: #DADCE0;
+  --gemini-border-subtle: #F1F3F4;
+  --gemini-text-primary: #202124;
+  --gemini-text-secondary: #5F6368;
+  --gemini-text-tertiary: #70757A;
+  --gemini-user-bubble: #E8F0FE;
+  --gemini-assistant-bubble: #F8F9FA;
+  --gemini-radius: 24px;
+  --gemini-radius-sm: 12px;
+}
+```
+
+## 主要改进
+
+### 相比原有 ChatPanel
+
+1. **视觉升级**: 全新 Material Design 3 风格
+2. **组件拆分**: 单一职责原则，每个组件 < 200 行
+3. **更好的 Markdown**: 代码高亮、表格、引用支持
+4. **空状态**: 美观的欢迎页 + 快捷问题推荐
+5. **侧边栏**: 完整的历史会话管理
+6. **动画效果**: 流式输出、消息出现动画
+
+## 后续优化建议
+
+- [ ] 暗黑模式适配
+- [ ] 消息搜索功能
+- [ ] 拖拽上传文件
+- [ ] 语音输入/输出
+- [ ] 消息编辑/重新生成
+- [ ] 会话标签/分类管理

--- a/frontend/components/chat/index.ts
+++ b/frontend/components/chat/index.ts
@@ -1,0 +1,9 @@
+export { default as ChatPanel } from "./ChatPanel";
+export { default as ChatDockPanel } from "./ChatDockPanel";
+export { default as ChatContent } from "./ChatContent";
+export { default as ChatMessage } from "./ChatMessage";
+export { default as ChatInput } from "./ChatInput";
+export { default as ChatHeader } from "./ChatHeader";
+export { default as EmptyState } from "./EmptyState";
+export { default as ChatHistorySidebar } from "./ChatHistorySidebar";
+export type { ChatMessageData, MessageStatus, ReasoningStep } from "./types";

--- a/frontend/components/chat/types.ts
+++ b/frontend/components/chat/types.ts
@@ -1,0 +1,26 @@
+// Shared chat types used by ChatPanel, ChatDockPanel, and ChatContent.
+
+import type { ChatSource } from "@/lib/chat-stream";
+
+export interface ReasoningStep {
+  step: number;
+  action: string;
+  query?: string;
+  reasoning?: string;
+  verdict?: string;
+  recall_score?: number;
+  sources: ChatSource[];
+}
+
+export type MessageStatus = "pending" | "completed" | "failed";
+
+export interface ChatMessageData {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  sources?: ChatSource[];
+  reasoningSteps?: ReasoningStep[];
+  status: MessageStatus;
+  error?: string;
+  timestamp: string;
+}

--- a/frontend/components/dock-modules/index.ts
+++ b/frontend/components/dock-modules/index.ts
@@ -1,6 +1,6 @@
 import { BarChart3, BookOpen, Cloud, FolderHeart, MessageCircle, MessageSquareText, Settings, User, Activity } from "lucide-react";
 import { DockModule } from "@/lib/dock-registry";
-import ChatPanel from "@/components/ChatPanel";
+import ChatDockPanel from "@/components/chat/ChatDockPanel";
 import FavoritesPanel from "./favorites";
 import ChatHistoryPanel from "./chat-history";
 import SettingsPanel from "./settings";
@@ -15,8 +15,8 @@ export const dockModules: DockModule[] = [
     id: "chat",
     icon: MessageCircle,
     title: "对话",
-    panel: ChatPanel,
-    defaultSize: { width: 1156, height: 640 },
+    panel: ChatDockPanel,
+    defaultSize: { width: 1156, height: 680 },
   },
   {
     id: "chat-history",

--- a/frontend/lib/chat-stream.ts
+++ b/frontend/lib/chat-stream.ts
@@ -1,0 +1,77 @@
+// Shared SSE stream parser for chat responses.
+// Centralizes chunk/sources/done/error handling so ChatPanel and ChatDockPanel
+// stay in sync without duplicating the decode/parse loop.
+
+export interface ChatSource {
+  title: string;
+  url?: string;
+  bvid?: string;
+}
+
+export interface StreamCallbacks {
+  onChunk: (accumulated: string, delta: string) => void;
+  onSources?: (sources: ChatSource[]) => void;
+  onError?: (message: string) => void;
+  onComplete?: () => void;
+}
+
+export interface StreamRequestParams {
+  question: string;
+  session_id?: string;
+  chat_session_id?: string;
+  folder_ids?: string[];
+}
+
+export async function streamChat(
+  stream: ReadableStream<Uint8Array>,
+  callbacks: StreamCallbacks
+): Promise<void> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder("utf-8");
+  let accumulated = "";
+  let buffer = "";
+  let done = false;
+
+  try {
+    while (!done) {
+      const { value, done: isDone } = await reader.read();
+      done = isDone;
+      if (!value) continue;
+
+      buffer += decoder.decode(value, { stream: !done });
+      const frames = buffer.split("\n\n");
+      // Keep the trailing partial frame in the buffer for the next iteration.
+      buffer = frames.pop() ?? "";
+
+      for (const frame of frames) {
+        const line = frame.trim();
+        if (!line.startsWith("data: ")) continue;
+        const dataStr = line.slice(6);
+        if (dataStr === "[DONE]") {
+          done = true;
+          break;
+        }
+
+        try {
+          const data = JSON.parse(dataStr);
+          if (data.type === "chunk") {
+            const delta = typeof data.content === "string" ? data.content : "";
+            accumulated += delta;
+            callbacks.onChunk(accumulated, delta);
+          } else if (data.type === "sources") {
+            callbacks.onSources?.(Array.isArray(data.sources) ? data.sources : []);
+          } else if (data.type === "error") {
+            callbacks.onError?.(data.message || data.error || "请求失败");
+          } else if (data.type === "done") {
+            done = true;
+          }
+        } catch {
+          // Ignore malformed JSON frames; SSE may split across chunks.
+        }
+      }
+    }
+  } finally {
+    reader.releaseLock();
+    callbacks.onComplete?.();
+  }
+}


### PR DESCRIPTION
重构前端聊天体验，统一 /chat 路由与首页 Dock 两种入口的组件结构。

主要改动：
- 新增 components/chat/ 模块（ChatContent / ChatMessage / ChatInput / EmptyState / ChatHeader / ChatHistorySidebar / ChatPanel / ChatDockPanel）， ChatContent 作为共享组件被 Panel 与 DockPanel 复用
- 新增 lib/chat-stream.ts：SSE 流式解析（chunk/sources/error/done）， 统一处理跨 chunk 帧拼接
- 新增 app/chat/page.tsx：独立聊天页路由
- 重构 ChatDockPanel：接入 DockContext，使用真实 activeChatSessionId 加载历史会话与发送消息，修复"Dock 内无法加载历史"问题
- 重构消息渲染：用户消息右侧紧凑胶囊，助手消息左侧头像式无气泡布局， 引用来源改为引用卡片，操作按钮 hover 显隐
- 三层 null 防御：stream parser / toUIMessage / ChatMessage 渲染层 均对 sources 做数组化处理，修复 backend 返回 null 时的 TypeError
- 修复 ChatSidebarEmpty 重复"新建对话"按钮（头部已有 CTA）
- globals.css 新增 ~1800 行对应样式（msg-* / chat-input-* / chat-empty-* / chat-suggestion-* / chat-sidebar-* / chat-session-*）
- 所有动画支持 prefers-reduced-motion

测试：
- npx tsc --noEmit 通过
- 手动验证 /chat 路由与首页 Dock 两种入口的发送/接收/历史加载