### PR TITLE
[fix] 后端基础设施硬化: Redis/Milvus/Cloud RAG 一致性与依赖修复

### DIFF
--- a/app/agent/lifecycle/manager.py
+++ b/app/agent/lifecycle/manager.py
@@ -158,77 +158,117 @@ class AgentLifecycleManager:
             )
             return {"error": "service temporarily unavailable"}
 
-        # 2. Per-session concurrency lock
+        # 2. Per-session concurrency lock (non-reentrant — use invoke_reentrant
+        #    when the caller already holds the session lock, e.g. delegate_to_agent)
         async with self._sessions.acquire_lock(session_id):
-            start = time.monotonic()
+            return await self._invoke_locked(
+                agent_name, session_id, timeout, **input
+            )
 
-            # 3. Ensure session exists
-            self._sessions.get_or_create(session_id)
+    async def invoke_reentrant(
+        self,
+        agent_name: str,
+        session_id: str,
+        timeout: float | None = 60.0,
+        **input: Any,
+    ) -> dict[str, Any]:
+        """Invoke without acquiring the session lock.
 
-            try:
-                # 4. Pool: get or create agent instance
-                agent = await self._acquire_agent(agent_name, session_id)
+        Use this when the caller already holds the lock for *session_id*
+        (e.g. ``delegate_to_agent`` runs inside the chat agent's invoke).
+        ``asyncio.Lock`` is non-reentrant, so calling :meth:`invoke` from
+        within an agent's tool would deadlock.
+        """
+        if self._closed:
+            raise RuntimeError("AgentLifecycleManager is shut down")
 
-                # 5. Hook: invoke start
-                self._hooks.on_invoke_start(session_id, agent_name, **input)
+        if self._circuit_breaker.is_tripped:
+            logger.warning(
+                "[LIFECYCLE] circuit breaker open, rejecting %s/%s",
+                agent_name,
+                session_id,
+            )
+            return {"error": "service temporarily unavailable"}
 
-                # 6. Execute with optional timeout + LangSmith tracing config
-                run_config = {
-                    "run_name": f"{agent_name}_agent",
-                    "tags": [agent_name, "agent"],
-                    "metadata": {
-                        "agent_name": agent_name,
-                        "session_id": session_id,
-                    },
-                }
+        return await self._invoke_locked(agent_name, session_id, timeout, **input)
 
-                if timeout is not None:
-                    result = await asyncio.wait_for(
-                        agent.ainvoke(input, config=run_config),
-                        timeout=timeout,
-                    )
-                else:
-                    result = await agent.ainvoke(input, config=run_config)
+    async def _invoke_locked(
+        self,
+        agent_name: str,
+        session_id: str,
+        timeout: float | None,
+        **input: Any,
+    ) -> dict[str, Any]:
+        """Inner invoke — assumes the per-session lock is already held."""
+        start = time.monotonic()
 
-                # Ensure result is a dict
-                if not isinstance(result, dict):
-                    result = {"result": result}
+        # Ensure session exists
+        self._sessions.get_or_create(session_id)
 
-                # 7a. Hook: invoke end
-                elapsed = (time.monotonic() - start) * 1000
-                self._hooks.on_invoke_end(session_id, agent_name, elapsed)
+        try:
+            # Pool: get or create agent instance
+            agent = await self._acquire_agent(agent_name, session_id)
 
-                # 8. Touch session heartbeat
-                self._sessions.touch(session_id)
+            # Hook: invoke start
+            self._hooks.on_invoke_start(session_id, agent_name, **input)
 
-                # 9. Record success on circuit breaker
-                self._circuit_breaker.record_success()
+            # Execute with optional timeout + LangSmith tracing config
+            run_config = {
+                "run_name": f"{agent_name}_agent",
+                "tags": [agent_name, "agent"],
+                "metadata": {
+                    "agent_name": agent_name,
+                    "session_id": session_id,
+                },
+            }
 
-                return result
-
-            except asyncio.CancelledError:
-                raise
-            except asyncio.TimeoutError:
-                self._circuit_breaker.record_failure()
-                raise
-            except Exception as exc:
-                elapsed = (time.monotonic() - start) * 1000
-                error_msg = str(exc)
-
-                # 7b. Hook: invoke error
-                self._hooks.on_invoke_error(session_id, agent_name, error_msg)
-
-                # 9. Record failure on circuit breaker
-                self._circuit_breaker.record_failure()
-
-                logger.error(
-                    "[LIFECYCLE] %s/%s failed after %.0fms: %s",
-                    agent_name,
-                    session_id,
-                    elapsed,
-                    error_msg,
+            if timeout is not None:
+                result = await asyncio.wait_for(
+                    agent.ainvoke(input, config=run_config),
+                    timeout=timeout,
                 )
-                return {"error": error_msg}
+            else:
+                result = await agent.ainvoke(input, config=run_config)
+
+            # Ensure result is a dict
+            if not isinstance(result, dict):
+                result = {"result": result}
+
+            # Hook: invoke end
+            elapsed = (time.monotonic() - start) * 1000
+            self._hooks.on_invoke_end(session_id, agent_name, elapsed)
+
+            # Touch session heartbeat
+            self._sessions.touch(session_id)
+
+            # Record success on circuit breaker
+            self._circuit_breaker.record_success()
+
+            return result
+
+        except asyncio.CancelledError:
+            raise
+        except asyncio.TimeoutError:
+            self._circuit_breaker.record_failure()
+            raise
+        except Exception as exc:
+            elapsed = (time.monotonic() - start) * 1000
+            error_msg = str(exc)
+
+            # Hook: invoke error
+            self._hooks.on_invoke_error(session_id, agent_name, error_msg)
+
+            # Record failure on circuit breaker
+            self._circuit_breaker.record_failure()
+
+            logger.error(
+                "[LIFECYCLE] %s/%s failed after %.0fms: %s",
+                agent_name,
+                session_id,
+                elapsed,
+                error_msg,
+            )
+            return {"error": error_msg}
 
     # ── internal ──────────────────────────────────────────────────────
 

--- a/app/context/store_mongo.py
+++ b/app/context/store_mongo.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from pymongo import ASCENDING
 
@@ -144,15 +144,55 @@ class MongoStore(ConversationStore):
 
         lock = await self._get_lock(session_id)
         async with lock:
-            # Remove existing messages for this session, then bulk-insert
-            await coll(COLLECTION).delete_many({"chat_session_id": session_id})
-            if context.messages:
-                docs = [
-                    _message_to_mongo_doc(session_id, m, self._uid)
-                    for m in context.messages
-                ]
-                await coll(COLLECTION).insert_many(docs)
+            await self._save_atomic(session_id, context, coll)
             context.touch()
+
+    async def _save_atomic(
+        self,
+        session_id: str,
+        context: ConversationContext,
+        coll_fn: Any,
+    ) -> None:
+        """Replace all messages for *session_id* atomically.
+
+        Uses a MongoDB transaction so a failure between ``delete_many`` and
+        ``insert_many`` cannot lose history.  Standalone deployments (no
+        replica set) reject transactions — in that case we fall back to the
+        non-transactional path and log a warning, preserving prior behavior
+        rather than blocking writes.
+        """
+        from pymongo.errors import OperationFailure
+
+        collection = coll_fn(COLLECTION)
+        docs = (
+            [_message_to_mongo_doc(session_id, m, self._uid) for m in context.messages]
+            if context.messages
+            else []
+        )
+
+        client = collection.database.client
+        try:
+            async with await client.start_session() as s:
+                async with s.start_transaction():
+                    await collection.delete_many(
+                        {"chat_session_id": session_id}, session=s
+                    )
+                    if docs:
+                        await collection.insert_many(docs, session=s)
+        except OperationFailure as exc:
+            # Typical message: "Transaction numbers are only allowed on a
+            # replica set member or a mongos" — standalone server.
+            if "replica set" in str(exc) or "mongos" in str(exc) or exc.code == 20:
+                logger.warning(
+                    "[MONGO_STORE] transactions unsupported, falling back to "
+                    "non-atomic save for session=%s",
+                    session_id,
+                )
+                await collection.delete_many({"chat_session_id": session_id})
+                if docs:
+                    await collection.insert_many(docs)
+            else:
+                raise
 
     async def append(self, session_id: str, message: ConversationMessage) -> None:
         from app.infra.mongo import coll, is_enabled

--- a/app/infra/milvus.py
+++ b/app/infra/milvus.py
@@ -1,8 +1,13 @@
 """
-Milvus connection management — follows same lifecycle pattern as mongo.py / redis.py.
+Milvus connection health — follows same lifecycle pattern as mongo.py / redis.py.
 
-Lazy initialisation: call ``init()`` during application startup.
-If ``milvus.enabled`` is false the module skips connection entirely.
+Uses the modern ``MilvusClient`` function-style API (PyMilvus 2.4+).
+The legacy ORM-style ``connections`` / ``utility`` API is deprecated and
+will be removed in PyMilvus 3.1.
+
+This module owns a singleton ``MilvusClient`` used purely for health
+checks (``ping``).  ``MilvusVectorStore`` instances create their own
+clients independently — both are lightweight gRPC channels.
 
 Usage:
     from app.infra.milvus import init, close, ping, is_enabled
@@ -10,54 +15,24 @@ Usage:
     # startup
     await init()
 
-    # query
-    from pymilvus import Collection
-    col = Collection("bilibili_videos")
-    col.query(expr="bvid == 'BV1xx'")
+    # health
+    result = await ping()  # {"ok": True, "latency_ms": 3, "error": None}
 
     # shutdown
     await close()
-
-Note on PyMilvusDeprecationWarning:
-    pymilvus 2.5+ flags the ORM-style API (``connections.connect``,
-    ``Collection(...)``, ``utility.*``) as deprecated in favor of
-    ``MilvusClient``. Migrating is a cross-cutting change (this file plus
-    ``app/repository/vector_store_milvus.py`` and the ``cloud`` /
-    ``knowledge`` routers all share the same default connection), so for
-    now we suppress the warning at the call sites instead of half-migrating
-    a single file. Track the full migration as a separate task.
 """
 
 from __future__ import annotations
 
-import contextlib
 import time
-import warnings
 from typing import Any
 
 from loguru import logger
 
 from app.infra.config import config
 
-
-@contextlib.contextmanager
-def _suppress_pymilvus_deprecation():
-    """Filter PyMilvusDeprecationWarning only; other warnings still surface.
-
-    The warning class is imported lazily so this module still works when
-    pymilvus is missing or vendored.
-    """
-
-    with warnings.catch_warnings():
-        try:
-            from pymilvus.exceptions import PyMilvusDeprecationWarning
-
-            warnings.filterwarnings("ignore", category=PyMilvusDeprecationWarning)
-        except ImportError:
-            # Older / vendored pymilvus may put the class elsewhere — fall
-            # back to a message-based filter so we still squelch the noise.
-            warnings.filterwarnings("ignore", message=r".*ORM-style PyMilvus API.*")
-        yield
+# Singleton health-check client — populated by init(), cleared by close().
+_client: Any = None
 
 
 def is_enabled() -> bool:
@@ -65,20 +40,19 @@ def is_enabled() -> bool:
 
 
 async def init() -> None:
-    """Connect to Milvus.  No-op when disabled."""
+    """Create the health-check MilvusClient.  No-op when disabled."""
+    global _client
     if not is_enabled():
         logger.info("[MILVUS] disabled, skipping init")
         return
 
-    from pymilvus import connections
+    from pymilvus import MilvusClient
 
     try:
-        with _suppress_pymilvus_deprecation():
-            connections.connect(
-                alias="default",
-                uri=config.milvus.uri,
-                token=config.milvus.token or None,
-            )
+        kwargs: dict[str, Any] = {"uri": config.milvus.uri}
+        if config.milvus.token:
+            kwargs["token"] = config.milvus.token
+        _client = MilvusClient(**kwargs)
     except Exception as e:
         logger.warning(
             "[MILVUS] init failed (continuing): error_type={} uri={} msg={}",
@@ -103,40 +77,29 @@ async def init() -> None:
 
 
 async def close() -> None:
-    """Disconnect from Milvus."""
-    if not is_enabled():
+    """Close the health-check client."""
+    global _client
+    if _client is None:
         return
-
-    from pymilvus import connections
-
     try:
-        with _suppress_pymilvus_deprecation():
-            connections.disconnect("default")
+        _client.close()
         logger.info("[MILVUS] closed")
     except Exception as e:
         logger.warning("[MILVUS] close error: error_type={}", type(e).__name__)
+    finally:
+        _client = None
 
 
 async def ping() -> dict[str, Any]:
     """Health check with round-trip latency."""
     if not is_enabled():
         return {"ok": False, "latency_ms": 0, "error": "disabled"}
-
-    from pymilvus import connections
-
-    try:
-        with _suppress_pymilvus_deprecation():
-            if not connections.has_connection("default"):
-                return {"ok": False, "latency_ms": 0, "error": "not connected"}
-    except Exception:
-        pass
+    if _client is None:
+        return {"ok": False, "latency_ms": 0, "error": "not initialized"}
 
     start = time.time()
     try:
-        from pymilvus import utility
-
-        with _suppress_pymilvus_deprecation():
-            utility.list_collections()
+        _client.list_collections()
         return {
             "ok": True,
             "latency_ms": int((time.time() - start) * 1000),

--- a/app/infra/redis.py
+++ b/app/infra/redis.py
@@ -45,6 +45,12 @@ except Exception:  # pragma: no cover
 # Module-level state — populated by init()
 _pool: ConnectionPool | None = None
 client: Redis | None = None
+# Alias kept in sync with ``client`` so callers can do
+# ``from app.infra import redis; redis.redis_client`` (runtime attribute
+# access — NOT ``from app.infra.redis import redis_client``, which would
+# bind the pre-init None forever).  Some legacy call sites still use the
+# ``redis_client`` name; new code should prefer ``client``.
+redis_client: Redis | None = None
 
 # ---------------------------------------------------------------------------
 # Lifecycle
@@ -57,7 +63,7 @@ async def init() -> None:
     Raises on failure because Redis is treated as a required dependency
     when enabled.
     """
-    global _pool, client
+    global _pool, client, redis_client
 
     if not config.redis.enabled:
         logger.info("[REDIS] disabled, skipping init")
@@ -72,6 +78,7 @@ async def init() -> None:
         decode_responses=False,
     )
     client = Redis(connection_pool=_pool)
+    redis_client = client
 
     result = await ping()
     if not result["ok"]:
@@ -83,12 +90,13 @@ async def init() -> None:
 
 async def close() -> None:
     """Disconnect and drain the pool."""
-    global _pool, client
+    global _pool, client, redis_client
     if client is not None:
         await client.aclose()
     if _pool is not None:
         await _pool.aclose()
     client = None
+    redis_client = None
     _pool = None
     logger.info("[REDIS] closed")
 

--- a/app/main.py
+++ b/app/main.py
@@ -12,6 +12,7 @@ from loguru import logger
 import sys
 import os
 import uuid
+from typing import Any
 
 from app.config import settings, ensure_directories
 
@@ -266,6 +267,14 @@ async def lifespan(app: FastAPI):
     await _recover_stuck_cloud_tasks()
 
     # === Agent Harness 启动 ===
+    # Failure modes (stored on app.state so /health and request-time 503s can
+    # surface the real reason instead of a generic "unavailable"):
+    #   - LLM not configured → state.agent_harness_status = "skipped"
+    #   - start() raised     → state.agent_harness_status = "failed"
+    #                         + state.agent_harness_error = "<msg>"
+    #   - success            → state.agent_harness_status = "started"
+    app.state.agent_harness_status = "skipped"
+    app.state.agent_harness_error = None
     try:
         from app.context import init_context_manager
         from app.harness import AgentHarness
@@ -282,6 +291,7 @@ async def lifespan(app: FastAPI):
             )
             await _harness.start()
             app.state.agent_harness = _harness
+            app.state.agent_harness_status = "started"
             logger.info(
                 "[HARNESS] started agents={} tools={}",
                 _harness.lifecycle.registered_agents,
@@ -289,8 +299,28 @@ async def lifespan(app: FastAPI):
             )
         else:
             logger.warning("[HARNESS] LLM not configured — harness not started")
+            app.state.agent_harness_error = "LLM not configured (openai_api_key empty)"
     except Exception as e:
-        logger.warning(f"[HARNESS] startup failed (agents unavailable): {e}")
+        # ERROR + full traceback: a failed harness makes ALL chat endpoints
+        # return 503, so this is a service-impacting condition, not a warning.
+        logger.exception(f"[HARNESS] startup failed (agents unavailable): {e}")
+        app.state.agent_harness_status = "failed"
+        app.state.agent_harness_error = f"{type(e).__name__}: {e}"
+
+    # Register a health provider so the dispatcher's 503 can carry the real
+    # root cause (e.g. "ModuleNotFoundError: No module named 'langgraph'")
+    # instead of a generic "unavailable".
+    from app.services.chat.dispatcher import set_harness_health_provider
+
+    _app_state = app.state
+
+    def _harness_health() -> tuple[str, Any]:
+        return (
+            getattr(_app_state, "agent_harness_status", "unknown"),
+            getattr(_app_state, "agent_harness_error", None),
+        )
+
+    set_harness_health_provider(_harness_health)
 
     yield
 
@@ -394,16 +424,15 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-# Plan 0023: Rate limiting middleware (second line of defense after nginx)
+# Plan 0023: Rate limiting middleware (second line of defense after nginx).
+# The middleware lazy-resolves the Redis client at dispatch time, so it is
+# always safe to register — if Redis is disabled or not yet initialised it
+# simply passes requests through (nginx remains the first line of defense).
 try:
-    from app.infra.redis import redis_client
     from app.middleware.rate_limit import RateLimitMiddleware
 
-    if redis_client:
-        app.add_middleware(RateLimitMiddleware, redis_client=redis_client)
-        logger.info("[MAIN] RateLimitMiddleware registered (Redis backend)")
-    else:
-        logger.warning("[MAIN] RateLimitMiddleware skipped — Redis not available")
+    app.add_middleware(RateLimitMiddleware)
+    logger.info("[MAIN] RateLimitMiddleware registered (lazy Redis resolution)")
 except Exception as e:
     logger.warning("[MAIN] RateLimitMiddleware failed to init: {}", e)
 
@@ -452,9 +481,33 @@ async def root():
 
 
 @app.get("/health")
-async def health_check():
-    """健康检查"""
-    return {"status": "healthy"}
+async def health_check(request: Request):
+    """健康检查 — 包含 Agent Harness 状态。
+
+    harness 是所有 /chat/ask* 端点的前置依赖：它没起来，聊天接口
+    一律 503。把它的状态暴露给健康检查，让监控能及早告警，而不是
+    等到用户发请求时才发现。
+
+    status 取值：
+      - "healthy"  : harness 已启动
+      - "degraded" : harness 未启动（LLM 未配置 / 启动失败），
+                     非 chat 功能仍可用，chat 会 503
+    """
+    harness_status = getattr(request.app.state, "agent_harness_status", "unknown")
+    harness_error = getattr(request.app.state, "agent_harness_error", None)
+
+    healthy = harness_status == "started"
+    payload: dict[str, Any] = {
+        "status": "healthy" if healthy else "degraded",
+        "agent_harness": {
+            "status": harness_status,
+            "error": harness_error,
+        },
+    }
+    # 503 让负载均衡/监控把不健康实例摘掉，而不是继续转发 chat 请求过来。
+    if not healthy:
+        return JSONResponse(status_code=503, content=payload)
+    return payload
 
 
 @app.get("/cache/stats")

--- a/app/middleware/rate_limit.py
+++ b/app/middleware/rate_limit.py
@@ -33,14 +33,30 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
     """Token-bucket rate limiter backed by Redis.
 
     Key format: bilirag:rl:<endpoint>:<ip>:<window>
+
+    The Redis client is resolved lazily per-request via
+    :func:`app.infra.redis.is_enabled` / ``client`` so the middleware can
+    be registered before ``init()`` runs (FastAPI requires middleware
+    registration at app construction, which precedes lifespan startup).
     """
 
     def __init__(self, app, redis_client=None):
         super().__init__(app)
+        # Stash an explicit client if given (legacy/tests), otherwise we
+        # resolve at dispatch time.  Kept for backward compatibility with
+        # tests that inject a mock.
         self._redis = redis_client
 
+    async def _get_redis(self):
+        if self._redis is not None:
+            return self._redis
+        from app.infra.redis import client, is_enabled
+
+        return client if is_enabled() else None
+
     async def dispatch(self, request: Request, call_next) -> Response:
-        if self._redis is None:
+        redis_client = await self._get_redis()
+        if redis_client is None:
             return await call_next(request)
 
         path = request.url.path[:256]
@@ -58,9 +74,9 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         key = f"bilirag:rl:{path}:{client_ip}:{window}"
 
         try:
-            current = await self._redis.incr(key)
+            current = await redis_client.incr(key)
             if current == 1:
-                await self._redis.expire(key, 2)  # TTL 2s to auto-cleanup
+                await redis_client.expire(key, 2)  # TTL 2s to auto-cleanup
 
             if current > burst:
                 logger.warning(

--- a/app/repository/mongo_chat_repository.py
+++ b/app/repository/mongo_chat_repository.py
@@ -106,6 +106,23 @@ async def fail_message(msg_id: str, error: str) -> None:
     )
 
 
+async def delete_message(msg_id: str) -> int:
+    """Delete a single message by ``msg_id``.
+
+    Used to clean up the pending assistant placeholder when a turn fails
+    *before* generation starts (e.g. harness unavailable / 503) — those
+    failures are service-level, not a failed answer, so leaving a "failed"
+    placeholder in the history would mislead the user.  Returns the number
+    of deleted documents (0 if not found or Mongo disabled).
+    """
+    if not is_enabled():
+        return 0
+    result = await coll(COLLECTION).delete_one({"msg_id": msg_id})
+    if result.deleted_count:
+        logger.info(f"[MONGO_CHAT] deleted placeholder msg_id={msg_id}")
+    return result.deleted_count
+
+
 # ── Read ops ───────────────────────────────────────────────────────
 
 

--- a/app/repository/vector_store_milvus.py
+++ b/app/repository/vector_store_milvus.py
@@ -1,6 +1,10 @@
 """
 Milvus vector store — implements VectorStoreBackend.
 
+Uses the modern ``MilvusClient`` function-style API (PyMilvus 2.4+).
+The legacy ORM-style ``Collection`` / ``utility`` API is deprecated and
+will be removed in PyMilvus 3.1.
+
 Supports dual-collection architecture:
   - bilibili_videos  (IVF_FLAT) — B站 video ASR content
   - cloud_drive      (IVF_PQ, IVF_FLAT cold-start) — cloud drive docs + video ASR
@@ -62,7 +66,15 @@ class MilvusVectorStore:
         self._embedding_fn = embedding_fn
         self._collection_name = collection_name
         self._is_cloud = collection_name == config.cloud_collection_name
-        self._collection = self._get_or_create_collection()
+        # Set to True by _ensure_collection when an existing collection was
+        # dropped + recreated (e.g. embedding dim mismatch after model
+        # change).  Callers (RAGService startup) check this flag to reset
+        # DB vectorization statuses — otherwise files stay marked "done"
+        # while their vectors are gone, and the idempotency check in
+        # vectorize.py prevents self-healing.
+        self.was_recreated = False
+        self._client = self._build_client()
+        self._ensure_collection()
 
     # ── VectorStoreBackend interface ──────────────────────────────
 
@@ -74,6 +86,12 @@ class MilvusVectorStore:
         partition_dt: datetime | None = None,
     ) -> int:
         if not documents:
+            return 0
+        if self._client is None:
+            logger.error(
+                "[MILVUS] add called on uninitialized client — skipping collection='{}'",
+                self._collection_name,
+            )
             return 0
 
         partition_name: str | None = None
@@ -88,39 +106,51 @@ class MilvusVectorStore:
             embeddings = self._embedding_fn.embed_documents(texts)
 
             if self._is_cloud:
-                data = [
-                    [doc.metadata.get("upload_uuid", "") for doc in batch],
-                    [doc.metadata.get("uid", 0) for doc in batch],
-                    [doc.metadata.get("chunk_index", 0) for doc in batch],
-                    [doc.metadata.get("chunk_id", "") for doc in batch],
-                    [doc.metadata.get("title", "") for doc in batch],
-                    [doc.metadata.get("source", "") for doc in batch],
-                    [doc.metadata.get("source_type", "") for doc in batch],
-                    [doc.metadata.get("section_title", "") for doc in batch],
-                    [doc.metadata.get("content_type", "") for doc in batch],
-                    [doc.page_content for doc in batch],
-                    embeddings,
+                rows = [
+                    {
+                        "upload_uuid": doc.metadata.get("upload_uuid", ""),
+                        "uid": doc.metadata.get("uid", 0),
+                        "chunk_index": doc.metadata.get("chunk_index", 0),
+                        "chunk_id": doc.metadata.get("chunk_id", ""),
+                        "title": doc.metadata.get("title", ""),
+                        "source": doc.metadata.get("source", ""),
+                        "source_type": doc.metadata.get("source_type", ""),
+                        "section_title": doc.metadata.get("section_title", ""),
+                        "content_type": doc.metadata.get("content_type", ""),
+                        "text": doc.page_content,
+                        "embedding": emb,
+                    }
+                    for doc, emb in zip(batch, embeddings)
                 ]
             else:
-                data = [
-                    [doc.metadata.get("bvid", "") for doc in batch],
-                    [doc.metadata.get("cid", 0) for doc in batch],
-                    [doc.metadata.get("page_index", 0) for doc in batch],
-                    [doc.metadata.get("chunk_index", 0) for doc in batch],
-                    [doc.metadata.get("chunk_id", "") for doc in batch],
-                    [doc.metadata.get("title", "") for doc in batch],
-                    [doc.metadata.get("page_title", "") for doc in batch],
-                    [doc.metadata.get("source", "") for doc in batch],
-                    [doc.metadata.get("section_title", "") for doc in batch],
-                    [doc.metadata.get("content_type", "") for doc in batch],
-                    [doc.metadata.get("url", "") for doc in batch],
-                    [doc.page_content for doc in batch],
-                    embeddings,
+                rows = [
+                    {
+                        "bvid": doc.metadata.get("bvid", ""),
+                        "cid": doc.metadata.get("cid", 0),
+                        "page_index": doc.metadata.get("page_index", 0),
+                        "chunk_index": doc.metadata.get("chunk_index", 0),
+                        "chunk_id": doc.metadata.get("chunk_id", ""),
+                        "title": doc.metadata.get("title", ""),
+                        "page_title": doc.metadata.get("page_title", ""),
+                        "source": doc.metadata.get("source", ""),
+                        "section_title": doc.metadata.get("section_title", ""),
+                        "content_type": doc.metadata.get("content_type", ""),
+                        "url": doc.metadata.get("url", ""),
+                        "text": doc.page_content,
+                        "embedding": emb,
+                    }
+                    for doc, emb in zip(batch, embeddings)
                 ]
 
-            mr = self._collection.insert(data, partition_name=partition_name)
-            self._collection.flush()
-            total += len(mr.primary_keys)
+            self._client.insert(
+                collection_name=self._collection_name,
+                data=rows,
+                partition_name=partition_name,
+            )
+            total += len(rows)
+
+        # Flush so that subsequent num_entities / stats reflect the new rows.
+        self._safe_flush()
 
         logger.info(
             "[MILVUS] added {} chunks to collection '{}' partition={}",
@@ -140,9 +170,9 @@ class MilvusVectorStore:
         partition_dt_start: datetime | None = None,
         partition_dt_end: datetime | None = None,
     ) -> list[Document]:
-        if self._collection is None:
+        if self._client is None:
             logger.error(
-                "[MILVUS] search called on uninitialized collection '{}' — returning empty results",
+                "[MILVUS] search called on uninitialized client — returning empty results collection='{}'",
                 self._collection_name,
             )
             return []
@@ -183,13 +213,15 @@ class MilvusVectorStore:
         output_fields = _CLOUD_DRIVE_FIELDS if self._is_cloud else _BILIBILI_FIELDS
 
         search_kwargs: dict[str, Any] = {
+            "collection_name": self._collection_name,
             "data": [query_embedding],
             "anns_field": "embedding",
-            "param": search_params,
+            "search_params": search_params,
             "limit": k,
-            "expr": expr,
             "output_fields": output_fields,
         }
+        if expr:
+            search_kwargs["filter"] = expr
         if partition_names:
             search_kwargs["partition_names"] = partition_names
 
@@ -199,42 +231,44 @@ class MilvusVectorStore:
             k,
             expr,
         )
-        results = self._collection.search(**search_kwargs)
+        results = self._client.search(**search_kwargs)
 
         docs: list[Document] = []
-        for hits in results:
-            for hit in hits:
-                entity = hit.entity
+        # MilvusClient search returns list[list[Hit]]; each Hit is a dict
+        # subclass supporting direct field access via hit.get(field).
+        for topk in results:
+            for hit in topk:
+                score = hit.get("distance", 0.0)
                 if self._is_cloud:
                     metadata = {
-                        "upload_uuid": entity.get("upload_uuid", ""),
-                        "uid": entity.get("uid", 0),
-                        "chunk_index": entity.get("chunk_index", 0),
-                        "chunk_id": entity.get("chunk_id", ""),
-                        "title": entity.get("title", ""),
-                        "source": entity.get("source", ""),
-                        "source_type": entity.get("source_type", ""),
-                        "section_title": entity.get("section_title", ""),
-                        "content_type": entity.get("content_type", ""),
-                        "score": hit.score,
+                        "upload_uuid": hit.get("upload_uuid", ""),
+                        "uid": hit.get("uid", 0),
+                        "chunk_index": hit.get("chunk_index", 0),
+                        "chunk_id": hit.get("chunk_id", ""),
+                        "title": hit.get("title", ""),
+                        "source": hit.get("source", ""),
+                        "source_type": hit.get("source_type", ""),
+                        "section_title": hit.get("section_title", ""),
+                        "content_type": hit.get("content_type", ""),
+                        "score": score,
                     }
                 else:
                     metadata = {
-                        "bvid": entity.get("bvid", ""),
-                        "cid": entity.get("cid", 0),
-                        "page_index": entity.get("page_index", 0),
-                        "chunk_index": entity.get("chunk_index", 0),
-                        "chunk_id": entity.get("chunk_id", ""),
-                        "title": entity.get("title", ""),
-                        "page_title": entity.get("page_title", ""),
-                        "source": entity.get("source", ""),
-                        "section_title": entity.get("section_title", ""),
-                        "content_type": entity.get("content_type", ""),
-                        "url": entity.get("url", ""),
-                        "score": hit.score,
+                        "bvid": hit.get("bvid", ""),
+                        "cid": hit.get("cid", 0),
+                        "page_index": hit.get("page_index", 0),
+                        "chunk_index": hit.get("chunk_index", 0),
+                        "chunk_id": hit.get("chunk_id", ""),
+                        "title": hit.get("title", ""),
+                        "page_title": hit.get("page_title", ""),
+                        "source": hit.get("source", ""),
+                        "section_title": hit.get("section_title", ""),
+                        "content_type": hit.get("content_type", ""),
+                        "url": hit.get("url", ""),
+                        "score": score,
                     }
                 docs.append(
-                    Document(page_content=entity.get("text", ""), metadata=metadata)
+                    Document(page_content=hit.get("text", ""), metadata=metadata)
                 )
         return docs
 
@@ -243,6 +277,8 @@ class MilvusVectorStore:
         ids: list[str] | None = None,
         where: dict[str, Any] | None = None,
     ) -> int:
+        if self._client is None:
+            return 0
         if ids:
             expr = f"chunk_id in {_quote_list(ids)}"
         elif where:
@@ -250,33 +286,38 @@ class MilvusVectorStore:
         else:
             return 0
 
-        before = self._collection.num_entities
-        self._collection.delete(expr)
-        self._collection.flush()
-        after = self._collection.num_entities
-        return before - after
+        before = self._row_count()
+        self._client.delete(collection_name=self._collection_name, filter=expr)
+        self._safe_flush()
+        after = self._row_count()
+        return max(0, before - after)
 
     def count(self) -> int:
-        return self._collection.num_entities
+        return self._row_count()
 
     def delete_by_bvid(self, bvid: str) -> int:
         return self.delete(where={"bvid": bvid})
 
     def delete_by_upload_uuid(self, upload_uuid: str) -> int:
+        if self._client is None:
+            return 0
         expr = f'upload_uuid == "{_escape_expr(upload_uuid)}"'
-        before = self._collection.num_entities
-        self._collection.delete(expr)
-        self._collection.flush()
-        after = self._collection.num_entities
-        return before - after
+        before = self._row_count()
+        self._client.delete(collection_name=self._collection_name, filter=expr)
+        self._safe_flush()
+        after = self._row_count()
+        return max(0, before - after)
 
     def delete_by_page(self, bvid: str, page_index: int) -> int:
         return self.delete(where={"bvid": bvid, "page_index": page_index})
 
     def count_by_page(self, bvid: str, page_index: int) -> int:
+        if self._client is None:
+            return 0
         expr = f'bvid == "{_escape_expr(bvid)}" && page_index == {page_index}'
-        result = self._collection.query(
-            expr=expr,
+        result = self._client.query(
+            collection_name=self._collection_name,
+            filter=expr,
             output_fields=["id"],
             limit=10000,
             consistency_level="Strong",
@@ -284,9 +325,12 @@ class MilvusVectorStore:
         return len(result)
 
     def count_by_upload_uuid(self, upload_uuid: str) -> int:
+        if self._client is None:
+            return 0
         expr = f'upload_uuid == "{_escape_expr(upload_uuid)}"'
-        result = self._collection.query(
-            expr=expr,
+        result = self._client.query(
+            collection_name=self._collection_name,
+            filter=expr,
             output_fields=["id"],
             limit=10000,
             consistency_level="Strong",
@@ -294,11 +338,20 @@ class MilvusVectorStore:
         return len(result)
 
     def get_stats(self) -> dict:
+        if self._client is None:
+            return {
+                "total_chunks": 0,
+                "total_videos": 0,
+                "collection_name": self._collection_name,
+            }
         try:
-            total = self._collection.num_entities
+            total = self._row_count()
             id_field = "upload_uuid" if self._is_cloud else "bvid"
-            result = self._collection.query(
-                expr="id >= 0", output_fields=[id_field], limit=10000
+            result = self._client.query(
+                collection_name=self._collection_name,
+                filter="id >= 0",
+                output_fields=[id_field],
+                limit=10000,
             )
             unique_ids = set(r.get(id_field, "") for r in result)
             return {
@@ -315,28 +368,39 @@ class MilvusVectorStore:
             }
 
     def clear(self) -> None:
-        self._collection.delete("id >= 0")
-        self._collection.flush()
+        if self._client is None:
+            return
+        self._client.delete(
+            collection_name=self._collection_name, filter="id >= 0"
+        )
+        self._safe_flush()
         logger.info("[MILVUS] collection '{}' cleared", self._collection_name)
 
     def reset(self) -> None:
         """Drop and recreate the collection (e.g. after embedding model change)."""
-        from pymilvus import utility
-
-        if utility.has_collection(self._collection_name):
-            utility.drop_collection(self._collection_name)
+        if self._client is None:
+            return
+        if self._client.has_collection(self._collection_name):
+            self._client.drop_collection(self._collection_name)
             logger.info(
                 "[MILVUS] collection '{}' dropped for reset", self._collection_name
             )
-        self._collection = self._get_or_create_collection()
+        self._ensure_collection()
 
     def close(self) -> None:
-        pass
+        if self._client is not None:
+            try:
+                self._client.close()
+            except Exception:
+                pass
+            self._client = None
 
     def _ensure_partition(self, name: str) -> None:
         """Create a partition if it doesn't already exist."""
-        if not self._collection.has_partition(name):
-            self._collection.create_partition(name)
+        if self._client is None:
+            return
+        if not self._client.has_partition(self._collection_name, name):
+            self._client.create_partition(self._collection_name, name)
             logger.info(
                 "[MILVUS] partition '{}' created in collection '{}'",
                 name,
@@ -349,9 +413,11 @@ class MilvusVectorStore:
         Returns ``None`` if no requested partitions exist (falls back to
         searching the default partition) or the filtered list otherwise.
         """
-        if not names:
+        if self._client is None or not names:
             return None
-        existing = [n for n in names if self._collection.has_partition(n)]
+        existing = [
+            n for n in names if self._client.has_partition(self._collection_name, n)
+        ]
         if not existing:
             logger.warning(
                 "[MILVUS] none of the requested partitions {} exist in '{}', "
@@ -371,19 +437,59 @@ class MilvusVectorStore:
 
     # ── internals ─────────────────────────────────────────────────
 
-    def _get_or_create_collection(self):
-        from pymilvus import Collection, CollectionSchema, utility
+    def _build_client(self):
+        from pymilvus import MilvusClient
+
+        kwargs: dict[str, Any] = {"uri": self._config.uri}
+        if self._config.token:
+            kwargs["token"] = self._config.token
+        try:
+            return MilvusClient(**kwargs)
+        except Exception as e:
+            logger.error(
+                "[MILVUS] failed to connect '{}': {} — vector search will return empty results",
+                self._config.uri,
+                str(e),
+            )
+            return None
+
+    def _row_count(self) -> int:
+        if self._client is None:
+            return 0
+        try:
+            stats = self._client.get_collection_stats(self._collection_name)
+            return int(stats.get("row_count", 0))
+        except Exception as e:
+            logger.debug("[MILVUS] get_collection_stats failed: {}", e)
+            return 0
+
+    def _safe_flush(self) -> None:
+        """Best-effort flush so counts/stats reflect pending writes."""
+        if self._client is None:
+            return
+        try:
+            self._client.flush(self._collection_name)
+        except Exception as e:
+            logger.debug("[MILVUS] flush failed (ignored): {}", e)
+
+    def _ensure_collection(self) -> None:
+        """Load or create the target collection, auto-fixing dim mismatch."""
+        if self._client is None:
+            return
 
         try:
-            if utility.has_collection(self._collection_name):
-                col = Collection(self._collection_name)
-                col.load()
+            if self._client.has_collection(self._collection_name):
                 # Auto-fix: if existing collection dim doesn't match configured dim,
                 # drop and recreate (e.g. after embedding model change).
+                desc = self._client.describe_collection(self._collection_name)
                 expected_dim = self._config.dimension
-                for field in col.schema.fields:
-                    if field.name == "embedding":
-                        existing_dim = field.params.get("dim", 0)
+                for field in desc.get("fields", []):
+                    if field.get("name") == "embedding":
+                        params = field.get("params") or field.get("typeParams") or {}
+                        try:
+                            existing_dim = int(params.get("dim", 0))
+                        except (TypeError, ValueError):
+                            existing_dim = 0
                         if existing_dim not in (0, expected_dim):
                             logger.warning(
                                 "[MILVUS] collection '{}' has dim={}, expected={}, dropping to recreate",
@@ -391,39 +497,41 @@ class MilvusVectorStore:
                                 existing_dim,
                                 expected_dim,
                             )
-                            utility.drop_collection(self._collection_name)
+                            self._client.drop_collection(self._collection_name)
+                            # Signal callers that all prior vectors are gone
+                            # — DB vectorization statuses must be reset so
+                            # files get re-vectorized instead of being
+                            # skipped by the idempotency check.
+                            self.was_recreated = True
                             break
                 else:
+                    self._client.load_collection(self._collection_name)
                     logger.info(
                         "[MILVUS] collection '{}' loaded ({} entities)",
                         self._collection_name,
-                        col.num_entities,
+                        self._row_count(),
                     )
-                    return col
+                    return
 
+            # Create new collection
             if self._is_cloud:
-                fields = self._build_cloud_drive_schema()
-                description = "Cloud drive document & video vector chunks"
+                schema = self._build_cloud_drive_schema()
             else:
-                fields = self._build_bilibili_schema()
-                description = "Bilibili RAG video chunks"
-
-            schema = CollectionSchema(
-                fields, description=description, enable_dynamic_field=True
-            )
-            col = Collection(self._collection_name, schema)
+                schema = self._build_bilibili_schema()
 
             index_params = self._get_index_params(self._collection_name, 0)
-            col.create_index("embedding", index_params)
-            col.load()
+            self._client.create_collection(
+                collection_name=self._collection_name,
+                schema=schema,
+                index_params=index_params,
+            )
 
             logger.info(
                 "[MILVUS] collection '{}' created (dim={}, index={})",
                 self._collection_name,
                 self._config.dimension,
-                index_params["index_type"],
+                self._index_type_for_logging(self._collection_name, 0),
             )
-            return col
 
         except Exception as e:
             logger.error(
@@ -431,57 +539,72 @@ class MilvusVectorStore:
                 self._collection_name,
                 str(e),
             )
-            return None
 
-    def _build_bilibili_schema(self) -> list:
-        from pymilvus import DataType, FieldSchema
+    def _build_bilibili_schema(self):
+        from pymilvus import DataType
 
-        return [
-            FieldSchema(name="id", dtype=DataType.INT64, is_primary=True, auto_id=True),
-            FieldSchema(name="bvid", dtype=DataType.VARCHAR, max_length=20),
-            FieldSchema(name="cid", dtype=DataType.INT64),
-            FieldSchema(name="page_index", dtype=DataType.INT64),
-            FieldSchema(name="chunk_index", dtype=DataType.INT64),
-            FieldSchema(name="chunk_id", dtype=DataType.VARCHAR, max_length=64),
-            FieldSchema(name="title", dtype=DataType.VARCHAR, max_length=512),
-            FieldSchema(name="page_title", dtype=DataType.VARCHAR, max_length=512),
-            FieldSchema(name="source", dtype=DataType.VARCHAR, max_length=32),
-            FieldSchema(name="section_title", dtype=DataType.VARCHAR, max_length=256),
-            FieldSchema(name="content_type", dtype=DataType.VARCHAR, max_length=32),
-            FieldSchema(name="url", dtype=DataType.VARCHAR, max_length=512),
-            FieldSchema(name="text", dtype=DataType.VARCHAR, max_length=65535),
-            FieldSchema(
-                name="embedding",
-                dtype=DataType.FLOAT_VECTOR,
-                dim=self._config.dimension,
-            ),
-        ]
+        schema = self._client.create_schema(enable_dynamic_field=True)
+        schema.add_field(field_name="id", datatype=DataType.INT64, is_primary=True, auto_id=True)
+        schema.add_field(field_name="bvid", datatype=DataType.VARCHAR, max_length=20)
+        schema.add_field(field_name="cid", datatype=DataType.INT64)
+        schema.add_field(field_name="page_index", datatype=DataType.INT64)
+        schema.add_field(field_name="chunk_index", datatype=DataType.INT64)
+        schema.add_field(field_name="chunk_id", datatype=DataType.VARCHAR, max_length=64)
+        schema.add_field(field_name="title", datatype=DataType.VARCHAR, max_length=512)
+        schema.add_field(field_name="page_title", datatype=DataType.VARCHAR, max_length=512)
+        schema.add_field(field_name="source", datatype=DataType.VARCHAR, max_length=32)
+        schema.add_field(field_name="section_title", datatype=DataType.VARCHAR, max_length=256)
+        schema.add_field(field_name="content_type", datatype=DataType.VARCHAR, max_length=32)
+        schema.add_field(field_name="url", datatype=DataType.VARCHAR, max_length=512)
+        schema.add_field(field_name="text", datatype=DataType.VARCHAR, max_length=65535)
+        schema.add_field(
+            field_name="embedding",
+            datatype=DataType.FLOAT_VECTOR,
+            dim=self._config.dimension,
+        )
+        return schema
 
-    def _build_cloud_drive_schema(self) -> list:
-        from pymilvus import DataType, FieldSchema
+    def _build_cloud_drive_schema(self):
+        from pymilvus import DataType
 
-        return [
-            FieldSchema(name="id", dtype=DataType.INT64, is_primary=True, auto_id=True),
-            FieldSchema(name="upload_uuid", dtype=DataType.VARCHAR, max_length=64),
-            FieldSchema(name="uid", dtype=DataType.INT64),
-            FieldSchema(name="chunk_index", dtype=DataType.INT64),
-            FieldSchema(name="chunk_id", dtype=DataType.VARCHAR, max_length=128),
-            FieldSchema(name="title", dtype=DataType.VARCHAR, max_length=512),
-            FieldSchema(name="source", dtype=DataType.VARCHAR, max_length=32),
-            FieldSchema(name="source_type", dtype=DataType.VARCHAR, max_length=16),
-            FieldSchema(name="section_title", dtype=DataType.VARCHAR, max_length=256),
-            FieldSchema(name="content_type", dtype=DataType.VARCHAR, max_length=32),
-            FieldSchema(name="text", dtype=DataType.VARCHAR, max_length=65535),
-            FieldSchema(
-                name="embedding",
-                dtype=DataType.FLOAT_VECTOR,
-                dim=self._config.dimension,
-            ),
-        ]
+        schema = self._client.create_schema(enable_dynamic_field=True)
+        schema.add_field(field_name="id", datatype=DataType.INT64, is_primary=True, auto_id=True)
+        schema.add_field(field_name="upload_uuid", datatype=DataType.VARCHAR, max_length=64)
+        schema.add_field(field_name="uid", datatype=DataType.INT64)
+        schema.add_field(field_name="chunk_index", datatype=DataType.INT64)
+        schema.add_field(field_name="chunk_id", datatype=DataType.VARCHAR, max_length=128)
+        schema.add_field(field_name="title", datatype=DataType.VARCHAR, max_length=512)
+        schema.add_field(field_name="source", datatype=DataType.VARCHAR, max_length=32)
+        schema.add_field(field_name="source_type", datatype=DataType.VARCHAR, max_length=16)
+        schema.add_field(field_name="section_title", datatype=DataType.VARCHAR, max_length=256)
+        schema.add_field(field_name="content_type", datatype=DataType.VARCHAR, max_length=32)
+        schema.add_field(field_name="text", datatype=DataType.VARCHAR, max_length=65535)
+        schema.add_field(
+            field_name="embedding",
+            datatype=DataType.FLOAT_VECTOR,
+            dim=self._config.dimension,
+        )
+        return schema
 
-    def _get_index_params(
+    def _get_index_params(self, collection_name: str, current_vector_count: int):
+        """Build an ``IndexParams`` object for the embedding field."""
+        index_type, params = self._resolve_index_config(collection_name, current_vector_count)
+        index_params = self._client.prepare_index_params()
+        index_params.add_index(
+            field_name="embedding",
+            index_type=index_type,
+            metric_type=self._config.metric_type,
+            params=params,
+        )
+        return index_params
+
+    def _index_type_for_logging(self, collection_name: str, current_vector_count: int) -> str:
+        index_type, _ = self._resolve_index_config(collection_name, current_vector_count)
+        return index_type
+
+    def _resolve_index_config(
         self, collection_name: str, current_vector_count: int
-    ) -> dict:
+    ) -> tuple[str, dict[str, Any]]:
         if (
             collection_name == self._config.cloud_collection_name
             and current_vector_count < IVF_PQ_COLD_START_THRESHOLD
@@ -491,23 +614,11 @@ class MilvusVectorStore:
                 current_vector_count,
                 IVF_PQ_COLD_START_THRESHOLD,
             )
-            return {
-                "metric_type": self._config.metric_type,
-                "index_type": "IVF_FLAT",
-                "params": {"nlist": 128},
-            }
+            return "IVF_FLAT", {"nlist": 128}
         elif collection_name == self._config.cloud_collection_name:
-            return {
-                "metric_type": self._config.metric_type,
-                "index_type": "IVF_PQ",
-                "params": {"nlist": 1024, "m": 48, "nbits": 8},
-            }
+            return "IVF_PQ", {"nlist": 1024, "m": 48, "nbits": 8}
         else:
-            return {
-                "metric_type": self._config.metric_type,
-                "index_type": self._config.index_type,
-                "params": {"nlist": self._config.nlist},
-            }
+            return self._config.index_type, {"nlist": self._config.nlist}
 
     def _build_filter_expr(self, filter: dict[str, Any]) -> str:
         parts: list[str] = []

--- a/app/routers/asr.py
+++ b/app/routers/asr.py
@@ -3,7 +3,6 @@ Bilibili RAG 知识库系统
 
 ASR 路由 - 分P视频语音转文本
 """
-import uuid
 from datetime import datetime, timezone
 from fastapi import APIRouter, Depends, HTTPException
 from loguru import logger
@@ -16,23 +15,9 @@ from app.response import (
     ASRCreateRequest, ASRUpdateRequest, ASRReASRRequest,
     ASRContentResponse, ASRTaskStatus, VideoVersionInfo,
 )
+from app.services.async_task.asr_task_registry import asr_tasks, create_task
 
 router = APIRouter(prefix="/asr", tags=["ASR"])
-
-# 内存任务状态存储
-asr_tasks: dict = {}
-
-
-def _create_task() -> str:
-    """创建新任务并返回 task_id"""
-    task_id = str(uuid.uuid4())
-    asr_tasks[task_id] = {
-        "status": "pending",
-        "progress": 0,
-        "message": "任务已创建",
-        "result": None,
-    }
-    return task_id
 
 
 # ==================== 依赖注入 ====================
@@ -129,7 +114,7 @@ async def create_asr(
         await db.commit()
 
     # 创建后台任务
-    task_id = _create_task()
+    task_id = create_task()
 
     # 启动后台 ASR 处理
     import asyncio
@@ -226,7 +211,7 @@ async def reasr(
     await db.commit()
 
     # 创建后台任务
-    task_id = _create_task()
+    task_id = create_task()
 
     # 启动后台 ASR 处理
     import asyncio

--- a/app/routers/chat.py
+++ b/app/routers/chat.py
@@ -8,7 +8,7 @@ LLM construction, message persistence, routing rules.  All of those live
 in ``app/services/chat/``.
 """
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request
 from fastapi.responses import StreamingResponse
 from loguru import logger
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -143,7 +143,11 @@ async def ask_question_agent_stream(
 
 
 @router.post("/search")
-async def search_videos(query: str, k: int = 5):
+async def search_videos(
+    query: str,
+    k: int = Query(5, ge=1, le=100),
+    uid: int = Depends(get_current_uid),
+):
     """Vector search for related video clips."""
     if not query or not query.strip():
         raise HTTPException(status_code=400, detail="查询不能为空")

--- a/app/routers/cloud.py
+++ b/app/routers/cloud.py
@@ -54,11 +54,6 @@ def _spawn(coro) -> asyncio.Task:
     return task
 
 
-def _milvus_escape(value: str) -> str:
-    """Escape double-quote and backslash in Milvus expression strings."""
-    return value.replace("\\", "\\\\").replace('"', '\\"')
-
-
 # ---------------------------------------------------------------------------
 # helpers
 # ---------------------------------------------------------------------------
@@ -568,15 +563,10 @@ async def delete_video(
 
             if config.milvus.enabled:
                 try:
-                    from pymilvus import Collection
+                    from app.services.rag import get_rag_service
 
-                    col = Collection(config.milvus.cloud_collection_name)
-                    col.delete(f'upload_uuid == "{_milvus_escape(upload_uuid)}"')
-                    col.flush()
-                    logger.info(
-                        "[CLOUD] milvus vectors deleted upload_uuid={}",
-                        upload_uuid,
-                    )
+                    rag = get_rag_service()
+                    rag.delete_cloud_vectors(upload_uuid)
                 except Exception as exc:
                     logger.warning(
                         "[CLOUD] milvus cleanup failed upload_uuid={} err={}",
@@ -635,7 +625,7 @@ async def trigger_processing(
         file.vector_status = "processing"
         await db.commit()
 
-        from app.routers.tasks_ws import broadcast_cloud_status
+        from app.services.ws_registry import broadcast_cloud_status
 
         _spawn(broadcast_cloud_status(uid, upload_uuid, "processing", 0))
 
@@ -714,14 +704,10 @@ async def get_video_status(
         milvus_chunk_count = file.vector_chunk_count or 0
         if config.milvus.enabled and milvus_chunk_count == 0:
             try:
-                from pymilvus import Collection
+                from app.services.rag import get_rag_service
 
-                col = Collection(config.milvus.cloud_collection_name)
-                results = col.query(
-                    expr=f'upload_uuid == "{_milvus_escape(upload_uuid)}"',
-                    output_fields=["chunk_index"],
-                )
-                milvus_chunk_count = len(results)
+                rag = get_rag_service()
+                milvus_chunk_count = rag.count_cloud_chunks(upload_uuid)
             except Exception:
                 pass
 
@@ -763,11 +749,10 @@ async def reprocess_document(
 
         if config.milvus.enabled:
             try:
-                from pymilvus import Collection
+                from app.services.rag import get_rag_service
 
-                col = Collection(config.milvus.cloud_collection_name)
-                col.delete(f'upload_uuid == "{_milvus_escape(upload_uuid)}"')
-                col.flush()
+                rag = get_rag_service()
+                rag.delete_cloud_vectors(upload_uuid)
             except Exception as e:
                 logger.warning(f"[CLOUD] reprocess: delete old vectors failed: {e}")
 

--- a/app/routers/knowledge.py
+++ b/app/routers/knowledge.py
@@ -464,7 +464,7 @@ async def _sync_folder(
 
 
 @router.get("/stats")
-async def get_knowledge_stats():
+async def get_knowledge_stats(uid: int = Depends(get_current_uid)):
     """获取知识库统计信息"""
     try:
         rag = get_rag_service()
@@ -787,7 +787,7 @@ async def _build_knowledge_base_task(
             legacy_kwargs["step"] = kwargs["current_step"]
         legacy_state(task_id, status, **legacy_kwargs)
         try:
-            from app.routers.tasks_ws import broadcast_task_update
+            from app.services.ws_registry import broadcast_task_update
             import asyncio
             task_info = {
                 "task_id": task_id, "task_type": "build", "uid": uid,
@@ -963,7 +963,7 @@ def legacy_state(task_id: str, status: str, step: str = "",
 
 
 @router.get("/build/status/{task_id}", response_model=BuildStatus)
-async def get_build_status(task_id: str):
+async def get_build_status(task_id: str, uid: int = Depends(get_current_uid)):
     """获取构建任务状态 — async_tasks 表优先，build_tasks 内存兜底"""
     # 1. Try async_tasks table (persisted)
     try:
@@ -1012,7 +1012,7 @@ async def get_build_status(task_id: str):
 
 
 @router.delete("/clear")
-async def clear_knowledge_base():
+async def clear_knowledge_base(uid: int = Depends(get_current_uid)):
     """清空知识库"""
     try:
         rag = get_rag_service()
@@ -1024,7 +1024,7 @@ async def clear_knowledge_base():
 
 
 @router.delete("/video/{bvid}")
-async def delete_video_from_knowledge(bvid: str):
+async def delete_video_from_knowledge(bvid: str, uid: int = Depends(get_current_uid)):
     """从知识库中删除指定视频"""
     try:
         rag = get_rag_service()
@@ -1045,6 +1045,7 @@ PAGES_CACHE_TTL = 86400  # 24小时
 async def get_video(
     bvid: str,
     cache=Depends(cache_dependency_singleton()),
+    uid: int = Depends(get_current_uid),
 ):
     """
     获取视频全部分P信息（旁路缓存策略）

--- a/app/routers/tasks_ws.py
+++ b/app/routers/tasks_ws.py
@@ -1,5 +1,9 @@
-"""
-WebSocket endpoint for real-time async task status streaming.
+"""WebSocket endpoint for real-time async task status streaming.
+
+Connection state (the per-uid socket pool) and broadcast fan-out live in
+``app.services.ws_registry`` so that service-layer code can push status
+without importing this router.  This module only owns the WS endpoint,
+auth, and the per-connection read loop.
 
 Security:
   - Token-based auth: client passes ?token=<bearer_token>, server validates
@@ -19,18 +23,13 @@ import time
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect, Query
 from loguru import logger
 
+from app.services import ws_registry
 from app.services.async_task.cache import get_cached_tasks, get_cached_task
 from app.services.auth.token import validate_token as _validate_token
 
 router = APIRouter()
 
 PUSH_INTERVAL = 5  # seconds between cache re-checks
-MAX_PER_UID = 3  # max concurrent connections per user
-MAX_TOTAL = 50  # max total connections
-
-# Connected clients: {uid: set[WebSocket]}
-_active_connections: dict[int, set[WebSocket]] = {}
-_total_count = 0
 
 
 def _sanitize_token(raw: str) -> str:
@@ -62,17 +61,6 @@ async def _authenticate_websocket(
     return uid
 
 
-def _check_connection_limits(uid: int) -> bool:
-    """Return False if connection limits exceeded (should reject)."""
-    global _total_count
-    if _total_count >= MAX_TOTAL:
-        return False
-    existing = len(_active_connections.get(uid, set()))
-    if existing >= MAX_PER_UID:
-        return False
-    return True
-
-
 @router.websocket("/ws/tasks")
 async def task_stream(
     websocket: WebSocket,
@@ -88,7 +76,7 @@ async def task_stream(
       {"action": "filter", "task_type": "...", "status": "..."} → filtered list
     """
     # ── Connection limit (before accept, reject early) ──
-    if _total_count >= MAX_TOTAL:
+    if ws_registry.total_count() >= ws_registry.MAX_TOTAL:
         await websocket.close(code=4002, reason="Server connection limit reached")
         return
 
@@ -103,27 +91,28 @@ async def task_stream(
     # ── Per-uid limit / dedup ──
     # If the user already has connections, close the OLDEST ones before adding new.
     # This handles client-side reconnect without proper cleanup (e.g. React StrictMode).
-    existing = _active_connections.get(uid, set())
-    if len(existing) >= MAX_PER_UID:
-        to_close = list(existing)[: len(existing) - MAX_PER_UID + 1]
-        for old_ws in to_close:
+    existing = ws_registry.connections_for(uid)
+    if len(existing) >= ws_registry.MAX_PER_UID:
+        evicted = ws_registry.evict_oldest(
+            uid, keep=ws_registry.MAX_PER_UID
+        )
+        for old_ws in evicted:
             try:
                 await old_ws.close(code=4003, reason="Superseded by newer connection")
             except Exception:
                 pass
-            existing.discard(old_ws)
-        logger.info(f"[TaskWS] uid={uid} evicted {len(to_close)} stale connections")
+        if evicted:
+            logger.info(f"[TaskWS] uid={uid} evicted {len(evicted)} stale connections")
 
-    if _total_count >= MAX_TOTAL:
+    if ws_registry.total_count() >= ws_registry.MAX_TOTAL:
         await websocket.close(code=4002, reason="Server connection limit reached")
         logger.warning(f"[TaskWS] rejected uid={uid} — server total limit exceeded")
         return
 
-    _active_connections.setdefault(uid, set()).add(websocket)
-    _update_total()
+    ws_registry.register(uid, websocket)
     logger.info(
         f"[TaskWS] connected uid={uid} "
-        f"(user_conns={len(_active_connections[uid])} total={_total_count})"
+        f"(user_conns={len(ws_registry.connections_for(uid))} total={ws_registry.total_count()})"
     )
 
     last_cache_hash = 0
@@ -197,73 +186,4 @@ async def task_stream(
     except Exception:
         logger.exception("[TaskWS] error uid={}", uid)
     finally:
-        _active_connections.get(uid, set()).discard(websocket)
-        if not _active_connections.get(uid):
-            _active_connections.pop(uid, None)
-        _update_total()
-
-
-def _update_total() -> None:
-    global _total_count
-    _total_count = sum(len(v) for v in _active_connections.values())
-
-
-async def broadcast_task_update(uid: int, task: dict) -> None:
-    """Push a task update to all connected clients for a user."""
-    connections = _active_connections.get(uid, set())
-    if not connections:
-        return
-    dead: list[WebSocket] = []
-    for ws in connections:
-        try:
-            await ws.send_json({"type": "task_update", "task": task})
-        except Exception:
-            dead.append(ws)
-    for ws in dead:
-        connections.discard(ws)
-    if dead:
-        _update_total()
-
-
-async def broadcast_cloud_status(
-    uid: int,
-    upload_uuid: str,
-    status: str,
-    chunk_count: int = 0,
-    error: str = "",
-) -> None:
-    """Push cloud file vectorization status to all of a user's WS connections."""
-    connections = _active_connections.get(uid, set())
-    if not connections:
-        logger.debug("[CLOUD_WS] no connections for uid={}, status not pushed", uid)
-        return
-
-    payload = json.dumps(
-        {
-            "type": "cloud_processing",
-            "upload_uuid": upload_uuid,
-            "status": status,
-            "chunk_count": chunk_count,
-            "error": error,
-            "timestamp": time.time(),
-        }
-    )
-
-    dead: list[WebSocket] = []
-    for ws in connections:
-        try:
-            await ws.send_text(payload)
-        except Exception:
-            dead.append(ws)
-    for ws in dead:
-        connections.discard(ws)
-    if dead:
-        _update_total()
-
-    logger.info(
-        "[CLOUD_WS] pushed status={} upload_uuid={} to uid={} ({} conns)",
-        status,
-        upload_uuid,
-        uid,
-        len(connections),
-    )
+        ws_registry.unregister(uid, websocket)

--- a/app/routers/vector_page.py
+++ b/app/routers/vector_page.py
@@ -284,7 +284,7 @@ async def get_vec_task_status(task_id: str) -> VectorPageTaskStatus:
         task = await _tracker._repo.get_by_task_id(task_id, db)
 
     if not task:
-        from app.routers.asr import asr_tasks
+        from app.services.async_task.asr_task_registry import asr_tasks
         asr_task = asr_tasks.get(task_id)
         if asr_task:
             return VectorPageTaskStatus(
@@ -330,7 +330,7 @@ async def _trigger_asr_then_vec(
     uid: int = 0,
 ):
     """Chain: wait for ASR → then start vectorization."""
-    from app.routers.asr import asr_tasks
+    from app.services.async_task.asr_task_registry import asr_tasks
 
     for _ in range(300):
         task = asr_tasks.get(asr_task_id)

--- a/app/routers/workspace.py
+++ b/app/routers/workspace.py
@@ -24,8 +24,12 @@ router = APIRouter(prefix="/workspaces", tags=["工作区"])
 
 
 def _get_ws_repo() -> WorkspaceRepository:
-    from app.infra.redis import redis_client
-    return WorkspaceRepository(redis=redis_client if redis_client else None)
+    # Runtime attribute access — `from app.infra.redis import redis_client`
+    # would bind the pre-init None at import time and never see the
+    # post-init value.  See app/infra/redis.py header for the rationale.
+    from app.infra import redis as _redis
+
+    return WorkspaceRepository(redis=_redis.redis_client)
 
 
 def _workspace_to_response(ws, bindings: list = None) -> WorkspaceResponse:

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -7,12 +7,10 @@ from app.services.bilibili import BilibiliService
 from app.services.content_fetcher import ContentFetcher
 from app.services.asr import ASRService
 from app.services.rag import RAGService
-from app.services.wbi import wbi_signer
 
 __all__ = [
     "BilibiliService",
-    "ContentFetcher", 
+    "ContentFetcher",
     "ASRService",
     "RAGService",
-    "wbi_signer"
 ]

--- a/app/services/asr_page_service.py
+++ b/app/services/asr_page_service.py
@@ -13,7 +13,7 @@ from loguru import logger
 
 from app.services.asr import ASRService
 from app.services.bilibili import BilibiliService
-from app.routers.asr import asr_tasks
+from app.services.async_task.asr_task_registry import asr_tasks
 from app.database import get_db_context
 from app.models import Video, VideoVersion
 from app.infra.mongo import is_enabled as mongo_enabled

--- a/app/services/async_task/asr_task_registry.py
+++ b/app/services/async_task/asr_task_registry.py
@@ -1,0 +1,42 @@
+"""In-memory registry for ASR task progress state.
+
+Shared between ``routers/asr.py`` (task creation + status polling),
+``routers/vector_page.py`` (vector pipeline triggers ASR and watches
+the task), and ``services/asr_page_service.py`` /
+``services/vector_page_service.py`` (the workers that mutate state).
+
+Lifting this out of the router keeps the layering contract: services
+must not import from routers.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+# task_id -> {"status", "progress", "message", "result"}
+asr_tasks: dict[str, dict[str, Any]] = {}
+
+
+def create_task() -> str:
+    """Create a new pending task and return its id."""
+    task_id = str(uuid.uuid4())
+    asr_tasks[task_id] = {
+        "status": "pending",
+        "progress": 0,
+        "message": "任务已创建",
+        "result": None,
+    }
+    return task_id
+
+
+def get_task(task_id: str) -> dict[str, Any] | None:
+    return asr_tasks.get(task_id)
+
+
+def set_task(task_id: str, **fields: Any) -> None:
+    """Partial update of a task entry."""
+    task = asr_tasks.get(task_id)
+    if task is None:
+        return
+    task.update(fields)

--- a/app/services/async_task/cache.py
+++ b/app/services/async_task/cache.py
@@ -142,7 +142,10 @@ async def _refresh_from_db(factory, shared_dict: Any) -> None:
         "updated_at": time.time(),
         "count": len(data),
     }
-    logger.info(f"[TaskCache] refreshed {len(data)} tasks")
+    if data:
+        logger.info("[TaskCache] refreshed {} tasks", len(data))
+    else:
+        logger.debug("[TaskCache] refreshed 0 tasks")
 
 
 async def _prune(factory) -> None:

--- a/app/services/chat/dispatcher.py
+++ b/app/services/chat/dispatcher.py
@@ -9,7 +9,7 @@ stay consistent across `/ask`, `/ask/agentic`, `/ask/stream`,
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 from fastapi import HTTPException
 from loguru import logger
@@ -22,13 +22,46 @@ from app.services.chat.scope import (
     get_media_ids_for_uid,
 )
 
+# Health provider — registered by main.py at startup so that the 503 raised
+# here can carry the real root cause (e.g. "No module named 'langgraph'") back
+# to the client and logs, instead of a generic "unavailable".
+# Returns (status, error_message); status is one of:
+#   "started" | "skipped" | "failed" | "unknown"
+def _default_harness_health() -> tuple[str, Optional[str]]:
+    return ("unknown", None)
+
+
+_harness_health_provider: Callable[[], tuple[str, Optional[str]]] = _default_harness_health
+
+
+def set_harness_health_provider(
+    provider: Callable[[], tuple[str, Optional[str]]],
+) -> None:
+    """Register a callable returning (harness_status, harness_error).
+
+    Called by ``app.main`` during startup with a closure over
+    ``app.state``.  Keeping this as an injected provider (rather than
+    passing ``app.state`` through every orchestrator/dispatcher signature)
+    avoids threading a FastAPI-specific object through the service layer.
+    """
+    global _harness_health_provider
+    _harness_health_provider = provider
+
 
 def _ensure_started(agent_harness: Any) -> None:
-    if not agent_harness or not getattr(agent_harness, "started", False):
-        raise HTTPException(
-            status_code=503,
-            detail="Agent 服务暂不可用，请稍后再试",
-        )
+    if agent_harness and getattr(agent_harness, "started", False):
+        return
+
+    status, error = _harness_health_provider()
+    # Build a detail string that surfaces the root cause when we have one.
+    if status == "failed" and error:
+        detail = f"Agent 服务启动失败: {error}"
+    elif status == "skipped":
+        detail = f"Agent 服务未启动: {error or 'LLM 未配置'}"
+    else:
+        detail = "Agent 服务暂不可用，请稍后再试"
+    logger.warning("[DISPATCHER] harness not ready: status={} error={}", status, error)
+    raise HTTPException(status_code=503, detail=detail)
 
 
 async def _resolve_agent_context(

--- a/app/services/chat/lifecycle.py
+++ b/app/services/chat/lifecycle.py
@@ -92,3 +92,18 @@ async def fail_turn(
     await chat_history_service.fail_assistant_message(
         db, assistant_msg_id, error=error
     )
+
+
+async def cancel_turn(
+    db: AsyncSession,
+    *,
+    assistant_msg_id: str,
+) -> None:
+    """Remove the pending assistant placeholder for a turn that never ran.
+
+    Call this when setup failed *before* the agent produced anything
+    (e.g. harness 503, scope resolution error).  Unlike :func:`fail_turn`,
+    this leaves no trace in history — the user's question is preserved
+    but no empty "failed" assistant bubble appears.
+    """
+    await chat_history_service.delete_assistant_message(db, assistant_msg_id)

--- a/app/services/chat/orchestrator.py
+++ b/app/services/chat/orchestrator.py
@@ -28,6 +28,7 @@ from app.services.chat.dispatcher import agent_run, agent_stream_setup
 from app.services.chat.lifecycle import (
     TurnContext,
     begin_turn,
+    cancel_turn,
     fail_turn,
     finalize_turn,
 )
@@ -164,9 +165,10 @@ async def ask(
         )
         return ChatResponse(answer=answer, sources=sources[:5])
     except HTTPException:
-        await fail_turn(
-            db, assistant_msg_id=ctx.assistant_msg_id, error="HTTPException during ask"
-        )
+        # Service-level failure (e.g. harness 503) before generation started:
+        # remove the placeholder rather than marking it failed, so the
+        # history doesn't show an empty "failed" assistant bubble.
+        await cancel_turn(db, assistant_msg_id=ctx.assistant_msg_id)
         raise
     except Exception as e:
         logger.exception("Chat ask failed")
@@ -228,11 +230,7 @@ async def ask_agentic(
             avg_recall_score=0.0,
         )
     except HTTPException:
-        await fail_turn(
-            db,
-            assistant_msg_id=ctx.assistant_msg_id,
-            error="HTTPException during agentic",
-        )
+        await cancel_turn(db, assistant_msg_id=ctx.assistant_msg_id)
         raise
     except Exception as e:
         logger.exception("Agentic RAG ask failed")
@@ -273,11 +271,7 @@ async def ask_stream(
             query=ctx.user_message,
         )
     except HTTPException:
-        await fail_turn(
-            db,
-            assistant_msg_id=ctx.assistant_msg_id,
-            error="HTTPException during stream",
-        )
+        await cancel_turn(db, assistant_msg_id=ctx.assistant_msg_id)
         raise
     except Exception as e:
         logger.exception("Stream ask setup failed")
@@ -345,11 +339,7 @@ async def ask_agent_stream(
             query=ctx.user_message,
         )
     except HTTPException:
-        await fail_turn(
-            db,
-            assistant_msg_id=ctx.assistant_msg_id,
-            error="HTTPException during agent stream",
-        )
+        await cancel_turn(db, assistant_msg_id=ctx.assistant_msg_id)
         raise
     except Exception as e:
         logger.exception("Agent stream dispatch failed")
@@ -397,7 +387,19 @@ async def _stream_agent_events(
     try:
         async for frame in streamer.stream(agent_graph, input_state, run_config):
             yield frame
+    except Exception as e:
+        logger.exception("Agent stream generation failed")
+        error_msg = str(e)
+        yield sse_event({"type": "error", "message": error_msg})
+        await fail_turn(db, assistant_msg_id=ctx.assistant_msg_id, error=error_msg)
+        return
 
+    # Post-stream persistence.  By this point the client has already
+    # received the ``done`` frame from ``streamer.stream()``, so any
+    # failure here MUST NOT emit a second ``error`` event — clients that
+    # close on ``done`` would never see it, and those that don't would
+    # render a spurious error after a successful answer.
+    try:
         latency_ms = int((time.time() - start_time) * 1000)
         await finalize_turn(
             db,
@@ -418,8 +420,5 @@ async def _stream_agent_events(
             completion_tokens=token_handler.completion_tokens,
             api_calls=token_handler.llm_calls or 1,
         )
-    except Exception as e:
-        logger.exception("Agent stream generation failed")
-        error_msg = str(e)
-        yield sse_event({"type": "error", "message": error_msg})
-        await fail_turn(db, assistant_msg_id=ctx.assistant_msg_id, error=error_msg)
+    except Exception:
+        logger.exception("Post-stream finalize/usage failed; answer already delivered to client")

--- a/app/services/chat/scope.py
+++ b/app/services/chat/scope.py
@@ -71,10 +71,11 @@ async def resolve_search_scope(
         workspace_pages_dicts = [wp.model_dump() for wp in request.workspace_pages]
 
     if request.workspace_id is not None:
-        from app.infra.redis import redis_client
+        # Runtime attribute access — see app/infra/redis.py header.
+        from app.infra import redis as _redis
         from app.repository.workspace_repository import WorkspaceRepository
 
-        ws_repo = WorkspaceRepository(redis=redis_client if redis_client else None)
+        ws_repo = WorkspaceRepository(redis=_redis.redis_client)
         ws = await ws_repo.get_by_id(request.workspace_id, uid, db)
         if ws is None:
             raise HTTPException(status_code=404, detail="工作区不存在")

--- a/app/services/chat_history.py
+++ b/app/services/chat_history.py
@@ -416,6 +416,22 @@ async def fail_assistant_message(
     logger.warning(f"[CHAT_HISTORY] failed assistant msg_id={msg_id}")
 
 
+async def delete_assistant_message(
+    db: AsyncSession,
+    msg_id: str,
+) -> None:
+    """Delete a pending assistant placeholder.
+
+    Use this (not :func:`fail_assistant_message`) when the turn failed
+    *before* any generation happened — e.g. harness unavailable (503) or
+    scope-resolution errors.  A placeholder that never produced content
+    should not linger in history as a "failed" turn, because that misleads
+    the user into thinking the model attempted and failed an answer.
+    """
+    await mongo_chat.delete_message(msg_id)
+    logger.info(f"[CHAT_HISTORY] removed placeholder msg_id={msg_id} (turn aborted before generation)")
+
+
 async def _unsafe_get_history(
     db: AsyncSession,
     chat_session_id: str,

--- a/app/services/cloud/cleanup.py
+++ b/app/services/cloud/cleanup.py
@@ -15,8 +15,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db_context
 from app.infra.config import config
+from app.infra import redis as _redis
 from app.infra.redis import (
-    client as redis_client,
     is_enabled as redis_enabled,
     pubsub,
 )
@@ -131,12 +131,12 @@ async def _is_heartbeat_alive(session_uuid: str) -> bool:
     Returns True if Redis is disabled (cannot check -- assume alive so we
     do not accidentally clean up active sessions).
     """
-    if not redis_enabled() or redis_client is None:
+    if not redis_enabled() or _redis.client is None:
         return True  # cannot verify; err on the side of caution
 
     try:
         key = f"{_HEARTBEAT_PREFIX}{session_uuid}"
-        exists = await redis_client.exists(key)
+        exists = await _redis.client.exists(key)
         return bool(exists)
     except Exception:
         logger.warning(

--- a/app/services/cloud/upload_service.py
+++ b/app/services/cloud/upload_service.py
@@ -20,8 +20,8 @@ from loguru import logger
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.infra.config import config
+from app.infra import redis as _redis
 from app.infra.redis import (
-    client as redis_client,
     is_enabled as redis_enabled,
     k,
     jset,
@@ -163,7 +163,7 @@ class CloudUploadService:
 
     async def _get_upload_meta(self, upload_uuid: str) -> dict:
         """Fetch upload metadata from Redis.  Raises ValueError on miss."""
-        if not redis_enabled() or redis_client is None:
+        if not redis_enabled() or _redis.client is None:
             raise ValueError("Redis is required for cloud uploads")
         meta = await jget(self._upload_key(upload_uuid))
         if meta is None:
@@ -171,13 +171,14 @@ class CloudUploadService:
         return meta
 
     async def _set_upload_meta(self, upload_uuid: str, meta: dict) -> None:
-        if not redis_enabled() or redis_client is None:
+        if not redis_enabled() or _redis.client is None:
             raise ValueError("Redis is required for cloud uploads")
         await jset(self._upload_key(upload_uuid), meta, ex=UPLOAD_META_TTL)
 
     async def _delete_upload_meta(self, upload_uuid: str) -> None:
-        if redis_client is not None:
-            await redis_client.delete(self._upload_key(upload_uuid))
+        client = _redis.client
+        if client is not None:
+            await client.delete(self._upload_key(upload_uuid))
 
     # ------------------------------------------------------------------
     # init_upload
@@ -372,12 +373,12 @@ class CloudUploadService:
 
     async def _set_heartbeat(self, session_uuid: str) -> None:
         """Internal: Redis SETEX heartbeat key."""
-        if not redis_enabled() or redis_client is None:
+        if not redis_enabled() or _redis.client is None:
             logger.debug("[CLOUD_UPLOAD] heartbeat skipped — Redis disabled")
             return
         try:
             key = k("cloud", "heartbeat", session_uuid)
-            await redis_client.setex(key, HEARTBEAT_TTL, "alive")
+            await _redis.client.setex(key, HEARTBEAT_TTL, "alive")
             logger.debug(
                 "[CLOUD_UPLOAD] heartbeat set session_uuid={} ttl={}",
                 session_uuid,

--- a/app/services/doc_parser/vectorize.py
+++ b/app/services/doc_parser/vectorize.py
@@ -33,11 +33,11 @@ async def _push_status(
 ):
     """Fire-and-forget WebSocket push — never blocks the pipeline on failure."""
     try:
-        from app.routers.tasks_ws import broadcast_cloud_status
+        from app.services.ws_registry import broadcast_cloud_status
 
         await broadcast_cloud_status(uid, upload_uuid, status, chunk_count, error)
     except Exception:
-        logger.debug("[VECTORIZE] WS push skipped (no router loaded yet)")
+        logger.debug("[VECTORIZE] WS push skipped (registry unavailable)")
 
 
 async def vectorize_cloud_document(
@@ -92,10 +92,36 @@ async def vectorize_cloud_document(
         # mid-flight cannot poison the dedup check on retry.
         content_hash = hashlib.sha256(content_bytes).hexdigest()
         if file.vector_status == "done" and file.content_hash == content_hash:
-            logger.info(
-                "[VECTORIZE] file %s already vectorized, content unchanged", upload_uuid
-            )
-            return file.vector_chunk_count or 0
+            # DB says done — but verify Milvus actually still has the
+            # vectors.  The cloud_drive collection may have been dropped
+            # +recreated by _ensure_collection on an embedding dim
+            # mismatch (e.g. after switching embedding models), which
+            # silently loses all vectors while the DB status stays
+            # "done".  Without this check the idempotency guard would
+            # skip re-vectorization forever and the file would be
+            # unsearchable.
+            rag = get_rag_service()
+            if rag.cloud_backend is not None:
+                actual = rag.cloud_backend.count_by_upload_uuid(upload_uuid)
+                if actual == 0:
+                    logger.warning(
+                        "[VECTORIZE] file %s marked done but Milvus has 0 chunks "
+                        "(collection likely recreated) — re-vectorizing",
+                        upload_uuid,
+                    )
+                    # Fall through to re-run the full pipeline.
+                else:
+                    logger.info(
+                        "[VECTORIZE] file %s already vectorized, content unchanged",
+                        upload_uuid,
+                    )
+                    return file.vector_chunk_count or 0
+            else:
+                logger.info(
+                    "[VECTORIZE] file %s already vectorized, content unchanged",
+                    upload_uuid,
+                )
+                return file.vector_chunk_count or 0
 
         file.vector_status = "processing"
         await db.commit()

--- a/app/services/rag/legacy.py
+++ b/app/services/rag/legacy.py
@@ -139,6 +139,17 @@ class RAGService:
                     "[RAG] cloud_backend initialized: {}",
                     config.milvus.cloud_collection_name,
                 )
+                # If the collection was dropped+recreated on dim mismatch,
+                # all prior vectors are gone.  Reset every cloud file marked
+                # "done" back to "pending" so the next access re-vectorizes
+                # it — otherwise the idempotency guard in vectorize.py
+                # would skip them forever and the files stay unsearchable.
+                if getattr(self.cloud_backend, "was_recreated", False):
+                    logger.warning(
+                        "[RAG] cloud_drive collection was recreated (dim mismatch) — "
+                        "resetting vector_status for all done files to pending"
+                    )
+                    self._reset_cloud_vector_statuses()
             except Exception as e:
                 logger.warning(
                     "[RAG] cloud_backend init failed: error_type={}",
@@ -770,3 +781,99 @@ class RAGService:
                 type(e).__name__,
             )
             return 0
+
+    def count_cloud_chunks(self, upload_uuid: str) -> int:
+        """Count cloud-drive vectors for *upload_uuid*.
+
+        Returns 0 when the cloud backend is not initialized or the upload
+        has no vectors.  Routers call this instead of querying Milvus
+        directly so all vector-store access stays inside the RAG layer.
+        """
+        if self.cloud_backend is None:
+            return 0
+        try:
+            return self.cloud_backend.count_by_upload_uuid(upload_uuid)
+        except Exception as e:
+            logger.warning(
+                "[RAG] count_cloud_chunks failed upload_uuid={} error_type={}",
+                upload_uuid,
+                type(e).__name__,
+            )
+            return 0
+
+    def delete_cloud_vectors(self, upload_uuid: str) -> int:
+        """Delete all cloud-drive vectors for *upload_uuid*.
+
+        Returns the number of deleted chunks, or 0 if the cloud backend is
+        unavailable.  Routers must call this instead of operating on Milvus
+        collections directly.
+        """
+        if self.cloud_backend is None:
+            return 0
+        try:
+            deleted = self.cloud_backend.delete_by_upload_uuid(upload_uuid)
+            logger.info(
+                "[RAG] cloud vectors deleted upload_uuid={} count={}",
+                upload_uuid,
+                deleted,
+            )
+            return deleted
+        except Exception as e:
+            logger.warning(
+                "[RAG] delete_cloud_vectors failed upload_uuid={} error_type={}",
+                upload_uuid,
+                type(e).__name__,
+            )
+            return 0
+
+    def _reset_cloud_vector_statuses(self) -> None:
+        """Reset all cloud files marked ``done`` back to ``pending``.
+
+        Called from ``__init__`` when the cloud_drive collection was
+        recreated (dim mismatch).  Spawns a background task so the sync
+        constructor is not blocked and does not need its own DB session.
+
+        The background task resets ``vector_status='pending'``,
+        ``vector_chunk_count=0``, ``content_hash=NULL`` for every
+        non-deleted cloud file whose status was ``done``.  Files are
+        then re-vectorized lazily on next access (the idempotency guard
+        in vectorize.py sees pending status and runs the pipeline), or
+        eagerly by a caller invoking ``vectorize_cloud_document``.
+        """
+        import asyncio
+
+        async def _reset() -> None:
+            from sqlalchemy import text
+            from app.database import async_session_factory
+
+            try:
+                async with async_session_factory() as session:
+                    result = await session.execute(
+                        text(
+                            "UPDATE cloud_files "
+                            "SET vector_status = 'pending', "
+                            "    vector_chunk_count = 0, "
+                            "    content_hash = NULL "
+                            "WHERE vector_status = 'done' "
+                            "  AND deleted_at IS NULL"
+                        )
+                    )
+                    await session.commit()
+                    logger.warning(
+                        "[RAG] reset {} cloud files from done → pending "
+                        "(collection was recreated, vectors lost)",
+                        result.rowcount,
+                    )
+            except Exception:
+                logger.exception("[RAG] failed to reset cloud vector statuses")
+
+        try:
+            loop = asyncio.get_running_loop()
+            loop.create_task(_reset())
+        except RuntimeError:
+            # No running loop (e.g. constructing outside an event loop) —
+            # run synchronously as a fallback.  This blocks init briefly
+            # but guarantees the reset happens.
+            import asyncio as _aio
+
+            _aio.run(_reset())

--- a/app/services/vector_page_service.py
+++ b/app/services/vector_page_service.py
@@ -3,7 +3,6 @@ Per-page vectorization service — atomic protection + step-level progress.
 """
 
 import asyncio
-import uuid
 from datetime import datetime, timezone
 from typing import Optional
 
@@ -173,11 +172,11 @@ class VectorPageService:
     async def _run_asr(self, bvid: str, cid: int, page_index: int, page_title: str):
         """Run ASR via ASRPageService (poll for completion, max 5 minutes)."""
         from app.services.asr_page_service import ASRPageService
-        from app.routers.asr import asr_tasks
+        from app.services.async_task.asr_task_registry import asr_tasks, create_task
 
         service = ASRPageService()
-        task_id = str(uuid.uuid4())
-        asr_tasks[task_id] = {"status": "pending", "progress": 0, "message": "ASR task created"}
+        task_id = create_task()
+        asr_tasks[task_id].update({"message": "ASR task created"})
 
         await service.process_page(
             task_id=task_id, bvid=bvid, cid=cid,

--- a/app/services/ws_registry.py
+++ b/app/services/ws_registry.py
@@ -1,0 +1,136 @@
+"""Process-local WebSocket connection registry and broadcast helpers.
+
+Lives in the service layer so that both ``routers/tasks_ws.py`` (which
+accepts WS connections) and ``services/doc_parser/vectorize.py`` (which
+pushes cloud-file vectorization progress) can share the same connection
+pool without services importing from routers.
+
+This module owns no HTTP / WebSocket endpoint — it only stores
+``WebSocket`` objects handed to it by the router and pushes JSON frames
+back through them.  The router remains responsible for auth, accept,
+and lifecycle; this registry is purely the shared state plus the
+broadcast fan-out.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from typing import Any
+
+from fastapi import WebSocket
+
+logger = logging.getLogger(__name__)
+
+# uid -> set of live WebSockets for that user
+_active_connections: dict[int, set[WebSocket]] = {}
+
+MAX_PER_UID = 3
+MAX_TOTAL = 50
+
+
+def total_count() -> int:
+    return sum(len(v) for v in _active_connections.values())
+
+
+def connections_for(uid: int) -> set[WebSocket]:
+    """Return the (possibly empty) set of live sockets for *uid*."""
+    return _active_connections.get(uid, set())
+
+
+def register(uid: int, ws: WebSocket) -> None:
+    """Add *ws* to the registry. Caller must have already accepted it."""
+    _active_connections.setdefault(uid, set()).add(ws)
+
+
+def unregister(uid: int, ws: WebSocket) -> None:
+    """Remove *ws*; drop the uid bucket if it becomes empty."""
+    bucket = _active_connections.get(uid)
+    if bucket is None:
+        return
+    bucket.discard(ws)
+    if not bucket:
+        _active_connections.pop(uid, None)
+
+
+def within_limits(uid: int) -> bool:
+    """True if accepting one more connection for *uid* stays under caps."""
+    if total_count() >= MAX_TOTAL:
+        return False
+    if len(_active_connections.get(uid, set())) >= MAX_PER_UID:
+        return False
+    return True
+
+
+def evict_oldest(uid: int, keep: int = MAX_PER_UID) -> list[WebSocket]:
+    """Evict oldest connections for *uid* so that at most *keep* remain.
+
+    Returns the evicted sockets so the caller can close them.
+    """
+    bucket = _active_connections.get(uid)
+    if bucket is None:
+        return []
+    evicted: list[WebSocket] = []
+    while len(bucket) > keep - 1:
+        # sets are unordered; pick any via iter() — caller closes them
+        ws = next(iter(bucket), None)
+        if ws is None:
+            break
+        bucket.discard(ws)
+        evicted.append(ws)
+    return evicted
+
+
+async def broadcast_cloud_status(
+    uid: int,
+    upload_uuid: str,
+    status: str,
+    chunk_count: int = 0,
+    error: str = "",
+) -> None:
+    """Push cloud-file vectorization status to all of a user's connections."""
+    connections = _active_connections.get(uid, set())
+    if not connections:
+        logger.debug("[CLOUD_WS] no connections for uid=%s, status not pushed", uid)
+        return
+
+    payload = json.dumps(
+        {
+            "type": "cloud_processing",
+            "upload_uuid": upload_uuid,
+            "status": status,
+            "chunk_count": chunk_count,
+            "error": error,
+            "timestamp": time.time(),
+        }
+    )
+
+    dead: list[WebSocket] = []
+    for ws in connections:
+        try:
+            await ws.send_text(payload)
+        except Exception:
+            dead.append(ws)
+    for ws in dead:
+        # Use the same unregister path so the bucket cleanup is consistent.
+        connections.discard(ws)
+    if dead and not connections:
+        _active_connections.pop(uid, None)
+
+
+async def broadcast_task_update(uid: int, task: dict[str, Any]) -> None:
+    """Push a generic task update to all of a user's connections."""
+    connections = _active_connections.get(uid, set())
+    if not connections:
+        return
+    dead: list[WebSocket] = []
+    for ws in connections:
+        try:
+            await ws.send_json({"type": "task_update", "task": task})
+        except Exception:
+            dead.append(ws)
+    for ws in dead:
+        connections.discard(ws)
+    if dead and not connections:
+        _active_connections.pop(uid, None)

--- a/app/test/test_asr_api.py
+++ b/app/test/test_asr_api.py
@@ -305,7 +305,7 @@ class TestGetASRStatus:
     @pytest.mark.asyncio
     async def test_status_pending(self, client, test_db):
         """pending 状态"""
-        from app.routers.asr import asr_tasks
+        from app.services.async_task.asr_task_registry import asr_tasks
 
         task_id = "test-task-pending"
         asr_tasks[task_id] = {

--- a/app/tools/harness/delegate.py
+++ b/app/tools/harness/delegate.py
@@ -96,7 +96,10 @@ class DelegateToAgentTool:
         )
 
         try:
-            result = await self._lifecycle.invoke(
+            # Reentrant entry: the chat agent already holds the session lock,
+            # and asyncio.Lock is non-reentrant. Using plain invoke() would
+            # deadlock against the outer acquire.
+            result = await self._lifecycle.invoke_reentrant(
                 agent_name,
                 session_id,
                 timeout=self._timeout,

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,12 @@ aiomysql==0.3.2
 # LangChain + vector store
 langchain==0.3.28
 langchain-openai==0.2.6
-langgraph==1.1.2
+# langgraph 1.x pulls langgraph-prebuilt>=1.0.0 which requires
+# langchain-core>=1.0.0, conflicting with langchain 0.3.x (core<1.0.0).
+# 0.6.11 is the last 0.x release; it pulls prebuilt 0.6.x which allows
+# langchain-core 0.3.x. All APIs used by this codebase (StateGraph, END,
+# add_messages, ToolNode) exist in 0.6.x.
+langgraph==0.6.11
 openai==1.59.7
 dashscope==1.20.0
 langsmith==0.7.22

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ aiomysql==0.3.2
 # LangChain + vector store
 langchain==0.3.28
 langchain-openai==0.2.6
+langgraph==1.1.2
 openai==1.59.7
 dashscope==1.20.0
 langsmith==0.7.22


### PR DESCRIPTION
 ## Summary

  本 PR 汇总 `fix/backend-infra-hardening` 分支的 6
  个独立修复,聚焦后端基础设施层的静默降级、向量数据一致性、以及依赖冲突问题。所有改动均为 bug fix /
  refactor,不引入新功能。

  ## 修复清单

  ### 1. `[infra]` redis_client 名字不匹配导致多处静默降级
  - **根因**: `from app.infra.redis import client as redis_client` 在 import 时绑定 None,init() 之后不会更新,导致
  RateLimitMiddleware / WorkspaceRepository / UploadService / Cleanup 等多处拿到 None 静默降级。
  - **修复**: 改为运行时属性访问 `from app.infra import redis as _redis; _redis.client`,确保每次访问拿到最新值。

  ### 2. `[milvus]` ORM API 迁移到 MilvusClient,消除弃用警告
  - **根因**: PyMilvus 3.1 将弃用 ORM 风格 API (`Collection` / `utility` / `connections`),日志持续刷
  `PyMilvusDeprecationWarning`。
  - **修复**: `vector_store_milvus.py` 与 `infra/milvus.py` 全量迁移到 `MilvusClient` 函数式 API (create_schema /
  prepare_index_params / row-based insert / search with filter)。

  ### 3. `[cloud]` cloud_drive 向量丢失死锁 + 自愈机制
  - **根因**: 切换 embedding 模型引发维度不一致 → `_ensure_collection` drop+recreate collection → Milvus 向量全部丢失,但
   MySQL `vector_status='done'` 未变。幂等检查 `status==done && hash match` 直接 skip,文件永远无法重新向量化,B题.pdf
  等文件检索不到。
  - **修复**:
    - `vector_store_milvus` 新增 `was_recreated` 标志位
    - `RAGService` 启动时检测到 recreate → 批量重置 `vector_status='pending'`
    - `vectorize.py` 幂等检查增加 Milvus 实际 chunk 数校验,0 chunks 时 fall through 重新跑全流程

  ### 4. `[harness]` 健康检查透传根因 + SSE 顺序 + 死锁 + 事务原子性
  - 健康检查错误信息透传到前端,而非被吞掉
  - SSE `done` 与 `error` 事件顺序修正 (done 后不再发 error)
  - `asyncio.Lock` 非可重入导致同一 session_id 死锁 → 移除或改用 RLock
  - 消息持久化与向量写入事务原子性保证

  ### 5. `[arch]` 修复分层违规,提取共享状态到 service 层 registry
  - 将原本散落在 router 层的共享状态 (如 upload 进度、WS 连接注册表) 下沉到 `services/` 下的 registry 模块,消除 router →
   router 横向依赖。

  ### 6. `[deps]` langgraph 降级到 0.6.11 解决与 langchain 0.3.x 的依赖冲突
  - **根因**: `langgraph 1.x` → `langgraph-prebuilt>=1.0.0` → `langchain-core>=1.0.0`,与 `langchain 0.3.28` (core<1.0.0)
   冲突,`pip install -r requirements.txt` 无法解析。
  - **修复**: 降级到 `langgraph==0.6.11` (最后一个 0.x 版本),拉取 `prebuilt 0.6.x`,允许 `core 0.3.x`。本仓库使用的 API
  (StateGraph / END / add_messages / ToolNode) 在 0.6.x 均存在。