### PR TITLE
feat(quiz): add quiz sharing with public view, owner management, and three-layer cache

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -102,6 +102,10 @@ async def _migrate_add_columns():
         ("cloud_files", "doc_parser", "VARCHAR(20) NULL"),
         ("cloud_files", "doc_meta", "JSON NULL"),
         ("cloud_files", "content_hash", "VARCHAR(128) NULL"),
+        # Quiz sharing — unguessable share token (separate from quiz_uuid)
+        ("quiz_sets", "share_token", "VARCHAR(32)"),
+        ("quiz_sets", "shared_at", "TIMESTAMP"),
+        ("quiz_sets", "share_expires_at", "TIMESTAMP"),
     ]
 
     # Plan 0024/0025/0026: drop deprecated content columns & session_id columns
@@ -423,6 +427,36 @@ async def _migrate_add_columns():
                 logger.debug(f"[MIGRATION] Column {table}.{column} already modified, skipping")
             else:
                 logger.warning(f"[MIGRATION] Could not modify {table}.{column}: {e}")
+
+    # Unique index on quiz_sets.share_token — separate from the column add
+    # above because ALTER TABLE ADD COLUMN does not always create the index
+    # on existing tables (esp. MySQL). Idempotent.
+    # Try with IF NOT EXISTS first (SQLite + MySQL 8.0.29+); fall back to plain
+    # CREATE UNIQUE INDEX for older MySQL where the syntax is unsupported.
+    index_statements = [
+        "CREATE UNIQUE INDEX IF NOT EXISTS ix_quiz_sets_share_token ON quiz_sets (share_token)",
+        "CREATE UNIQUE INDEX ix_quiz_sets_share_token ON quiz_sets (share_token)",
+    ]
+    index_created = False
+    for stmt in index_statements:
+        if index_created:
+            break
+        try:
+            async with engine.begin() as conn:
+                await conn.execute(text(stmt))
+            logger.info("[MIGRATION] Index ensured: ix_quiz_sets_share_token")
+            index_created = True
+        except Exception as e:
+            err_msg = str(e).lower()
+            if "already exists" in err_msg or "1061" in str(e):
+                logger.debug("[MIGRATION] Index ix_quiz_sets_share_token already exists, skipping")
+                index_created = True
+            elif "syntax" in err_msg or "1064" in str(e):
+                # Unsupported IF NOT EXISTS syntax — try the next statement form.
+                logger.debug(f"[MIGRATION] Statement form unsupported, trying fallback: {stmt}")
+                continue
+            else:
+                logger.warning(f"[MIGRATION] Could not create index ix_quiz_sets_share_token: {e}")
 
 
 async def _seed_default_data():

--- a/app/middleware/rate_limit.py
+++ b/app/middleware/rate_limit.py
@@ -22,6 +22,7 @@ _RATE_LIMITS: dict[str, tuple[float, int]] = {
     "/cloud/upload": (5.0, 30),  # chunked upload: 5 rps burst 30
     "/favorites/organize": (1.0, 3),
     "/quiz/generate": (2.0, 5),
+    "/quiz/shared": (2.0, 5),  # public unauthenticated endpoint — throttle token guessing
     "/credentials": (1.0, 3),
     "/workspaces": (5.0, 10),
 }

--- a/app/models.py
+++ b/app/models.py
@@ -413,6 +413,12 @@ class QuizSet(Base):
     total_score = Column(Integer, default=100)
     passing_score = Column(Integer, default=60)
     completed_at = Column(DateTime, nullable=True)
+    # Quiz sharing — share_token is a separate unguessable secret so that
+    # quiz_uuid (which is only a UUID4) cannot be enumerated. NULL = not shared.
+    share_token = Column(String(32), unique=True, index=True, nullable=True)
+    shared_at = Column(DateTime, nullable=True)
+    # Optional expiry — NULL = never expires (until owner revokes).
+    share_expires_at = Column(DateTime, nullable=True)
     created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
     updated_at = Column(
         DateTime,

--- a/app/repository/quiz_repository.py
+++ b/app/repository/quiz_repository.py
@@ -1,0 +1,291 @@
+"""Quiz query repository — MySQL read access + cross-store consistency checks.
+
+Absorbs the raw SQL that previously lived inline in ``app/routers/quiz.py``.
+All queries are parameterised; no user input is ever string-interpolated into
+SQL text.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from sqlalchemy import text, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from loguru import logger
+
+from app.models import QuizSet
+
+
+class QuizRepository:
+    """Data access for quiz_sets / quiz_submissions / quiz_answers queries."""
+
+    # ── Cross-store consistency ───────────────────────────────────
+
+    async def refresh_stale_quiz_sets(self, uid: int, db: AsyncSession) -> None:
+        """Mark quiz_sets as failed when MySQL says 'done' but MongoDB has 0 questions.
+
+        Best-effort: if MongoDB is unavailable the check is skipped silently.
+        Mutates rows in-place and commits.
+        """
+        from app.repository import mongo_quiz_repository as mongo_quiz
+
+        stale_result = await db.execute(
+            select(QuizSet.quiz_uuid).where(
+                QuizSet.uid == uid,
+                QuizSet.status == "done",
+            )
+        )
+        stale_uuids = [row[0] for row in stale_result.all()]
+        for qid in stale_uuids:
+            try:
+                mq_count = await mongo_quiz.count_questions(qid)
+                if mq_count == 0:
+                    qs_result = await db.execute(
+                        select(QuizSet).where(QuizSet.quiz_uuid == qid)
+                    )
+                    qs = qs_result.scalar_one_or_none()
+                    if qs:
+                        qs.status = "failed"
+                        qs.error_message = "MongoDB data lost — questions not found"
+            except Exception:
+                # MongoDB unavailable — skip this quiz set.
+                pass
+        await db.commit()
+
+    async def mark_quiz_lost(self, quiz_uuid: str, db: AsyncSession) -> None:
+        """Flip a single quiz_set to 'failed' with a data-lost message."""
+        result = await db.execute(
+            select(QuizSet).where(QuizSet.quiz_uuid == quiz_uuid)
+        )
+        qs = result.scalar_one_or_none()
+        if qs:
+            qs.status = "failed"
+            qs.error_message = "MongoDB data lost — questions not found"
+            await db.commit()
+
+    # ── History ───────────────────────────────────────────────────
+
+    async def count_history(self, uid: int, db: AsyncSession) -> int:
+        """Count quiz_sets with terminal status for the user."""
+        result = await db.execute(
+            text(
+                "SELECT COUNT(*) FROM quiz_sets "
+                "WHERE uid = :uid AND status IN ('done', 'failed')"
+            ),
+            {"uid": uid},
+        )
+        return int(result.scalar() or 0)
+
+    async def list_history(
+        self, uid: int, page: int, page_size: int, db: AsyncSession
+    ) -> list[dict]:
+        """Paginated history with LEFT JOIN to submissions.
+
+        Returns one row per quiz_set; submission columns are NULL when the
+        user has not submitted yet.
+        """
+        offset = (page - 1) * page_size
+        result = await db.execute(
+            text(
+                """SELECT qs.quiz_uuid, qs.title, qs.question_count,
+                          qs.difficulty, qs.status, qs.source_type,
+                          qs.created_at,
+                          qsub.submission_uuid, qsub.total_score,
+                          qsub.is_passed, qsub.correct_count,
+                          qsub.total_question_count, qsub.time_spent_seconds,
+                          qsub.submitted_at
+                   FROM quiz_sets qs
+                   LEFT JOIN quiz_submissions qsub
+                     ON qsub.quiz_uuid = qs.quiz_uuid AND qsub.uid = :uid
+                   WHERE qs.uid = :uid
+                     AND qs.status IN ('done', 'failed')
+                   ORDER BY qs.created_at DESC
+                   LIMIT :limit OFFSET :offset"""
+            ),
+            {"uid": uid, "limit": page_size, "offset": offset},
+        )
+        submissions: list[dict] = []
+        for row in result.fetchall():
+            d = dict(row._mapping)
+            submissions.append(
+                {
+                    "submission_uuid": d["submission_uuid"],
+                    "quiz_uuid": d["quiz_uuid"],
+                    "title": d["title"],
+                    "status": d["status"],
+                    "question_count": d["question_count"],
+                    "difficulty": d["difficulty"],
+                    "source_type": d["source_type"],
+                    "score": d["total_score"],
+                    "passed": (
+                        bool(d["is_passed"]) if d["is_passed"] is not None else None
+                    ),
+                    "correct_count": d["correct_count"],
+                    "total_question_count": d["total_question_count"],
+                    "time_spent_seconds": d["time_spent_seconds"],
+                    "submitted_at": d["submitted_at"],
+                    "created_at": str(d["created_at"]) if d["created_at"] else "",
+                }
+            )
+        return submissions
+
+    # ── Wrong-answer notebook ─────────────────────────────────────
+
+    async def list_wrong_answers(
+        self,
+        uid: int,
+        folder_ids: Optional[list[int]],
+        db: AsyncSession,
+    ) -> list[dict]:
+        """Wrong-answer notebook, optionally filtered by folder_ids.
+
+        ``folder_ids`` filtering uses parameterised ``LIKE :fid_N`` clauses —
+        the param name is index-derived (never user input) and the value is
+        ``%{int}%`` so there is no injection surface.
+        """
+        sql = """
+            SELECT qq.question_uuid, qq.quiz_uuid, qq.question_type,
+                   qq.question_text, qq.options,
+                   qa.user_answer, qa.correct_answer_snapshot,
+                   qq.explanation,
+                   COUNT(qa.id) as times_wrong,
+                   MAX(qa.submitted_at) as last_attempt_at
+            FROM quiz_answers qa
+            JOIN quiz_submissions qsub ON qsub.submission_uuid = qa.submission_uuid
+            JOIN quiz_questions qq ON qq.question_uuid = qa.question_uuid
+            JOIN quiz_sets qs ON qs.quiz_uuid = qsub.quiz_uuid
+            WHERE qsub.uid = :uid AND qa.is_correct = 0 AND qs.status = 'done'
+        """
+        params: dict[str, Any] = {"uid": uid}
+
+        if folder_ids:
+            folder_conditions: list[str] = []
+            for i, fid in enumerate(folder_ids):
+                param_name = f"fid_{i}"
+                folder_conditions.append(f"qs.folder_ids LIKE :{param_name}")
+                params[param_name] = f"%{fid}%"
+            if folder_conditions:
+                sql += " AND (" + " OR ".join(folder_conditions) + ")"
+
+        sql += " GROUP BY qq.question_uuid ORDER BY last_attempt_at DESC"
+
+        result = await db.execute(text(sql), params)
+        wrong_answers: list[dict] = []
+        for row in result.fetchall():
+            d = dict(row._mapping)
+            user_answer = (
+                json.loads(d["user_answer"]) if d["user_answer"] else d["user_answer"]
+            )
+            correct_answer = (
+                json.loads(d["correct_answer_snapshot"])
+                if d["correct_answer_snapshot"]
+                else d["correct_answer_snapshot"]
+            )
+            options_data = (
+                json.loads(d["options"])
+                if isinstance(d.get("options"), str)
+                else d.get("options")
+            )
+            wrong_answers.append(
+                {
+                    "question_uuid": d["question_uuid"],
+                    "quiz_uuid": d["quiz_uuid"],
+                    "question_type": d["question_type"],
+                    "question_text": d["question_text"],
+                    "options": options_data,
+                    "user_answer": user_answer,
+                    "correct_answer": correct_answer,
+                    "explanation": d["explanation"],
+                    "times_wrong": d["times_wrong"],
+                    "last_attempt_at": d["last_attempt_at"],
+                }
+            )
+        return wrong_answers
+
+    # ── Sharing ───────────────────────────────────────────────────
+
+    async def get_owned_quiz(
+        self, quiz_uuid: str, uid: int, db: AsyncSession
+    ) -> Optional[QuizSet]:
+        """Fetch a quiz_set owned by ``uid``. Returns None if not found or
+        not owned — callers should treat both as 404 to avoid leaking existence.
+        """
+        result = await db.execute(
+            select(QuizSet).where(QuizSet.quiz_uuid == quiz_uuid, QuizSet.uid == uid)
+        )
+        return result.scalar_one_or_none()
+
+    async def set_share_token(
+        self,
+        quiz_uuid: str,
+        uid: int,
+        share_token: str,
+        db: AsyncSession,
+        expires_at: Optional[datetime] = None,
+    ) -> tuple[bool, Optional[str]]:
+        """Set share_token on an owned quiz.
+
+        Returns ``(success, previous_token)``. ``previous_token`` is the old
+        share_token if one existed (so the caller can invalidate its cache
+        entry), else None. Re-issuing replaces the previous token (old link
+        becomes invalid). ``expires_at`` is an optional absolute expiry
+        timestamp; None = no expiry.
+        """
+        result = await db.execute(
+            select(QuizSet).where(QuizSet.quiz_uuid == quiz_uuid, QuizSet.uid == uid)
+        )
+        qs = result.scalar_one_or_none()
+        if qs is None:
+            return False, None
+        previous = qs.share_token
+        qs.share_token = share_token
+        qs.shared_at = datetime.now(timezone.utc)
+        qs.share_expires_at = expires_at
+        await db.commit()
+        return True, previous
+
+    async def clear_share_token(
+        self, quiz_uuid: str, uid: int, db: AsyncSession
+    ) -> tuple[bool, Optional[str]]:
+        """Revoke sharing on an owned quiz.
+
+        Returns ``(success, previous_token)`` so the caller can invalidate
+        the cache entry for the revoked token.
+        """
+        result = await db.execute(
+            select(QuizSet).where(QuizSet.quiz_uuid == quiz_uuid, QuizSet.uid == uid)
+        )
+        qs = result.scalar_one_or_none()
+        if qs is None:
+            return False, None
+        previous = qs.share_token
+        qs.share_token = None
+        qs.shared_at = None
+        qs.share_expires_at = None
+        await db.commit()
+        return True, previous
+
+    async def get_by_share_token(
+        self, share_token: str, db: AsyncSession
+    ) -> Optional[QuizSet]:
+        """Fetch a quiz_set by its share_token. Returns None if not shared
+        or token is invalid. No uid scoping — this is the public read path.
+        """
+        result = await db.execute(
+            select(QuizSet).where(QuizSet.share_token == share_token)
+        )
+        return result.scalar_one_or_none()
+
+
+# ── Module-level singleton ────────────────────────────────────────
+
+_repo: Optional[QuizRepository] = None
+
+
+def get_quiz_repository() -> QuizRepository:
+    global _repo
+    if _repo is None:
+        _repo = QuizRepository()
+    return _repo

--- a/app/repository/quiz_repository.py
+++ b/app/repository/quiz_repository.py
@@ -13,7 +13,6 @@ from typing import Any, Optional
 
 from sqlalchemy import text, select
 from sqlalchemy.ext.asyncio import AsyncSession
-from loguru import logger
 
 from app.models import QuizSet
 

--- a/app/routers/quiz.py
+++ b/app/routers/quiz.py
@@ -7,10 +7,13 @@ import json
 from datetime import datetime
 from typing import Any, Optional
 
-from fastapi import APIRouter, HTTPException, Query, Body, Depends, BackgroundTasks
+from fastapi import APIRouter, HTTPException, Query, Body, Depends, BackgroundTasks, Response
 from fastapi.responses import StreamingResponse
 from loguru import logger
+from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.database import get_db, get_db_context
+from app.routers.auth import get_current_uid
 from app.services.quiz_delete import QuizDeleteError, QuizDeleteService
 from app.services.quiz_generator import (
     QuizGeneratorService,
@@ -20,8 +23,7 @@ from app.services.quiz_generator import (
 )
 from app.services.quiz_grader import QuizGraderService
 from app.services.quiz_export import QuizDataExportService
-from app.database import get_db_context
-from app.routers.auth import get_current_uid
+from app.services.quiz_share_service import get_quiz_share_service
 
 router = APIRouter(prefix="/quiz", tags=["quiz"])
 
@@ -160,95 +162,22 @@ async def get_history(
     Cross-store consistency: if a quiz_set has status='done' but MongoDB
     has 0 questions, mark it as failed and exclude from results.
     """
+    from app.repository.quiz_repository import get_quiz_repository
+
+    repo = get_quiz_repository()
     async with get_db_context() as db:
-        from sqlalchemy import text, select as sa_select
-        from app.models import QuizSet
-        from app.repository import mongo_quiz_repository as mongo_quiz
+        await repo.refresh_stale_quiz_sets(uid, db)
+        total = await repo.count_history(uid, db)
+        submissions = await repo.list_history(uid, page, page_size, db)
 
-        # 1. Check for stale quiz sets (MySQL done but MongoDB empty)
-        stale_result = await db.execute(
-            sa_select(QuizSet.quiz_uuid).where(
-                QuizSet.uid == uid,
-                QuizSet.status == "done",
-            )
-        )
-        stale_uuids = [row[0] for row in stale_result.all()]
-        for qid in stale_uuids:
-            try:
-                mq_count = await mongo_quiz.count_questions(qid)
-                if mq_count == 0:
-                    qs_result = await db.execute(
-                        sa_select(QuizSet).where(QuizSet.quiz_uuid == qid)
-                    )
-                    qs = qs_result.scalar_one_or_none()
-                    if qs:
-                        qs.status = "failed"
-                        qs.error_message = "MongoDB data lost — questions not found"
-            except Exception:
-                pass  # MongoDB unavailable — skip check
-        await db.commit()
-
-        # 2. Count and paginate
-        count_result = await db.execute(
-            text(
-                """SELECT COUNT(*) FROM quiz_sets
-                   WHERE uid = :uid AND status IN ('done', 'failed')"""
-            ),
-            {"uid": uid},
-        )
-        total = count_result.scalar()
-
-        offset = (page - 1) * page_size
-        result = await db.execute(
-            text(
-                """SELECT qs.quiz_uuid, qs.title, qs.question_count,
-                          qs.difficulty, qs.status, qs.source_type,
-                          qs.created_at,
-                          qsub.submission_uuid, qsub.total_score,
-                          qsub.is_passed, qsub.correct_count,
-                          qsub.total_question_count, qsub.time_spent_seconds,
-                          qsub.submitted_at
-                   FROM quiz_sets qs
-                   LEFT JOIN quiz_submissions qsub
-                     ON qsub.quiz_uuid = qs.quiz_uuid AND qsub.uid = :uid
-                   WHERE qs.uid = :uid
-                     AND qs.status IN ('done', 'failed')
-                   ORDER BY qs.created_at DESC
-                   LIMIT :limit OFFSET :offset"""
-            ),
-            {"uid": uid, "limit": page_size, "offset": offset},
-        )
-        submissions = []
-        for row in result.fetchall():
-            d = dict(row._mapping)
-            submissions.append(
-                {
-                    "submission_uuid": d["submission_uuid"],
-                    "quiz_uuid": d["quiz_uuid"],
-                    "title": d["title"],
-                    "status": d["status"],
-                    "question_count": d["question_count"],
-                    "difficulty": d["difficulty"],
-                    "source_type": d["source_type"],
-                    "score": d["total_score"],
-                    "passed": (
-                        bool(d["is_passed"]) if d["is_passed"] is not None else None
-                    ),
-                    "correct_count": d["correct_count"],
-                    "total_question_count": d["total_question_count"],
-                    "time_spent_seconds": d["time_spent_seconds"],
-                    "submitted_at": d["submitted_at"],
-                    "created_at": str(d["created_at"]) if d["created_at"] else "",
-                }
-            )
-
-        return {
-            "submissions": submissions,
-            "total": total,
-            "page": page,
-            "page_size": page_size,
-            "has_more": offset + page_size < total,
-        }
+    offset = (page - 1) * page_size
+    return {
+        "submissions": submissions,
+        "total": total,
+        "page": page,
+        "page_size": page_size,
+        "has_more": offset + page_size < total,
+    }
 
 
 @router.get("/wrong-answers")
@@ -257,86 +186,19 @@ async def get_wrong_answers(
     uid: int = Depends(get_current_uid),
 ):
     """Get wrong-answer notebook for the current user."""
+    fids = (
+        [int(x.strip()) for x in folder_ids.split(",") if x.strip()]
+        if folder_ids
+        else None
+    )
+
+    from app.repository.quiz_repository import get_quiz_repository
+
+    repo = get_quiz_repository()
     async with get_db_context() as db:
-        from sqlalchemy import text
+        wrong_answers = await repo.list_wrong_answers(uid, fids, db)
 
-        sql = """
-            SELECT qq.question_uuid, qq.quiz_uuid, qq.question_type,
-                   qq.question_text, qq.options,
-                   qa.user_answer, qa.correct_answer_snapshot,
-                   qq.explanation,
-                   COUNT(qa.id) as times_wrong,
-                   MAX(qa.submitted_at) as last_attempt_at
-            FROM quiz_answers qa
-            JOIN quiz_submissions qsub ON qsub.submission_uuid = qa.submission_uuid
-            JOIN quiz_questions qq ON qq.question_uuid = qa.question_uuid
-            JOIN quiz_sets qs ON qs.quiz_uuid = qsub.quiz_uuid
-            WHERE qsub.uid = :uid AND qa.is_correct = 0 AND qs.status = 'done'
-        """
-
-        params = {"uid": uid}
-        if folder_ids:
-            fids = [int(x.strip()) for x in folder_ids.split(",") if x.strip()]
-            folder_conditions = []
-            for i, fid in enumerate(fids):
-                param_name = f"fid_{i}"
-                folder_conditions.append(f"qs.folder_ids LIKE :{param_name}")
-                params[param_name] = f"%{fid}%"
-            if folder_conditions:
-                sql = """
-                    SELECT qq.question_uuid, qq.quiz_uuid, qq.question_type,
-                           qq.question_text, qq.options,
-                           qa.user_answer, qa.correct_answer_snapshot,
-                           qq.explanation,
-                           COUNT(qa.id) as times_wrong,
-                           MAX(qa.submitted_at) as last_attempt_at
-                    FROM quiz_answers qa
-                    JOIN quiz_submissions qsub ON qsub.submission_uuid = qa.submission_uuid
-                    JOIN quiz_questions qq ON qq.question_uuid = qa.question_uuid
-                    JOIN quiz_sets qs ON qs.quiz_uuid = qsub.quiz_uuid
-                    WHERE qsub.uid = :uid AND qa.is_correct = 0 AND qs.status = 'done'
-                """ + (
-                    " AND (" + " OR ".join(folder_conditions) + ")"
-                )
-
-        sql += " GROUP BY qq.question_uuid ORDER BY last_attempt_at DESC"
-
-        result = await db.execute(text(sql), params)
-        wrong_answers = []
-        import json as _json
-
-        for row in result.fetchall():
-            d = dict(row._mapping)
-            user_answer = (
-                _json.loads(d["user_answer"]) if d["user_answer"] else d["user_answer"]
-            )
-            correct_answer = (
-                _json.loads(d["correct_answer_snapshot"])
-                if d["correct_answer_snapshot"]
-                else d["correct_answer_snapshot"]
-            )
-            options_data = (
-                _json.loads(d["options"])
-                if isinstance(d.get("options"), str)
-                else d.get("options")
-            )
-
-            wrong_answers.append(
-                {
-                    "question_uuid": d["question_uuid"],
-                    "quiz_uuid": d["quiz_uuid"],
-                    "question_type": d["question_type"],
-                    "question_text": d["question_text"],
-                    "options": options_data,
-                    "user_answer": user_answer,
-                    "correct_answer": correct_answer,
-                    "explanation": d["explanation"],
-                    "times_wrong": d["times_wrong"],
-                    "last_attempt_at": d["last_attempt_at"],
-                }
-            )
-
-        return {"wrong_answers": wrong_answers, "total": len(wrong_answers)}
+    return {"wrong_answers": wrong_answers, "total": len(wrong_answers)}
 
 
 @router.get("/export")
@@ -374,6 +236,77 @@ async def export_quiz_data(
             "Cache-Control": "no-cache",
         },
     )
+
+
+# ── Sharing (public read + owner-managed write) ─────────────────
+
+
+@router.post("/{quiz_uuid}/share")
+async def create_quiz_share(
+    quiz_uuid: str,
+    body: dict = Body(default_factory=dict),
+    uid: int = Depends(get_current_uid),
+    db: AsyncSession = Depends(get_db),
+):
+    """Create or rotate the share_token for an owned quiz.
+
+    Body: ``{"expires_in_days": int | null}``. ``null``/absent = never expires.
+    Returns ``{quiz_uuid, share_token, shared_at, share_expires_at}``.
+    Re-issuing invalidates the previous link.
+    """
+    expires_in_days = body.get("expires_in_days") if isinstance(body, dict) else None
+    if expires_in_days is not None:
+        try:
+            expires_in_days = int(expires_in_days)
+        except (TypeError, ValueError):
+            raise HTTPException(status_code=400, detail="expires_in_days 必须是整数或 null")
+    service = get_quiz_share_service()
+    return await service.create_share(quiz_uuid, uid, db, expires_in_days)
+
+
+@router.get("/{quiz_uuid}/share")
+async def get_quiz_share_status(
+    quiz_uuid: str,
+    uid: int = Depends(get_current_uid),
+    db: AsyncSession = Depends(get_db),
+):
+    """Owner-side query: current share state for an owned quiz."""
+    service = get_quiz_share_service()
+    return await service.get_share_status(quiz_uuid, uid, db)
+
+
+@router.delete("/{quiz_uuid}/share")
+async def revoke_quiz_share(
+    quiz_uuid: str,
+    uid: int = Depends(get_current_uid),
+    db: AsyncSession = Depends(get_db),
+):
+    """Revoke sharing for an owned quiz. Idempotent."""
+    service = get_quiz_share_service()
+    return await service.revoke_share(quiz_uuid, uid, db)
+
+
+@router.get("/shared/{share_token}")
+async def get_shared_quiz(
+    share_token: str,
+    response: Response,
+    db: AsyncSession = Depends(get_db),
+):
+    """Public read of a shared quiz — NO authentication required.
+
+    Returns quiz questions WITHOUT correct answers / explanations / keywords
+    so viewers can self-test. Raises 404 for invalid / revoked / non-shareable
+    tokens (identical response to avoid state enumeration).
+
+    Response is cacheable for 60s at the browser and at nginx (separate
+    ``proxy_cache`` directive). Revocation / re-issuance takes effect
+    immediately at the Redis L2 layer; worst-case staleness at the HTTP
+    layers is bounded by the 60s TTL — acceptable for non-sensitive content.
+    """
+    response.headers["Cache-Control"] = "public, max-age=60"
+    response.headers["Vary"] = "Accept-Encoding"
+    service = get_quiz_share_service()
+    return await service.get_shared_quiz(share_token, db)
 
 
 # ── Parameterized routes (MUST be last) ────────────────────────
@@ -419,19 +352,10 @@ async def get_quiz(
             f"[QUIZ] quiz_uuid={quiz_uuid} has status=done question_count={quiz_set.question_count} "
             f"but MongoDB returned 0 questions — marking quiz as failed (data lost after migration?)"
         )
-        async with get_db_context() as db:
-            from app.models import QuizSet
+        from app.repository.quiz_repository import get_quiz_repository
 
-            result = await db.execute(
-                __import__("sqlalchemy")
-                .select(QuizSet)
-                .where(QuizSet.quiz_uuid == quiz_uuid)
-            )
-            qs = result.scalar_one_or_none()
-            if qs:
-                qs.status = "failed"
-                qs.error_message = "MongoDB data lost — questions not found"
-                await db.commit()
+        async with get_db_context() as db:
+            await get_quiz_repository().mark_quiz_lost(quiz_uuid, db)
         raise HTTPException(410, "题目数据已丢失，请重新生成")
 
     return {

--- a/app/services/quiz_share_service.py
+++ b/app/services/quiz_share_service.py
@@ -1,0 +1,281 @@
+"""Quiz sharing service — issue / revoke / read shared quiz sets.
+
+Layering:
+- Service orchestrates token generation, ownership checks, cross-store
+  reads (MySQL metadata + MongoDB questions), and Redis L2 cache.
+- Repository (QuizRepository) owns all SQL.
+- Router is a thin delegate.
+
+Caching strategy:
+- Public read path (``get_shared_quiz``) is backed by a 60s Redis cache
+  keyed by ``quiz_share:{share_token}``. Redis miss falls back to MySQL +
+  MongoDB and writes back.
+- ``revoke_share`` and ``create_share`` actively delete the old token's
+  cache entry so revocation takes effect immediately at the L2 layer.
+- nginx and the browser also cache for 60s (set in the router) — worst-case
+  staleness after revocation is bounded by that TTL, which is acceptable for
+  non-sensitive quiz content.
+
+Security notes:
+- ``share_token`` is a 16-byte ``secrets.token_urlsafe`` string (≈22 chars),
+  decoupled from ``quiz_uuid`` so that the public endpoint cannot be enumerated
+  by guessing UUID4s.
+- Public read path returns questions WITHOUT correct answers / explanations /
+  keywords — viewers get the quiz for self-testing only.
+- Expired / revoked / invalid tokens all return the same 404 to prevent
+  token-state enumeration.
+"""
+
+from __future__ import annotations
+
+import json
+import secrets
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional
+
+from fastapi import HTTPException
+from loguru import logger
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.repository.quiz_repository import get_quiz_repository
+
+
+_CACHE_TTL = 60  # seconds — keep short to bound staleness after revocation
+
+
+def _generate_share_token() -> str:
+    """Return a URL-safe random token with ~122 bits of entropy."""
+    return secrets.token_urlsafe(16)
+
+
+def _is_expired(expires_at: Optional[datetime]) -> bool:
+    """True if ``expires_at`` is set and in the past."""
+    if expires_at is None:
+        return False
+    # Stored datetimes may be tz-naive (MySQL) or tz-aware (SQLite). Normalise.
+    if expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=timezone.utc)
+    return expires_at < datetime.now(timezone.utc)
+
+
+def _cache_key(share_token: str) -> str:
+    """Build the Redis cache key for a share token."""
+    from app.infra.redis import k
+    return k("quiz_share", share_token)
+
+
+async def _invalidate_cache(share_token: Optional[str]) -> None:
+    """Delete the Redis cache entry for a token. No-op if token is None
+    or Redis is unavailable.
+    """
+    if not share_token:
+        return
+    try:
+        from app.infra.redis import client as _redis
+        if _redis:
+            await _redis.delete(_cache_key(share_token))
+    except Exception as e:
+        logger.warning(f"[QUIZ_SHARE] cache invalidation failed: {e}")
+
+
+class QuizShareService:
+    """Orchestrates quiz sharing lifecycle."""
+
+    async def create_share(
+        self,
+        quiz_uuid: str,
+        uid: int,
+        db: AsyncSession,
+        expires_in_days: Optional[int] = None,
+    ) -> dict[str, Any]:
+        """Create or rotate the share_token for an owned quiz.
+
+        Returns ``{"quiz_uuid", "share_token", "shared_at", "share_expires_at"}``.
+        Raises 404 if the quiz does not exist or is not owned by ``uid``.
+        Raises 400 if the quiz is not in a shareable state.
+        ``expires_in_days``: None = never expires; otherwise must be 1..365.
+        """
+        if expires_in_days is not None and not (1 <= expires_in_days <= 365):
+            raise HTTPException(status_code=400, detail="有效期必须在 1~365 天之间")
+
+        repo = get_quiz_repository()
+        qs = await repo.get_owned_quiz(quiz_uuid, uid, db)
+        if qs is None:
+            raise HTTPException(status_code=404, detail="题目集不存在")
+        if qs.status != "done":
+            raise HTTPException(
+                status_code=400, detail="题目尚未生成完成，无法分享"
+            )
+
+        token = _generate_share_token()
+        expires_at: Optional[datetime] = (
+            datetime.now(timezone.utc) + timedelta(days=expires_in_days)
+            if expires_in_days is not None
+            else None
+        )
+        ok, previous_token = await repo.set_share_token(
+            quiz_uuid, uid, token, db, expires_at
+        )
+        if not ok:
+            raise HTTPException(status_code=404, detail="题目集不存在")
+
+        # Invalidate the previous token's cache entry so the old link stops
+        # serving immediately at the L2 layer (nginx/browser TTL still apply).
+        await _invalidate_cache(previous_token)
+
+        logger.info(
+            f"[QUIZ_SHARE] created quiz_uuid={quiz_uuid} uid={uid} "
+            f"expires_in_days={expires_in_days}"
+        )
+        return {
+            "quiz_uuid": quiz_uuid,
+            "share_token": token,
+            "shared_at": qs.shared_at.isoformat() if qs.shared_at else None,
+            "share_expires_at": qs.share_expires_at.isoformat()
+            if qs.share_expires_at
+            else None,
+        }
+
+    async def revoke_share(
+        self, quiz_uuid: str, uid: int, db: AsyncSession
+    ) -> dict[str, Any]:
+        """Revoke sharing for an owned quiz. Idempotent."""
+        repo = get_quiz_repository()
+        ok, previous_token = await repo.clear_share_token(quiz_uuid, uid, db)
+        if not ok:
+            raise HTTPException(status_code=404, detail="题目集不存在")
+        await _invalidate_cache(previous_token)
+        logger.info(f"[QUIZ_SHARE] revoked quiz_uuid={quiz_uuid} uid={uid}")
+        return {"quiz_uuid": quiz_uuid, "shared": False}
+
+    async def get_share_status(
+        self, quiz_uuid: str, uid: int, db: AsyncSession
+    ) -> dict[str, Any]:
+        """Owner-side query: is this quiz currently shared, and until when?
+
+        Raises 404 if the quiz does not exist or is not owned by ``uid``.
+        Not cached — owner-facing, low QPS.
+        """
+        repo = get_quiz_repository()
+        qs = await repo.get_owned_quiz(quiz_uuid, uid, db)
+        if qs is None:
+            raise HTTPException(status_code=404, detail="题目集不存在")
+        if not qs.share_token:
+            return {"quiz_uuid": quiz_uuid, "shared": False}
+        return {
+            "quiz_uuid": quiz_uuid,
+            "shared": True,
+            "share_token": qs.share_token,
+            "shared_at": qs.shared_at.isoformat() if qs.shared_at else None,
+            "share_expires_at": qs.share_expires_at.isoformat()
+            if qs.share_expires_at
+            else None,
+            "expired": _is_expired(qs.share_expires_at),
+        }
+
+    async def get_shared_quiz(
+        self, share_token: str, db: AsyncSession
+    ) -> dict[str, Any]:
+        """Public read: return shared quiz WITHOUT answers.
+
+        Served from Redis L2 cache on hit; on miss, reads MySQL + MongoDB
+        and writes back with a 60s TTL.
+
+        Raises 404 if the token is invalid, revoked, expired, or the quiz is
+        not in a shareable state. The 404 is identical in all cases to prevent
+        token-state enumeration. 404s are NOT cached (the caller — nginx —
+        caches them briefly to absorb token-guessing).
+        """
+        # ── L2 read ──────────────────────────────────────────────────
+        try:
+            from app.infra.redis import client as _redis, jget
+            if _redis:
+                cached = await jget(_cache_key(share_token))
+                if cached is not None:
+                    return cached
+        except Exception as e:
+            logger.warning(f"[QUIZ_SHARE] cache read failed, falling through: {e}")
+
+        # ── Cache miss → build payload ──────────────────────────────
+        payload = await self._build_shared_quiz_payload(share_token, db)
+
+        # ── L2 write-back (best-effort) ─────────────────────────────
+        try:
+            from app.infra.redis import jset
+            if _redis:
+                await jset(_cache_key(share_token), payload, ex=_CACHE_TTL)
+        except Exception as e:
+            logger.warning(f"[QUIZ_SHARE] cache write-back failed: {e}")
+
+        return payload
+
+    async def _build_shared_quiz_payload(
+        self, share_token: str, db: AsyncSession
+    ) -> dict[str, Any]:
+        """Build the public quiz payload from MySQL + MongoDB.
+
+        Raises 404 for invalid / revoked / expired / empty tokens.
+        """
+        repo = get_quiz_repository()
+        qs = await repo.get_by_share_token(share_token, db)
+        if qs is None or qs.status != "done" or _is_expired(qs.share_expires_at):
+            raise HTTPException(status_code=404, detail="分享链接无效或已失效")
+
+        # MongoDB read — questions only (no answers/explanation/keywords).
+        from app.services.quiz_generator import get_quiz_questions
+
+        questions = await get_quiz_questions(qs.quiz_uuid)
+        if not questions:
+            logger.warning(
+                f"[QUIZ_SHARE] share_token has no questions in MongoDB "
+                f"quiz_uuid={qs.quiz_uuid}"
+            )
+            raise HTTPException(status_code=404, detail="分享链接无效或已失效")
+
+        return {
+            "quiz_uuid": qs.quiz_uuid,
+            "title": qs.title,
+            "question_count": qs.question_count,
+            "type_distribution": qs.type_distribution,
+            "difficulty": qs.difficulty,
+            "total_score": qs.total_score,
+            "passing_score": qs.passing_score,
+            "source_type": getattr(qs, "source_type", "folder") or "folder",
+            "shared_at": qs.shared_at.isoformat() if qs.shared_at else None,
+            "share_expires_at": qs.share_expires_at.isoformat()
+            if qs.share_expires_at
+            else None,
+            "questions": [
+                {
+                    "question_uuid": q.get("question_uuid"),
+                    "question_type": q.get("question_type"),
+                    "difficulty": q.get("difficulty"),
+                    "question_text": q.get("question_text"),
+                    "options": _parse_json_field(q.get("options")),
+                }
+                for q in questions
+            ],
+        }
+
+
+def _parse_json_field(value: Any) -> Any:
+    """Parse a JSON-encoded string field, fall back to raw value."""
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        return value
+    try:
+        return json.loads(value)
+    except (json.JSONDecodeError, TypeError):
+        return value
+
+
+# Module-level singleton — stateless service.
+_service: Optional[QuizShareService] = None
+
+
+def get_quiz_share_service() -> QuizShareService:
+    global _service
+    if _service is None:
+        _service = QuizShareService()
+    return _service

--- a/frontend/app/quiz/share-view/[token]/page.tsx
+++ b/frontend/app/quiz/share-view/[token]/page.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import { Plus_Jakarta_Sans } from "next/font/google";
+import { quizApi, type SharedQuizData } from "@/lib/api";
+import { SharedQuizView } from "@/components/quiz/SharedQuizView";
+
+const jakarta = Plus_Jakarta_Sans({
+  subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
+  variable: "--sqv-sans",
+  display: "swap",
+});
+
+export default function SharedQuizPage() {
+  const params = useParams<{ token: string }>();
+  const token = params?.token ?? "";
+  const [quiz, setQuiz] = useState<SharedQuizData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!token) return;
+    let cancelled = false;
+    setLoading(true);
+    quizApi
+      .getSharedQuiz(token)
+      .then((data) => {
+        if (!cancelled) {
+          setQuiz(data);
+          setError(null);
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          const msg =
+            err?.message || (err instanceof Error ? err.message : "加载失败");
+          setError(msg.includes("404") ? "分享链接无效或已失效" : msg);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
+
+  return (
+    <div
+      className={`sqv-page ${jakarta.variable}`}
+      style={{ fontFamily: "var(--sqv-sans), system-ui, sans-serif" }}
+    >
+      <div className="sqv-page__bg" aria-hidden />
+      <div className="sqv-page__inner">
+        {loading && <SharedQuizSkeleton />}
+        {!loading && error && <SharedQuizError message={error} />}
+        {!loading && !error && quiz && <SharedQuizView quiz={quiz} />}
+      </div>
+    </div>
+  );
+}
+
+function SharedQuizSkeleton() {
+  return (
+    <div className="sqv-skel">
+      <div className="sqv-skel__hero">
+        <div className="sqv-skel__pill" />
+        <div className="sqv-skel__title" />
+        <div className="sqv-skel__sub" />
+        <div className="sqv-skel__chips">
+          <div className="sqv-skel__chip" />
+          <div className="sqv-skel__chip" />
+        </div>
+      </div>
+      <div className="sqv-skel__cards">
+        <div className="sqv-skel__card" />
+        <div className="sqv-skel__card" />
+        <div className="sqv-skel__card" />
+      </div>
+    </div>
+  );
+}
+
+function SharedQuizError({ message }: { message: string }) {
+  return (
+    <div className="sqv-error">
+      <div className="sqv-error__mark" aria-hidden>
+        <svg viewBox="0 0 56 56" width="56" height="56">
+          <circle cx="28" cy="28" r="26" fill="none" stroke="currentColor" strokeWidth="1.5" />
+          <path d="M18 30l6 6 14-14" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+      </div>
+      <h1 className="sqv-error__title">{message}</h1>
+      <p className="sqv-error__hint">
+        请联系分享者获取新的链接，或登录后查看自己的题目集
+      </p>
+    </div>
+  );
+}

--- a/frontend/components/dock-modules/quiz.tsx
+++ b/frontend/components/dock-modules/quiz.tsx
@@ -1,7 +1,14 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { Loader2, CheckCircle, XCircle, Download, Database, Layers, History, Eye, ArrowLeft, Trash2 } from "lucide-react";
+import { Loader2, CheckCircle, XCircle, Download, Database, Layers, History, Eye, ArrowLeft, Trash2, Share2, Copy, Link as LinkIcon, CircleAlert } from "lucide-react";
+import {
+    Dialog,
+    DialogContent,
+    DialogHeader,
+    DialogTitle,
+    DialogDescription,
+} from "@/components/ui/dialog";
 import {
     quizApi,
     favoritesV2Api,
@@ -14,6 +21,7 @@ import {
     type FolderStatus,
     type VectorizedPageItem,
     type QuizHistoryItem,
+    type QuizShareStatus,
 } from "@/lib/api";
 import { type DockPanelProps } from "@/lib/dock-registry";
 import { useDockContext } from "@/lib/dock-context";
@@ -23,6 +31,12 @@ const TYPE_LABELS: Record<string, string> = {
     multi_choice: "多选",
     short_answer: "简答",
     essay: "主观",
+};
+
+const DIFFICULTY_LABELS: Record<string, string> = {
+    easy: "简单",
+    medium: "中等",
+    hard: "困难",
 };
 
 interface FolderInfo {
@@ -35,42 +49,42 @@ interface FolderInfo {
 export default function QuizPanel({ isOpen }: DockPanelProps) {
     const { sessionId } = useDockContext();
 
-    // Mode
     const [mode, setMode] = useState<"folder" | "pages">("folder");
 
-    // Folder list
     const [folders, setFolders] = useState<FolderInfo[]>([]);
     const [loadingFolders, setLoadingFolders] = useState(false);
     const [selectedFolderIds, setSelectedFolderIds] = useState<Set<number>>(new Set());
 
-    // Pages mode: vectorized pages list
     const [vectorizedPages, setVectorizedPages] = useState<VectorizedPageItem[]>([]);
     const [loadingPages, setLoadingPages] = useState(false);
     const [selectedPageKeys, setSelectedPageKeys] = useState<Set<string>>(new Set());
 
-    // Generation config
     const [questionCount, setQuestionCount] = useState(10);
     const [difficulty, setDifficulty] = useState("medium");
     const [generating, setGenerating] = useState(false);
     const [error, setError] = useState<string | null>(null);
 
-    // Current quiz
     const [currentQuiz, setCurrentQuiz] = useState<QuizSetData | null>(null);
     const [userAnswers, setUserAnswers] = useState<Map<string, string | string[]>>(new Map());
     const [submitting, setSubmitting] = useState(false);
     const [submitResult, setSubmitResult] = useState<QuizSubmissionResult | null>(null);
 
-    // Review mode (viewing a past quiz)
     const [isReviewMode, setIsReviewMode] = useState(false);
     const [reviewCorrectAnswers, setReviewCorrectAnswers] = useState<Map<string, string | string[]>>(new Map());
 
-    // History
     const [showHistory, setShowHistory] = useState(false);
     const [historyItems, setHistoryItems] = useState<QuizHistoryItem[]>([]);
     const [loadingHistory, setLoadingHistory] = useState(false);
     const [deletingQuizUuid, setDeletingQuizUuid] = useState<string | null>(null);
 
-    // Fetch folders on open
+    // Share modal state
+    const [shareModalUuid, setShareModalUuid] = useState<string | null>(null);
+    const [shareStatus, setShareStatus] = useState<QuizShareStatus | null>(null);
+    const [shareLoading, setShareLoading] = useState(false);
+    const [shareError, setShareError] = useState<string | null>(null);
+    const [shareDuration, setShareDuration] = useState<number | "">("");
+    const [copied, setCopied] = useState(false);
+
     useEffect(() => {
         if (!isOpen || !sessionId) return;
         setLoadingFolders(true);
@@ -90,7 +104,6 @@ export default function QuizPanel({ isOpen }: DockPanelProps) {
                 }));
                 setFolders(merged);
 
-                // Pre-select folders that have indexed data
                 const preSelected = new Set<number>();
                 for (const f of merged) {
                     if (f.indexed_count > 0) preSelected.add(f.media_id);
@@ -101,7 +114,6 @@ export default function QuizPanel({ isOpen }: DockPanelProps) {
             .finally(() => setLoadingFolders(false));
     }, [isOpen, sessionId]);
 
-    // Reset when closed
     useEffect(() => {
         if (!isOpen) {
             setCurrentQuiz(null);
@@ -124,14 +136,12 @@ export default function QuizPanel({ isOpen }: DockPanelProps) {
         });
     }, []);
 
-    // ────── Pages mode: fetch vectorized pages on mode switch ──────
     const fetchVectorizedPages = useCallback(async () => {
         setLoadingPages(true);
         setError(null);
         try {
             const pages = await knowledgeApi.getVectorizedPages();
             setVectorizedPages(pages);
-            // Pre-select all vectorized pages
             const keys = new Set<string>();
             for (const p of pages) {
                 keys.add(`${p.bvid}:${p.page_index}`);
@@ -144,7 +154,6 @@ export default function QuizPanel({ isOpen }: DockPanelProps) {
         }
     }, []);
 
-    // Fetch pages when switching to pages mode
     useEffect(() => {
         if (mode === "pages" && isOpen) {
             fetchVectorizedPages();
@@ -167,7 +176,6 @@ export default function QuizPanel({ isOpen }: DockPanelProps) {
         setSelectedPageKeys(new Set(allSelected ? [] : allKeys));
     }, [vectorizedPages, selectedPageKeys]);
 
-    // ────── Generate ──────
     const handleGenerate = useCallback(async () => {
         if (!sessionId) {
             setError("未登录");
@@ -270,7 +278,6 @@ export default function QuizPanel({ isOpen }: DockPanelProps) {
         [sessionId]
     );
 
-    // Download a specific quiz with answers
     const handleDownloadQuiz = useCallback(async (quizUuid: string, title: string) => {
         try {
             const quiz = await quizApi.getQuiz(quizUuid, true);
@@ -286,7 +293,6 @@ export default function QuizPanel({ isOpen }: DockPanelProps) {
         }
     }, []);
 
-    // Fetch quiz history
     const fetchHistory = useCallback(async () => {
         if (!sessionId) return;
         setLoadingHistory(true);
@@ -300,7 +306,6 @@ export default function QuizPanel({ isOpen }: DockPanelProps) {
         }
     }, [sessionId]);
 
-    // View a past quiz (review mode)
     const handleViewPastQuiz = useCallback(async (quizUuid: string) => {
         try {
             const quiz = await quizApi.getQuiz(quizUuid, true);
@@ -322,7 +327,7 @@ export default function QuizPanel({ isOpen }: DockPanelProps) {
 
     const handleRetakeQuiz = useCallback(async (quizUuid: string) => {
         try {
-            const quiz = await quizApi.getQuiz(quizUuid, false);  // no answers
+            const quiz = await quizApi.getQuiz(quizUuid, false);
             setReviewCorrectAnswers(new Map());
             setCurrentQuiz(quiz);
             setIsReviewMode(false);
@@ -363,7 +368,6 @@ export default function QuizPanel({ isOpen }: DockPanelProps) {
         }
     }, [currentQuiz]);
 
-    // Back to generate from review
     const handleBackToGenerate = useCallback(() => {
         setCurrentQuiz(null);
         setIsReviewMode(false);
@@ -371,6 +375,105 @@ export default function QuizPanel({ isOpen }: DockPanelProps) {
         setUserAnswers(new Map());
         setReviewCorrectAnswers(new Map());
     }, []);
+
+    const shareUrl = useCallback(
+        (token: string) => {
+            if (typeof window === "undefined") return `/quiz/share-view/${token}`;
+            return `${window.location.origin}/quiz/share-view/${token}`;
+        },
+        [],
+    );
+
+    const handleOpenShare = useCallback(async (quizUuid: string) => {
+        setShareModalUuid(quizUuid);
+        setShareStatus(null);
+        setShareError(null);
+        setShareDuration("");
+        setCopied(false);
+        setShareLoading(true);
+        try {
+            const status = await quizApi.getShareStatus(quizUuid);
+            setShareStatus(status);
+        } catch (e) {
+            setShareError(e instanceof Error ? e.message : "获取分享状态失败");
+        } finally {
+            setShareLoading(false);
+        }
+    }, []);
+
+    const handleCloseShare = useCallback(() => {
+        setShareModalUuid(null);
+        setShareStatus(null);
+        setShareError(null);
+        setShareDuration("");
+        setCopied(false);
+    }, []);
+
+    const handleCreateShare = useCallback(async () => {
+        if (!shareModalUuid) return;
+        const days =
+            shareDuration === "" ? null : Number(shareDuration);
+        if (days !== null && (!Number.isFinite(days) || days < 1 || days > 365)) {
+            setShareError("有效期必须在 1~365 天之间");
+            return;
+        }
+        setShareLoading(true);
+        setShareError(null);
+        try {
+            const res = await quizApi.createShare(shareModalUuid, days);
+            const status: QuizShareStatus = {
+                quiz_uuid: res.quiz_uuid,
+                shared: true,
+                share_token: res.share_token,
+                shared_at: res.shared_at,
+                share_expires_at: res.share_expires_at,
+                expired: false,
+            };
+            setShareStatus(status);
+            setCopied(false);
+        } catch (e) {
+            setShareError(e instanceof Error ? e.message : "创建分享失败");
+        } finally {
+            setShareLoading(false);
+        }
+    }, [shareModalUuid, shareDuration]);
+
+    const handleRevokeShare = useCallback(async () => {
+        if (!shareModalUuid) return;
+        if (!window.confirm("确定撤销分享？撤销后已分享的链接立即失效。")) return;
+        setShareLoading(true);
+        setShareError(null);
+        try {
+            await quizApi.revokeShare(shareModalUuid);
+            setShareStatus({ quiz_uuid: shareModalUuid, shared: false });
+            setCopied(false);
+        } catch (e) {
+            setShareError(e instanceof Error ? e.message : "撤销失败");
+        } finally {
+            setShareLoading(false);
+        }
+    }, [shareModalUuid]);
+
+    const handleCopyShareLink = useCallback(async () => {
+        if (!shareStatus?.share_token) return;
+        const url = shareUrl(shareStatus.share_token);
+        try {
+            if (navigator.clipboard?.writeText) {
+                await navigator.clipboard.writeText(url);
+            } else {
+                const ta = document.createElement("textarea");
+                ta.value = url;
+                document.body.appendChild(ta);
+                ta.select();
+                document.execCommand("copy");
+                document.body.removeChild(ta);
+            }
+            setCopied(true);
+            setTimeout(() => setCopied(false), 2000);
+        } catch {
+            setShareError("复制失败，请手动复制链接");
+        }
+    }, [shareStatus, shareUrl]);
 
     const isAllAnswered =
         currentQuiz?.questions.every((q) => {
@@ -385,38 +488,16 @@ export default function QuizPanel({ isOpen }: DockPanelProps) {
     const selectedFolderCount = selectedFolderIds.size;
     const hasIndexedFolders = folders.some((f) => f.indexed_count > 0);
 
-    // Pages mode stats
     const totalPageCount = vectorizedPages.length;
     const selectedPageCount = selectedPageKeys.size;
     const allPagesSelected = totalPageCount > 0 && selectedPageCount === totalPageCount;
 
     return (
-        <div style={{ color: "var(--foreground)", padding: "16px", overflow: "auto", flex: 1 }}>
+        <div className="quiz" style={{ color: "var(--foreground)", padding: "16px", overflow: "auto", flex: 1 }}>
             {error && (
-                <div
-                    style={{
-                        color: "var(--danger)",
-                        background: "var(--danger-bg)",
-                        padding: "8px 12px",
-                        borderRadius: "8px",
-                        marginBottom: "12px",
-                        fontSize: "14px",
-                        display: "flex",
-                        alignItems: "center",
-                        justifyContent: "space-between",
-                    }}
-                >
+                <div className="quiz-error">
                     <span>{error}</span>
-                    <button
-                        onClick={() => setError(null)}
-                        style={{
-                            background: "none",
-                            border: "none",
-                            color: "var(--danger)",
-                            cursor: "pointer",
-                            fontSize: "16px",
-                        }}
-                    >
+                    <button className="quiz-error__close" onClick={() => setError(null)} aria-label="关闭">
                         ✕
                     </button>
                 </div>
@@ -424,155 +505,66 @@ export default function QuizPanel({ isOpen }: DockPanelProps) {
 
             {!currentQuiz ? (
                 <div>
-                    {/* Mode toggle */}
-                    <div
-                        style={{
-                            display: "flex",
-                            background: "var(--card)",
-                            borderRadius: "10px",
-                            padding: "3px",
-                            marginBottom: "16px",
-                            border: "1px solid var(--border)",
-                        }}
-                    >
+                    <div className="quiz-seg" data-mode={mode}>
+                        <span className="quiz-seg__indicator" />
                         <button
+                            className="quiz-seg__btn"
+                            data-active={mode === "folder"}
                             onClick={() => setMode("folder")}
-                            style={{
-                                flex: 1,
-                                padding: "8px 0",
-                                borderRadius: "8px",
-                                border: "none",
-                                cursor: "pointer",
-                                fontSize: "13px",
-                                fontWeight: 600,
-                                background: mode === "folder"
-                                    ? "linear-gradient(180deg, rgba(6,182,212,0.18) 0%, rgba(6,182,212,0.1) 100%)"
-                                    : "transparent",
-                                color: mode === "folder" ? "var(--accent)" : "var(--muted-foreground)",
-                            }}
                         >
-                            <Database size={14} style={{ display: "inline", marginRight: "4px" }} />
+                            <Database size={14} />
                             按收藏夹
                         </button>
                         <button
+                            className="quiz-seg__btn"
+                            data-active={mode === "pages"}
                             onClick={() => setMode("pages")}
-                            style={{
-                                flex: 1,
-                                padding: "8px 0",
-                                borderRadius: "8px",
-                                border: "none",
-                                cursor: "pointer",
-                                fontSize: "13px",
-                                fontWeight: 600,
-                                background: mode === "pages"
-                                    ? "linear-gradient(180deg, rgba(6,182,212,0.18) 0%, rgba(6,182,212,0.1) 100%)"
-                                    : "transparent",
-                                color: mode === "pages" ? "var(--accent)" : "var(--muted-foreground)",
-                            }}
                         >
-                            <Layers size={14} style={{ display: "inline", marginRight: "4px" }} />
+                            <Layers size={14} />
                             按分P
                         </button>
                     </div>
 
-                    {/* ────── Folder mode ────── */}
                     {mode === "folder" && (
                         <>
-                            <p
-                                style={{
-                                    fontSize: "13px",
-                                    color: "var(--muted-foreground)",
-                                    marginBottom: "8px",
-                                }}
-                            >
-                                选择已入库的收藏夹出题
-                            </p>
+                            <div className="quiz-hint">
+                                <span className="quiz-hint__text">选择已入库的收藏夹出题</span>
+                            </div>
 
                             {loadingFolders ? (
-                                <div
-                                    style={{
-                                        display: "flex",
-                                        alignItems: "center",
-                                        gap: "8px",
-                                        padding: "16px",
-                                        color: "var(--muted-foreground)",
-                                        fontSize: "14px",
-                                    }}
-                                >
+                                <div className="quiz-loading">
                                     <Loader2 size={16} className="animate-spin" />
                                     加载收藏夹...
                                 </div>
                             ) : folders.length === 0 ? (
-                                <div
-                                    style={{
-                                        padding: "16px",
-                                        color: "var(--muted-foreground)",
-                                        fontSize: "14px",
-                                        textAlign: "center",
-                                    }}
-                                >
+                                <div className="quiz-empty">
                                     暂无收藏夹，请先在收藏夹面板中同步数据
                                 </div>
                             ) : (
-                                <div
-                                    style={{
-                                        maxHeight: "240px",
-                                        overflow: "auto",
-                                        marginBottom: "16px",
-                                        borderRadius: "10px",
-                                        border: "1px solid var(--border)",
-                                    }}
-                                >
+                                <div className="quiz-list">
                                     {folders.map((f) => (
                                         <label
                                             key={f.media_id}
-                                            style={{
-                                                display: "flex",
-                                                alignItems: "center",
-                                                justifyContent: "space-between",
-                                                padding: "10px 14px",
-                                                cursor: "pointer",
-                                                borderBottom: "1px solid var(--border)",
-                                                background: selectedFolderIds.has(f.media_id)
-                                                    ? "rgba(6,182,212,0.08)"
-                                                    : "transparent",
-                                            }}
+                                            className="quiz-list__item"
+                                            data-selected={selectedFolderIds.has(f.media_id)}
                                         >
-                                            <div style={{ display: "flex", alignItems: "center", gap: "10px" }}>
+                                            <div className="quiz-list__main">
                                                 <input
                                                     type="checkbox"
+                                                    className="quiz-list__check"
                                                     checked={selectedFolderIds.has(f.media_id)}
                                                     onChange={() => toggleFolder(f.media_id)}
-                                                    style={{ accentColor: "var(--accent)" }}
                                                 />
                                                 <div>
-                                                    <div style={{ fontSize: "14px", fontWeight: 500 }}>
-                                                        {f.title}
-                                                    </div>
-                                                    <div
-                                                        style={{
-                                                            fontSize: "12px",
-                                                            color: "var(--muted-foreground)",
-                                                        }}
-                                                    >
-                                                        {f.media_count} 个视频
-                                                    </div>
+                                                    <div className="quiz-list__title">{f.title}</div>
+                                                    <div className="quiz-list__sub">{f.media_count} 个视频</div>
                                                 </div>
                                             </div>
                                             <span
-                                                style={{
-                                                    fontSize: "12px",
-                                                    padding: "2px 8px",
-                                                    borderRadius: "6px",
-                                                    background: f.indexed_count > 0
-                                                        ? "var(--success-bg)"
-                                                        : "rgba(107,114,128,0.1)",
-                                                    color: f.indexed_count > 0
-                                                        ? "var(--success)"
-                                                        : "var(--muted-foreground)",
-                                                }}
+                                                className="quiz-list__badge"
+                                                data-tone={f.indexed_count > 0 ? "success" : "muted"}
                                             >
-                                                <Database size={10} style={{ display: "inline", marginRight: "3px" }} />
+                                                <Database size={10} />
                                                 {f.indexed_count > 0 ? `${f.indexed_count} 已入库` : "未入库"}
                                             </span>
                                         </label>
@@ -584,147 +576,66 @@ export default function QuizPanel({ isOpen }: DockPanelProps) {
                                 generating={generating}
                                 disabled={selectedFolderCount === 0}
                                 onClick={handleGenerate}
-                                label={`生成题目 (${selectedFolderCount} 个收藏夹)`}
+                                label={`生成题目 · ${selectedFolderCount} 个收藏夹`}
                             />
 
                             {!hasIndexedFolders && folders.length > 0 && !loadingFolders && (
-                                <p
-                                    style={{
-                                        fontSize: "12px",
-                                        color: "var(--warning)",
-                                        textAlign: "center",
-                                        marginTop: "4px",
-                                    }}
-                                >
+                                <p style={{ fontSize: "12px", color: "var(--warning)", textAlign: "center", marginTop: "6px" }}>
                                     提示：需要先在收藏夹面板中将视频入库，才能生成题目
                                 </p>
                             )}
                         </>
                     )}
 
-                    {/* ────── Pages mode ────── */}
                     {mode === "pages" && (
                         <>
-                            <div
-                                style={{
-                                    display: "flex",
-                                    alignItems: "center",
-                                    justifyContent: "space-between",
-                                    marginBottom: "8px",
-                                }}
-                            >
-                                <p
-                                    style={{
-                                        fontSize: "13px",
-                                        color: "var(--muted-foreground)",
-                                        margin: 0,
-                                    }}
-                                >
-                                    选择已向量化的分P出题
-                                </p>
+                            <div className="quiz-hint">
+                                <span className="quiz-hint__text">选择已向量化的分P出题</span>
                                 {totalPageCount > 0 && (
-                                    <button
-                                        onClick={toggleAllPages}
-                                        style={{
-                                            fontSize: "12px",
-                                            padding: "3px 10px",
-                                            borderRadius: "6px",
-                                            background: "var(--card)",
-                                            color: "var(--muted-foreground)",
-                                            border: "1px solid var(--border)",
-                                            cursor: "pointer",
-                                        }}
-                                    >
+                                    <button className="quiz-hint__action" onClick={toggleAllPages}>
                                         {allPagesSelected ? "取消全选" : "全选"}
                                     </button>
                                 )}
                             </div>
 
                             {loadingPages ? (
-                                <div
-                                    style={{
-                                        display: "flex",
-                                        alignItems: "center",
-                                        gap: "8px",
-                                        padding: "16px",
-                                        color: "var(--muted-foreground)",
-                                        fontSize: "14px",
-                                    }}
-                                >
+                                <div className="quiz-loading">
                                     <Loader2 size={16} className="animate-spin" />
                                     加载分P列表...
                                 </div>
                             ) : vectorizedPages.length === 0 ? (
-                                <div
-                                    style={{
-                                        padding: "16px",
-                                        color: "var(--muted-foreground)",
-                                        fontSize: "14px",
-                                        textAlign: "center",
-                                    }}
-                                >
+                                <div className="quiz-empty">
                                     暂无已入库的分P，请先在收藏夹面板中同步入库
                                 </div>
                             ) : (
-                                <div
-                                    style={{
-                                        maxHeight: "300px",
-                                        overflow: "auto",
-                                        marginBottom: "16px",
-                                        borderRadius: "10px",
-                                        border: "1px solid var(--border)",
-                                    }}
-                                >
+                                <div className="quiz-list" style={{ maxHeight: "300px" }}>
                                     {vectorizedPages.map((p) => {
                                         const key = `${p.bvid}:${p.page_index}`;
                                         const isSelected = selectedPageKeys.has(key);
                                         return (
                                             <label
                                                 key={key}
-                                                style={{
-                                                    display: "flex",
-                                                    alignItems: "center",
-                                                    justifyContent: "space-between",
-                                                    padding: "10px 14px",
-                                                    cursor: "pointer",
-                                                    borderBottom: "1px solid var(--border)",
-                                                    background: isSelected
-                                                        ? "rgba(6,182,212,0.08)"
-                                                        : "transparent",
-                                                }}
+                                                className="quiz-list__item"
+                                                data-selected={isSelected}
                                             >
-                                                <div style={{ display: "flex", alignItems: "center", gap: "10px" }}>
+                                                <div className="quiz-list__main">
                                                     <input
                                                         type="checkbox"
+                                                        className="quiz-list__check"
                                                         checked={isSelected}
                                                         onChange={() => togglePage(p.bvid, p.page_index)}
-                                                        style={{ accentColor: "var(--accent)" }}
                                                     />
                                                     <div>
-                                                        <div style={{ fontSize: "14px", fontWeight: 500 }}>
+                                                        <div className="quiz-list__title">
                                                             {p.page_title || `P${p.page_index + 1}`}
                                                         </div>
-                                                        <div
-                                                            style={{
-                                                                fontSize: "12px",
-                                                                color: "var(--muted-foreground)",
-                                                            }}
-                                                        >
+                                                        <div className="quiz-list__sub">
                                                             {p.video_title || p.bvid}
                                                         </div>
                                                     </div>
                                                 </div>
-                                                <span
-                                                    style={{
-                                                        fontSize: "12px",
-                                                        padding: "2px 8px",
-                                                        borderRadius: "6px",
-                                                        background: "var(--success-bg)",
-                                                        color: "var(--success)",
-                                                        flexShrink: 0,
-                                                    }}
-                                                >
-                                                    <Database size={10} style={{ display: "inline", marginRight: "3px" }} />
+                                                <span className="quiz-list__badge" data-tone="success">
+                                                    <Database size={10} />
                                                     {p.vector_chunk_count} 块
                                                 </span>
                                             </label>
@@ -737,64 +648,29 @@ export default function QuizPanel({ isOpen }: DockPanelProps) {
                                 generating={generating}
                                 disabled={selectedPageCount === 0}
                                 onClick={handleGenerate}
-                                label={`生成题目 (${selectedPageCount} 个分P)`}
+                                label={`生成题目 · ${selectedPageCount} 个分P`}
                             />
                         </>
                     )}
 
-                    {/* Config — shared between modes */}
-                    <div style={{ display: "flex", gap: "12px", marginTop: "12px", marginBottom: "12px" }}>
-                        <div style={{ flex: 1 }}>
-                            <label
-                                style={{
-                                    fontSize: "13px",
-                                    color: "var(--muted-foreground)",
-                                    display: "block",
-                                    marginBottom: "6px",
-                                }}
-                            >
-                                题目数量
-                            </label>
+                    <div className="quiz-config">
+                        <div className="quiz-config__field">
+                            <label className="quiz-config__label">题目数量</label>
                             <input
                                 type="number"
                                 min={1}
                                 max={50}
                                 value={questionCount}
                                 onChange={(e) => setQuestionCount(Number(e.target.value))}
-                                style={{
-                                    width: "100%",
-                                    padding: "10px 12px",
-                                    borderRadius: "8px",
-                                    background: "var(--background)",
-                                    color: "var(--foreground)",
-                                    border: "1px solid var(--border)",
-                                    fontSize: "14px",
-                                }}
+                                className="quiz-config__input"
                             />
                         </div>
-                        <div style={{ flex: 1 }}>
-                            <label
-                                style={{
-                                    fontSize: "13px",
-                                    color: "var(--muted-foreground)",
-                                    display: "block",
-                                    marginBottom: "6px",
-                                }}
-                            >
-                                难度
-                            </label>
+                        <div className="quiz-config__field">
+                            <label className="quiz-config__label">难度</label>
                             <select
                                 value={difficulty}
                                 onChange={(e) => setDifficulty(e.target.value)}
-                                style={{
-                                    width: "100%",
-                                    padding: "10px 12px",
-                                    borderRadius: "8px",
-                                    background: "var(--background)",
-                                    color: "var(--foreground)",
-                                    border: "1px solid var(--border)",
-                                    fontSize: "14px",
-                                }}
+                                className="quiz-config__select"
                             >
                                 <option value="easy">简单</option>
                                 <option value="medium">中等</option>
@@ -803,195 +679,114 @@ export default function QuizPanel({ isOpen }: DockPanelProps) {
                         </div>
                     </div>
 
-                    {/* Export area */}
-                    <div
-                        style={{
-                            marginTop: "24px",
-                            borderTop: "1px solid var(--border)",
-                            paddingTop: "16px",
-                        }}
-                    >
-                        <p
-                            style={{
-                                fontSize: "13px",
-                                color: "var(--muted-foreground)",
-                                marginBottom: "8px",
-                            }}
-                        >
-                            导出训练数据
-                        </p>
-                        <div style={{ display: "flex", gap: "8px" }}>
+                    <div className="quiz-section">
+                        <p className="quiz-section__title">导出训练数据</p>
+                        <div className="quiz-export">
                             {(["jsonl", "csv", "sft"] as const).map((fmt) => (
                                 <button
                                     key={fmt}
+                                    className="quiz-export__btn"
                                     onClick={() => handleExport(fmt)}
-                                    style={{
-                                        flex: 1,
-                                        padding: "8px",
-                                        borderRadius: "8px",
-                                        background: "var(--card)",
-                                        color: "var(--muted-foreground)",
-                                        border: "1px solid var(--border)",
-                                        cursor: "pointer",
-                                        fontSize: "13px",
-                                        fontWeight: 600,
-                                        textTransform: "uppercase",
-                                    }}
                                 >
-                                    <Download
-                                        size={14}
-                                        style={{ display: "inline", marginRight: "4px" }}
-                                    />
+                                    <Download size={13} />
                                     {fmt}
                                 </button>
                             ))}
                         </div>
                     </div>
 
-                    {/* History section */}
-                    <div
-                        style={{
-                            marginTop: "24px",
-                            borderTop: "1px solid var(--border)",
-                            paddingTop: "16px",
-                        }}
-                    >
+                    <div className="quiz-section">
                         <button
+                            className="quiz-section__toggle"
+                            data-open={showHistory}
                             onClick={() => {
                                 const willShow = !showHistory;
                                 setShowHistory(willShow);
                                 if (willShow) fetchHistory();
                             }}
-                            style={{
-                                display: "flex",
-                                alignItems: "center",
-                                gap: "6px",
-                                background: "none",
-                                border: "none",
-                                color: "var(--muted-foreground)",
-                                cursor: "pointer",
-                                fontSize: "13px",
-                                fontWeight: 600,
-                                padding: 0,
-                                marginBottom: showHistory ? "12px" : 0,
-                            }}
                         >
-                            <History size={14} />
+                            <History size={13} />
                             题目历史
-                            <span style={{ fontSize: "11px", transform: showHistory ? "rotate(90deg)" : "rotate(0deg)", transition: "transform 0.2s" }}>
-                                ▶
-                            </span>
+                            <span className="quiz-section__caret">▶</span>
                         </button>
 
                         {showHistory && (
                             loadingHistory ? (
-                                <div style={{ display: "flex", alignItems: "center", gap: "8px", padding: "12px", color: "var(--muted-foreground)", fontSize: "13px" }}>
+                                <div className="quiz-loading">
                                     <Loader2 size={14} className="animate-spin" />
                                     加载历史...
                                 </div>
                             ) : historyItems.length === 0 ? (
-                                <div style={{ padding: "12px", color: "var(--muted-foreground)", fontSize: "13px", textAlign: "center" }}>
-                                    暂无历史记录
-                                </div>
+                                <div className="quiz-empty">暂无历史记录</div>
                             ) : (
-                                <div style={{ maxHeight: "260px", overflow: "auto", borderRadius: "10px", border: "1px solid var(--border)" }}>
+                                <div className="quiz-history">
                                     {historyItems.map((item) => (
-                                        <div
-                                            key={item.quiz_uuid}
-                                            style={{
-                                                display: "flex",
-                                                alignItems: "center",
-                                                justifyContent: "space-between",
-                                                padding: "10px 14px",
-                                                borderBottom: "1px solid var(--border)",
-                                            }}
-                                        >
-                                            <div style={{ flex: 1, minWidth: 0 }}>
-                                                <div style={{ fontSize: "13px", fontWeight: 500, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                                                    {item.title}
-                                                </div>
-                                                <div style={{ fontSize: "11px", color: "var(--muted-foreground)", marginTop: "2px" }}>
-                                                    {item.question_count ?? item.total_question_count} 题
+                                        <div key={item.quiz_uuid} className="quiz-history__item">
+                                            <div className="quiz-history__info">
+                                                <div className="quiz-history__title">{item.title}</div>
+                                                <div className="quiz-history__meta">
+                                                    <span>{item.question_count ?? item.total_question_count} 题</span>
                                                     {item.submission_uuid ? (
                                                         <>
-                                                            {item.score != null && ` · ${item.score}分`}
-                                                            {item.passed != null && (item.passed ? " · 通过" : " · 未通过")}
+                                                            <span className="quiz-history__meta-dot" />
+                                                            <span className="quiz-history__score" data-tone={item.passed ? "pass" : "fail"}>
+                                                                {item.score != null ? `${item.score}分` : item.passed ? "通过" : "未通过"}
+                                                            </span>
                                                         </>
                                                     ) : (
-                                                        " · 未作答"
+                                                        <>
+                                                            <span className="quiz-history__meta-dot" />
+                                                            <span className="quiz-history__score" data-tone="idle">未作答</span>
+                                                        </>
                                                     )}
-                                                    {item.created_at && ` · ${new Date(item.created_at).toLocaleDateString()}`}
+                                                    {item.created_at && (
+                                                        <>
+                                                            <span className="quiz-history__meta-dot" />
+                                                            <span>{new Date(item.created_at).toLocaleDateString()}</span>
+                                                        </>
+                                                    )}
                                                 </div>
                                             </div>
-                                            <div style={{ display: "flex", gap: "6px", flexShrink: 0, marginLeft: "8px" }}>
+                                            <div className="quiz-history__actions">
                                                 <button
+                                                    className="quiz-history__btn"
+                                                    data-variant="primary"
                                                     onClick={() => handleRetakeQuiz(item.quiz_uuid)}
-                                                    style={{
-                                                        padding: "5px 10px",
-                                                        borderRadius: "6px",
-                                                        background: "var(--accent)",
-                                                        color: "#fff",
-                                                        border: "none",
-                                                        cursor: "pointer",
-                                                        fontSize: "12px",
-                                                        fontWeight: 600,
-                                                    }}
                                                 >
                                                     重做
                                                 </button>
                                                 <button
+                                                    className="quiz-history__btn"
                                                     onClick={() => handleViewPastQuiz(item.quiz_uuid)}
-                                                    style={{
-                                                        padding: "5px 10px",
-                                                        borderRadius: "6px",
-                                                        background: "var(--card)",
-                                                        color: "var(--accent)",
-                                                        border: "1px solid rgba(6,182,212,0.25)",
-                                                        cursor: "pointer",
-                                                        fontSize: "12px",
-                                                        fontWeight: 600,
-                                                    }}
                                                 >
-                                                    <Eye size={12} style={{ display: "inline", marginRight: "3px" }} />
+                                                    <Eye size={12} />
                                                     查看
                                                 </button>
                                                 <button
-                                                    onClick={() => handleDownloadQuiz(item.quiz_uuid, item.title)}
-                                                    style={{
-                                                        padding: "5px 10px",
-                                                        borderRadius: "6px",
-                                                        background: "var(--card)",
-                                                        color: "var(--muted-foreground)",
-                                                        border: "1px solid var(--border)",
-                                                        cursor: "pointer",
-                                                        fontSize: "12px",
-                                                        fontWeight: 600,
-                                                    }}
+                                                    className="quiz-history__btn"
+                                                    onClick={() => handleOpenShare(item.quiz_uuid)}
+                                                    title="分享"
                                                 >
-                                                    <Download size={12} style={{ display: "inline", marginRight: "3px" }} />
-                                                    下载
+                                                    <Share2 size={12} />
+                                                    分享
                                                 </button>
                                                 <button
+                                                    className="quiz-history__btn"
+                                                    onClick={() => handleDownloadQuiz(item.quiz_uuid, item.title)}
+                                                >
+                                                    <Download size={12} />
+                                                </button>
+                                                <button
+                                                    className="quiz-history__btn"
+                                                    data-variant="danger"
                                                     onClick={() => handleDeleteQuiz(item)}
                                                     disabled={deletingQuizUuid === item.quiz_uuid}
-                                                    style={{
-                                                        padding: "5px 10px",
-                                                        borderRadius: "6px",
-                                                        background: "var(--danger-bg)",
-                                                        color: "var(--danger)",
-                                                        border: "1px solid var(--danger)",
-                                                        cursor: deletingQuizUuid === item.quiz_uuid ? "not-allowed" : "pointer",
-                                                        fontSize: "12px",
-                                                        fontWeight: 600,
-                                                        opacity: deletingQuizUuid === item.quiz_uuid ? 0.6 : 1,
-                                                    }}
                                                 >
                                                     {deletingQuizUuid === item.quiz_uuid ? (
-                                                        <Loader2 size={12} className="animate-spin" style={{ display: "inline", marginRight: "3px" }} />
+                                                        <Loader2 size={12} className="animate-spin" />
                                                     ) : (
-                                                        <Trash2 size={12} style={{ display: "inline", marginRight: "3px" }} />
+                                                        <Trash2 size={12} />
                                                     )}
-                                                    {deletingQuizUuid === item.quiz_uuid ? "删除中" : "删除"}
                                                 </button>
                                             </div>
                                         </div>
@@ -1000,105 +795,76 @@ export default function QuizPanel({ isOpen }: DockPanelProps) {
                             )
                         )}
                     </div>
+                <ShareModal
+                    open={!!shareModalUuid}
+                    loading={shareLoading}
+                    status={shareStatus}
+                    error={shareError}
+                    duration={shareDuration}
+                    copied={copied}
+                    onDurationChange={setShareDuration}
+                    onCreate={handleCreateShare}
+                    onRevoke={handleRevokeShare}
+                    onCopy={handleCopyShareLink}
+                    onClose={handleCloseShare}
+                    shareUrl={shareStatus?.share_token ? shareUrl(shareStatus.share_token) : ""}
+                />
                 </div>
             ) : (
-                /* ────── Quiz Questions ────── */
                 <div>
-                    <div
-                        style={{
-                            display: "flex",
-                            alignItems: "center",
-                            justifyContent: "space-between",
-                            marginBottom: "16px",
-                        }}
-                    >
-                        <div>
-                            <h4 style={{ margin: 0, fontSize: "16px" }}>
-                                {isReviewMode && (
-                                    <span style={{ fontSize: "11px", padding: "2px 8px", borderRadius: "6px", background: "rgba(6,182,212,0.12)", color: "var(--accent)", marginRight: "8px", fontWeight: 600 }}>
-                                        回看
-                                    </span>
+                    <div className="quiz-run__head">
+                        <div className="quiz-run__title-block">
+                            <div>
+                                {isReviewMode && <span className="quiz-run__chip">回看</span>}
+                                <h4 className="quiz-run__title">{currentQuiz.title}</h4>
+                            </div>
+                            <div className="quiz-run__sub">
+                                <span>{currentQuiz.question_count} 题</span>
+                                <span className="quiz-history__meta-dot" />
+                                <span>{DIFFICULTY_LABELS[currentQuiz.difficulty] || currentQuiz.difficulty}</span>
+                                {currentQuiz.source_type === "pages" && (
+                                    <>
+                                        <span className="quiz-history__meta-dot" />
+                                        <span>按分P</span>
+                                    </>
                                 )}
-                                {currentQuiz.title}
-                            </h4>
-                            <span style={{ fontSize: "12px", color: "var(--muted-foreground)" }}>
-                                {currentQuiz.question_count} 题 · {currentQuiz.difficulty}
-                                {currentQuiz.source_type === "pages" && " · 按分P"}
-                            </span>
+                            </div>
                         </div>
-                        <div style={{ display: "flex", gap: "8px" }}>
+                        <div className="quiz-run__actions">
                             {!submitResult && !isReviewMode && (
                                 <button
+                                    className="quiz-btn"
+                                    data-variant="primary"
                                     onClick={handleSubmit}
                                     disabled={!isAllAnswered || submitting}
-                                    style={{
-                                        padding: "8px 20px",
-                                        borderRadius: "8px",
-                                        fontWeight: 700,
-                                        cursor: isAllAnswered && !submitting ? "pointer" : "not-allowed",
-                                        background: "var(--accent)",
-                                        color: "#0d1117",
-                                        border: "none",
-                                        opacity: isAllAnswered && !submitting ? 1 : 0.5,
-                                    }}
                                 >
                                     {submitting ? (
-                                        <span
-                                            style={{
-                                                display: "flex",
-                                                alignItems: "center",
-                                                gap: "6px",
-                                            }}
-                                        >
+                                        <>
                                             <Loader2 size={14} className="animate-spin" />
                                             批改中
-                                        </span>
+                                        </>
                                     ) : (
-                                        `交卷 (${userAnswers.size}/${currentQuiz.questions.length})`
+                                        `交卷 · ${userAnswers.size}/${currentQuiz.questions.length}`
                                     )}
                                 </button>
                             )}
                             {(submitResult || isReviewMode) && (
-                                <button
-                                    onClick={handleBackToGenerate}
-                                    style={{
-                                        padding: "8px 16px",
-                                        borderRadius: "8px",
-                                        cursor: "pointer",
-                                        background: "var(--card)",
-                                        color: "var(--muted-foreground)",
-                                        border: "1px solid var(--border)",
-                                        fontWeight: 600,
-                                        fontSize: "13px",
-                                    }}
-                                >
-                                    <ArrowLeft size={14} style={{ display: "inline", marginRight: "4px" }} />
+                                <button className="quiz-btn" onClick={handleBackToGenerate}>
+                                    <ArrowLeft size={14} />
                                     返回
                                 </button>
                             )}
                             <button
-                                onClick={() =>
-                                    handleDownloadQuiz(currentQuiz.quiz_uuid, currentQuiz.title)
-                                }
-                                style={{
-                                    padding: "8px 16px",
-                                    borderRadius: "8px",
-                                    cursor: "pointer",
-                                    background: "var(--card)",
-                                    color: "var(--muted-foreground)",
-                                    border: "1px solid var(--border)",
-                                    fontWeight: 600,
-                                    fontSize: "13px",
-                                }}
+                                className="quiz-btn"
+                                onClick={() => handleDownloadQuiz(currentQuiz.quiz_uuid, currentQuiz.title)}
                             >
-                                <Download size={14} style={{ display: "inline", marginRight: "4px" }} />
+                                <Download size={14} />
                                 下载
                             </button>
                         </div>
                     </div>
 
                     {currentQuiz.questions.map((q, i) => {
-                        // In review mode, create a pseudo-result to show correct answers
                         const reviewResult: QuizAnswerResult | undefined = isReviewMode
                             ? {
                                   question_uuid: q.question_uuid,
@@ -1130,55 +896,11 @@ export default function QuizPanel({ isOpen }: DockPanelProps) {
                         );
                     })}
 
-                    {/* Result summary */}
                     {submitResult && (
-                        <div
-                            style={{
-                                padding: "16px",
-                                borderRadius: "12px",
-                                textAlign: "center",
-                                background: submitResult.passed
-                                    ? "var(--success-bg)"
-                                    : "var(--danger-bg)",
-                                border: `1px solid ${
-                                    submitResult.passed ? "var(--success)" : "var(--danger)"
-                                }`,
-                            }}
-                        >
-                            <p
-                                style={{
-                                    fontSize: "20px",
-                                    fontWeight: 700,
-                                    color: submitResult.passed
-                                        ? "var(--success)"
-                                        : "var(--danger)",
-                                    margin: 0,
-                                }}
-                            >
-                                {submitResult.score} 分 -{" "}
-                                {submitResult.passed ? "通过" : "未通过"}
-                            </p>
-                            <p style={{ color: "var(--muted-foreground)", margin: "8px 0 0" }}>
-                                {submitResult.correct_count}/{submitResult.total_count} 正确
-                            </p>
-                            <div style={{ display: "flex", gap: "8px", justifyContent: "center", marginTop: "12px" }}>
-                                <button
-                                    onClick={handleBackToGenerate}
-                                    style={{
-                                        padding: "8px 20px",
-                                        borderRadius: "8px",
-                                        background:
-                                            "linear-gradient(180deg, rgba(6,182,212,0.18) 0%, rgba(6,182,212,0.1) 100%)",
-                                        color: "var(--accent)",
-                                        border: "1px solid rgba(6,182,212,0.25)",
-                                        cursor: "pointer",
-                                        fontWeight: 600,
-                                    }}
-                                >
-                                    再做一套
-                                </button>
-                            </div>
-                        </div>
+                        <ResultScorecard
+                            result={submitResult}
+                            onRetry={handleBackToGenerate}
+                        />
                     )}
                 </div>
             )}
@@ -1186,7 +908,7 @@ export default function QuizPanel({ isOpen }: DockPanelProps) {
     );
 }
 
-/* ────── Generate Button (reusable) ────── */
+/* ────── Generate Button ────── */
 
 function GenerateButton({
     generating,
@@ -1201,30 +923,13 @@ function GenerateButton({
 }) {
     return (
         <button
+            className="quiz-cta"
             disabled={generating || disabled}
             onClick={onClick}
-            style={{
-                width: "100%",
-                padding: "12px",
-                borderRadius: "10px",
-                fontWeight: 700,
-                cursor: generating || disabled ? "not-allowed" : "pointer",
-                background: "linear-gradient(180deg, rgba(6,182,212,0.18) 0%, rgba(6,182,212,0.1) 100%)",
-                color: "var(--accent)",
-                border: "1px solid rgba(6,182,212,0.25)",
-                opacity: generating || disabled ? 0.5 : 1,
-                marginBottom: "8px",
-            }}
+            style={{ marginBottom: "8px" }}
         >
             {generating ? (
-                <span
-                    style={{
-                        display: "flex",
-                        alignItems: "center",
-                        justifyContent: "center",
-                        gap: "8px",
-                    }}
-                >
+                <span className="quiz-cta__inner">
                     <Loader2 size={16} className="animate-spin" />
                     AI 正在出题...
                 </span>
@@ -1255,149 +960,116 @@ function QuizQuestionCard({
     const isMulti = question.question_type === "multi_choice";
     const showResult = !!result;
     const isCorrect = result?.is_correct;
-    const hasGradingNote = !!result?.grading_note;
+
+    const cardState = !showResult
+        ? "default"
+        : isCorrect === true
+        ? "correct"
+        : isCorrect === false
+        ? "wrong"
+        : "partial";
+
+    const feedbackTone =
+        isCorrect === true ? "correct" : isCorrect === false ? "wrong" : "partial";
+
+    const correctKeys = ((): string[] => {
+        if (!showResult) return [];
+        const ans = result!.correct_answer;
+        const arr = Array.isArray(ans) ? ans : [String(ans)];
+        return arr
+            .map((s) => String(s).trim().toUpperCase()[0])
+            .filter((c): c is string => !!c);
+    })();
+
+    const formatCorrectAnswer = (): string => {
+        if (!result) return "";
+        return Array.isArray(result.correct_answer)
+            ? result.correct_answer.join(", ")
+            : String(result.correct_answer);
+    };
 
     return (
-        <div
-            style={{
-                background: "var(--card)",
-                border: `1px solid ${
-                    showResult && isCorrect === false ? "var(--danger)" : "var(--border)"
-                }`,
-                borderRadius: "12px",
-                padding: "16px",
-                marginBottom: "12px",
-            }}
+        <article
+            className="quiz-card"
+            data-type={question.question_type}
+            data-state={cardState}
+            style={{ animationDelay: `${Math.min(index, 8) * 40}ms` }}
         >
-            {/* Header */}
-            <div
-                style={{
-                    display: "flex",
-                    alignItems: "center",
-                    gap: "8px",
-                    marginBottom: "12px",
-                }}
-            >
-                <span style={{ fontWeight: 700, color: "var(--foreground)" }}>
-                    Q{index + 1}.
+            <header className="quiz-card__head">
+                <span className="quiz-card__index">
+                    Q{String(index + 1).padStart(2, "0")}
                 </span>
-                <span
-                    style={{
-                        fontSize: "11px",
-                        padding: "2px 8px",
-                        borderRadius: "6px",
-                        background: "rgba(6, 182, 212, 0.1)",
-                        color: "var(--accent)",
-                        fontWeight: 600,
-                    }}
-                >
+                <span className="quiz-card__type">
                     {TYPE_LABELS[question.question_type] || question.question_type}
                 </span>
+                <span className="quiz-card__difficulty">
+                    {DIFFICULTY_LABELS[question.difficulty] || question.difficulty}
+                </span>
                 {showResult && (
-                    <span style={{ marginLeft: "auto" }}>
-                        {isCorrect ? (
+                    <span className="quiz-card__status">
+                        {isCorrect === true ? (
                             <CheckCircle size={18} style={{ color: "var(--success)" }} />
-                        ) : (
+                        ) : isCorrect === false ? (
                             <XCircle size={18} style={{ color: "var(--danger)" }} />
-                        )}
+                        ) : null}
                     </span>
                 )}
-            </div>
+            </header>
 
-            {/* Question text */}
-            <p
-                style={{
-                    color: "var(--foreground)",
-                    marginBottom: "12px",
-                    lineHeight: 1.6,
-                }}
-            >
-                {question.question_text}
-            </p>
+            <p className="quiz-card__text">{question.question_text}</p>
 
-            {/* Options (choice questions) */}
-            {question.options?.map((opt, i) => {
-                const optKey = opt[0];
-                const isSelected = Array.isArray(userAnswer)
-                    ? userAnswer.includes(optKey)
-                    : userAnswer === optKey;
+            {question.options && question.options.length > 0 && (
+                <div className="quiz-options">
+                    {question.options.map((opt, i) => {
+                        const optKey = opt[0];
+                        const isSelected = Array.isArray(userAnswer)
+                            ? userAnswer.includes(optKey)
+                            : userAnswer === optKey;
 
-                let bgColor = "var(--card)";
-                let borderColor = "var(--border)";
-                if (showResult) {
-                    const correctAnswer = result!.correct_answer;
-                    const correctKeys = Array.isArray(correctAnswer)
-                        ? correctAnswer.map((s: string) =>
-                              String(s).trim().toUpperCase()[0]
-                          )
-                        : [String(correctAnswer).trim().toUpperCase()[0]];
-                    if (correctKeys.includes(optKey)) {
-                        bgColor = "var(--success-bg)";
-                        borderColor = "var(--success)";
-                    } else if (isSelected && !correctKeys.includes(optKey)) {
-                        bgColor = "var(--danger-bg)";
-                        borderColor = "var(--danger)";
-                    }
-                } else if (isSelected) {
-                    borderColor = "var(--accent)";
-                }
+                        let optState: "default" | "selected" | "correct" | "wrong" = "default";
+                        if (showResult) {
+                            if (correctKeys.includes(optKey)) optState = "correct";
+                            else if (isSelected) optState = "wrong";
+                        } else if (isSelected) {
+                            optState = "selected";
+                        }
 
-                return (
-                    <label
-                        key={i}
-                        style={{
-                            display: "flex",
-                            alignItems: "center",
-                            gap: "10px",
-                            padding: "10px 12px",
-                            borderRadius: "8px",
-                            background: bgColor,
-                            border: `1px solid ${borderColor}`,
-                            cursor: disabled ? "default" : "pointer",
-                            marginBottom: "6px",
-                        }}
-                    >
-                        <input
-                            type={isMulti ? "checkbox" : "radio"}
-                            name={`q-${question.question_uuid}`}
-                            checked={isSelected}
-                            disabled={disabled}
-                            onChange={() => {
-                                if (isMulti) {
-                                    const arr = Array.isArray(userAnswer)
-                                        ? [...userAnswer]
-                                        : [];
-                                    arr.includes(optKey)
-                                        ? arr.splice(arr.indexOf(optKey), 1)
-                                        : arr.push(optKey);
-                                    onAnswer(question.question_uuid, arr);
-                                } else {
-                                    onAnswer(question.question_uuid, optKey);
-                                }
-                            }}
-                            style={{ accentColor: "var(--accent)" }}
-                        />
-                        <span style={{ color: "var(--foreground)", fontSize: "14px" }}>
-                            {opt}
-                        </span>
-                    </label>
-                );
-            })}
+                        return (
+                            <label
+                                key={i}
+                                className="quiz-option"
+                                data-selected={optState === "selected"}
+                                data-state={optState === "correct" || optState === "wrong" ? optState : undefined}
+                            >
+                                <input
+                                    type={isMulti ? "checkbox" : "radio"}
+                                    className="quiz-option__native"
+                                    name={`q-${question.question_uuid}`}
+                                    checked={isSelected}
+                                    disabled={disabled}
+                                    onChange={() => {
+                                        if (isMulti) {
+                                            const arr = Array.isArray(userAnswer) ? [...userAnswer] : [];
+                                            arr.includes(optKey)
+                                                ? arr.splice(arr.indexOf(optKey), 1)
+                                                : arr.push(optKey);
+                                            onAnswer(question.question_uuid, arr);
+                                        } else {
+                                            onAnswer(question.question_uuid, optKey);
+                                        }
+                                    }}
+                                />
+                                <span className="quiz-option__badge">{optKey}</span>
+                                <span className="quiz-option__text">{opt}</span>
+                            </label>
+                        );
+                    })}
+                </div>
+            )}
 
-            {/* Text input for short_answer / essay */}
             {!question.options && (
                 <textarea
-                    style={{
-                        width: "100%",
-                        minHeight: "100px",
-                        padding: "10px 12px",
-                        borderRadius: "8px",
-                        background: "var(--background)",
-                        color: "var(--foreground)",
-                        border: "1px solid var(--border)",
-                        resize: "vertical",
-                        fontFamily: "inherit",
-                    }}
+                    className="quiz-textarea"
                     placeholder="请输入答案..."
                     value={(userAnswer as string) ?? ""}
                     onChange={(e) => onAnswer(question.question_uuid, e.target.value)}
@@ -1405,81 +1077,92 @@ function QuizQuestionCard({
                 />
             )}
 
-            {/* Result feedback */}
             {showResult && (
-                <div
-                    style={{
-                        marginTop: "12px",
-                        padding: "10px 12px",
-                        borderRadius: "8px",
-                        background: isCorrect === false
-                            ? "var(--danger-bg)"
-                            : isCorrect === true
-                            ? "var(--success-bg)"
-                            : "rgba(6,182,212,0.08)",
-                        border: `1px solid ${
-                            isCorrect === false ? "var(--danger)"
-                            : isCorrect === true ? "var(--success)"
-                            : "rgba(6,182,212,0.25)"
-                        }`,
-                    }}
-                >
-                    {isCorrect === true ? (
-                        <span style={{ color: "var(--success)", fontWeight: 600 }}>
-                            ✓ 正确
-                        </span>
-                    ) : isCorrect === false ? (
-                        <>
-                            <span style={{ color: "var(--danger)", fontWeight: 600 }}>
-                                ✗
-                            </span>
-                            <span
-                                style={{
-                                    color: "var(--muted-foreground)",
-                                    marginLeft: "8px",
-                                }}
-                            >
-                                正确答案：
-                                {Array.isArray(result!.correct_answer)
-                                    ? result!.correct_answer.join(", ")
-                                    : String(result!.correct_answer)}
-                            </span>
-                        </>
-                    ) : (
-                        <span style={{ color: "var(--accent)", fontWeight: 600 }}>
-                            正确答案：
-                            {Array.isArray(result!.correct_answer)
-                                ? result!.correct_answer.join(", ")
-                                : String(result!.correct_answer)}
-                        </span>
-                    )}
-                    {hasGradingNote && (
-                        <span
-                            style={{
-                                marginLeft: "8px",
-                                fontSize: "11px",
-                                color: "var(--warning)",
-                                fontWeight: 600,
-                            }}
-                        >
-                            {result!.grading_note}
-                        </span>
-                    )}
+                <div className="quiz-feedback" data-tone={feedbackTone}>
+                    <div className="quiz-feedback__line">
+                        {isCorrect === true ? (
+                            <span className="quiz-feedback__tag">✓ 正确</span>
+                        ) : isCorrect === false ? (
+                            <>
+                                <span className="quiz-feedback__tag">✗ 错误</span>
+                                <span className="quiz-feedback__answer-label">正确答案：</span>
+                                <span className="quiz-feedback__answer">{formatCorrectAnswer()}</span>
+                            </>
+                        ) : (
+                            <>
+                                <span className="quiz-feedback__tag">参考答案</span>
+                                <span className="quiz-feedback__answer">{formatCorrectAnswer()}</span>
+                            </>
+                        )}
+                        {result?.grading_note && (
+                            <span className="quiz-feedback__note">{result.grading_note}</span>
+                        )}
+                    </div>
                     {question.explanation && (
-                        <p style={{
-                            margin: "8px 0 0",
-                            fontSize: "12px",
-                            color: "var(--muted-foreground)",
-                            lineHeight: 1.6,
-                            borderTop: "1px solid var(--border)",
-                            paddingTop: "8px",
-                        }}>
-                            <span style={{ fontWeight: 600 }}>解析：</span>
+                        <div className="quiz-feedback__explanation">
+                            <span className="quiz-feedback__explanation-tag">解析</span>
                             {question.explanation}
-                        </p>
+                        </div>
                     )}
                 </div>
             )}
+        </article>
+    );
+}
+
+/* ────── Result Scorecard ────── */
+
+function ResultScorecard({
+    result,
+    onRetry,
+}: {
+    result: QuizSubmissionResult;
+    onRetry: () => void;
+}) {
+    const passed = result.passed === true;
+    const score = result.score ?? 0;
+    const total = result.total_count || 1;
+    const correct = result.correct_count;
+    const ratio = Math.max(0, Math.min(1, score / 100));
+    const RING_C = 2 * Math.PI * 52; // radius 52
+
+    return (
+        <div className="quiz-result" data-passed={String(passed)}>
+            <span className="quiz-result__stamp">
+                {passed ? "Passed" : "Failed"}
+            </span>
+
+            <div className="quiz-result__ring">
+                <svg width="120" height="120" viewBox="0 0 120 120">
+                    <circle className="quiz-result__ring-bg" cx="60" cy="60" r="52" />
+                    <circle
+                        className="quiz-result__ring-fg"
+                        cx="60"
+                        cy="60"
+                        r="52"
+                        strokeDasharray={RING_C}
+                        strokeDashoffset={RING_C * (1 - ratio)}
+                    />
+                </svg>
+                <div className="quiz-result__score">
+                    <span className="quiz-result__score-num">{score}</span>
+                    <span className="quiz-result__score-unit">/ 100</span>
+                </div>
+            </div>
+
+            <p className="quiz-result__verdict">
+                {passed ? "考核通过" : "未通过"}
+            </p>
+            <p className="quiz-result__detail">
+                正确 <strong>{correct}</strong> / {total} · 得分率{" "}
+                <strong>{Math.round(ratio * 100)}%</strong>
+            </p>
+
+            <div className="quiz-result__actions">
+                <button className="quiz-btn" data-variant="primary" onClick={onRetry}>
+                    再做一套
+                </button>
+            </div>
         </div>
     );
 }
@@ -1496,7 +1179,259 @@ async function pollUntilReady(
         if (quiz.status === "done") return quiz;
         if (quiz.status === "failed") throw new Error("题目生成失败");
         await new Promise((resolve) => setTimeout(resolve, delay));
-        delay = Math.min(delay * 2, 16000);  // exponential backoff: 2s → 16s cap
+        delay = Math.min(delay * 2, 16000);
     }
     throw new Error("题目生成超时");
+}
+
+interface ShareModalProps {
+    open: boolean;
+    loading: boolean;
+    status: QuizShareStatus | null;
+    error: string | null;
+    duration: number | "";
+    copied: boolean;
+    onDurationChange: (v: number | "") => void;
+    onCreate: () => void;
+    onRevoke: () => void;
+    onCopy: () => void;
+    onClose: () => void;
+    shareUrl: string;
+}
+
+function ShareModal({
+    open,
+    loading,
+    status,
+    error,
+    duration,
+    copied,
+    onDurationChange,
+    onCreate,
+    onRevoke,
+    onCopy,
+    onClose,
+    shareUrl,
+}: ShareModalProps) {
+    const isShared = status?.shared && !status.expired;
+    const isExpired = status?.shared && status.expired;
+    const isIdle = status && !isShared && !isExpired;
+
+    const pillTone = isShared ? "live" : isExpired ? "expired" : "idle";
+    const pillLabel = isShared ? "已分享 · 在线" : isExpired ? "已过期" : "未分享";
+
+    const formatTime = (t?: string | null): string => {
+        if (!t) return "—";
+        const d = new Date(t);
+        if (isNaN(d.getTime())) return "—";
+        return d.toLocaleString("zh-CN", {
+            month: "2-digit",
+            day: "2-digit",
+            hour: "2-digit",
+            minute: "2-digit",
+        });
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={(o) => { if (!o) onClose(); }}>
+            <DialogContent
+                className="quiz-share-dialog sm:max-w-[460px] gap-0 p-0 overflow-hidden"
+                showCloseButton
+            >
+                <header className="quiz-share__header">
+                    <span className="quiz-share__icon-wrap">
+                        <Share2 size={18} />
+                    </span>
+                    <DialogHeader className="gap-0">
+                        <DialogTitle className="quiz-share__title">分享题目</DialogTitle>
+                        <DialogDescription className="quiz-share__subtitle">
+                            生成链接即可让他人在浏览器自测
+                        </DialogDescription>
+                    </DialogHeader>
+                </header>
+
+                <div className="quiz-share__body">
+                    <span className="quiz-share__pill" data-tone={pillTone}>
+                        {isShared ? (
+                            <CheckCircle size={12} />
+                        ) : isExpired ? (
+                            <CircleAlert size={12} />
+                        ) : (
+                            <span className="quiz-share__pill-dot" />
+                        )}
+                        {pillLabel}
+                    </span>
+
+                    {loading && !status && (
+                        <div className="quiz-share__loading">
+                            <Loader2 size={16} className="animate-spin" />
+                            加载分享状态...
+                        </div>
+                    )}
+
+                    {error && (
+                        <div className="quiz-share__callout" data-tone="error">
+                            <span>{error}</span>
+                        </div>
+                    )}
+
+                    {isIdle && (
+                        <>
+                            <p className="quiz-share__desc">
+                                当前题目集未分享。生成链接后，任何人可通过链接查看题目用于自测（不含答案与解析）。
+                            </p>
+                            <div className="quiz-share__field">
+                                <label className="quiz-share__label">有效期</label>
+                                <div className="quiz-chips">
+                                    {([
+                                        { v: "", label: "永久" },
+                                        { v: 1, label: "1 天" },
+                                        { v: 7, label: "7 天" },
+                                        { v: 30, label: "30 天" },
+                                        { v: 365, label: "365 天" },
+                                    ] as const).map((opt) => (
+                                        <button
+                                            key={String(opt.v)}
+                                            type="button"
+                                            className="quiz-chip"
+                                            data-selected={duration === opt.v}
+                                            onClick={() => onDurationChange(opt.v)}
+                                        >
+                                            {opt.label}
+                                        </button>
+                                    ))}
+                                </div>
+                            </div>
+                            <button
+                                className="quiz-share__cta"
+                                onClick={onCreate}
+                                disabled={loading}
+                            >
+                                {loading ? (
+                                    <>
+                                        <Loader2 size={14} className="animate-spin" />
+                                        生成中...
+                                    </>
+                                ) : (
+                                    <>
+                                        <LinkIcon size={14} />
+                                        生成分享链接
+                                    </>
+                                )}
+                            </button>
+                        </>
+                    )}
+
+                    {(isShared || isExpired) && status && (
+                        <>
+                            {isExpired && (
+                                <div className="quiz-share__callout" data-tone="warning">
+                                    <CircleAlert size={14} style={{ flexShrink: 0, marginTop: 1 }} />
+                                    <span>此分享链接已过期，可重新生成以恢复访问。</span>
+                                </div>
+                            )}
+
+                            <div className="quiz-ticket" data-state={isShared ? "live" : "expired"}>
+                                <div className="quiz-ticket__head">
+                                    <div className="quiz-ticket__title-row">
+                                        <span className="quiz-ticket__icon">
+                                            <LinkIcon size={13} />
+                                        </span>
+                                        <span className="quiz-ticket__label">分享链接</span>
+                                    </div>
+                                    {isShared && (
+                                        <span className="quiz-ticket__badge">
+                                            <span className="quiz-ticket__badge-dot" />
+                                            LIVE
+                                        </span>
+                                    )}
+                                </div>
+                                <div className="quiz-ticket__url-row">
+                                    <input
+                                        readOnly
+                                        className="quiz-ticket__url"
+                                        value={shareUrl}
+                                        onFocus={(e) => e.target.select()}
+                                        aria-label="分享链接"
+                                    />
+                                </div>
+                                <button
+                                    className="quiz-ticket__copy"
+                                    data-copied={copied}
+                                    onClick={onCopy}
+                                    title="复制链接"
+                                >
+                                    {copied ? (
+                                        <>
+                                            <CheckCircle size={14} />
+                                            已复制
+                                        </>
+                                    ) : (
+                                        <>
+                                            <Copy size={14} />
+                                            复制链接
+                                        </>
+                                    )}
+                                </button>
+                            </div>
+
+                            <div className="quiz-share__meta">
+                                <div className="quiz-share__meta-cell">
+                                    <div className="quiz-share__meta-label">
+                                        <Share2 size={11} />
+                                        分享时间
+                                    </div>
+                                    <div className="quiz-share__meta-value">
+                                        {formatTime(status.shared_at)}
+                                    </div>
+                                </div>
+                                <div className="quiz-share__meta-cell">
+                                    <div className="quiz-share__meta-label">
+                                        <CircleAlert size={11} />
+                                        过期时间
+                                    </div>
+                                    <div className="quiz-share__meta-value">
+                                        {status.share_expires_at
+                                            ? formatTime(status.share_expires_at)
+                                            : "永不失效"}
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div className="quiz-share__actions">
+                                <button
+                                    className="quiz-share__btn"
+                                    onClick={onCreate}
+                                    disabled={loading}
+                                >
+                                    {loading ? (
+                                        <Loader2 size={13} className="animate-spin" />
+                                    ) : (
+                                        <LinkIcon size={13} />
+                                    )}
+                                    重新生成
+                                </button>
+                                <button
+                                    className="quiz-share__btn"
+                                    data-variant="danger"
+                                    onClick={onRevoke}
+                                    disabled={loading}
+                                >
+                                    <Trash2 size={13} />
+                                    撤销分享
+                                </button>
+                            </div>
+                        </>
+                    )}
+                </div>
+
+                <footer className="quiz-share__footer">
+                    <LinkIcon size={12} className="quiz-share__footer-icon" />
+                    <span>
+                        分享视图仅展示题目用于自测，不含正确答案与解析。重新生成或撤销会令旧链接立即失效。
+                    </span>
+                </footer>
+            </DialogContent>
+        </Dialog>
+    );
 }

--- a/frontend/components/quiz/SharedQuizView.tsx
+++ b/frontend/components/quiz/SharedQuizView.tsx
@@ -1,0 +1,326 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Plus_Jakarta_Sans, JetBrains_Mono } from "next/font/google";
+import { useTheme } from "@/components/ThemeProvider";
+import type { SharedQuizData, SharedQuizQuestion } from "@/lib/api";
+
+const jakarta = Plus_Jakarta_Sans({
+  subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
+  variable: "--sqv-sans",
+  display: "swap",
+});
+
+const jetbrains = JetBrains_Mono({
+  subsets: ["latin"],
+  weight: ["400", "500"],
+  variable: "--sqv-mono",
+  display: "swap",
+});
+
+interface SharedQuizViewProps {
+  quiz: SharedQuizData;
+}
+
+const TYPE_LABEL: Record<string, string> = {
+  single_choice: "单选题",
+  multi_choice: "多选题",
+  true_false: "判断题",
+  short_answer: "简答题",
+  essay: "论述题",
+};
+
+const DIFFICULTY_LABEL: Record<string, string> = {
+  easy: "基础",
+  medium: "进阶",
+  hard: "挑战",
+};
+
+function SunIcon() {
+  return (
+    <svg viewBox="0 0 20 20" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round">
+      <circle cx="10" cy="10" r="3.5" />
+      <path d="M10 1.5v2M10 16.5v2M3.4 3.4l1.4 1.4M15.2 15.2l1.4 1.4M1.5 10h2M16.5 10h2M3.4 16.6l1.4-1.4M15.2 4.8l1.4-1.4" />
+    </svg>
+  );
+}
+
+function MoonIcon() {
+  return (
+    <svg viewBox="0 0 20 20" width="16" height="16" fill="currentColor">
+      <path d="M17.3 13.5a7.4 7.4 0 0 1-9.8-9.8 7.4 7.4 0 1 0 9.8 9.8Z" />
+    </svg>
+  );
+}
+
+export function SharedQuizView({ quiz }: SharedQuizViewProps) {
+  const [answers, setAnswers] = useState<Record<string, string | string[]>>({});
+  const { theme, toggle } = useTheme();
+
+  const totalAnswered = useMemo(
+    () =>
+      Object.values(answers).filter(
+        (v) =>
+          v !== undefined &&
+          v !== "" &&
+          !(Array.isArray(v) && v.length === 0),
+      ).length,
+    [answers],
+  );
+
+  const typeDistribution = useMemo(() => {
+    const dist: Record<string, number> = {};
+    for (const q of quiz.questions) {
+      dist[q.question_type] = (dist[q.question_type] ?? 0) + 1;
+    }
+    return dist;
+  }, [quiz.questions]);
+
+  const onSelectSingle = (qUuid: string, option: string) => {
+    setAnswers((prev) => ({ ...prev, [qUuid]: option }));
+  };
+  const onSelectMulti = (qUuid: string, option: string) => {
+    setAnswers((prev) => {
+      const cur = Array.isArray(prev[qUuid]) ? (prev[qUuid] as string[]) : [];
+      const next = cur.includes(option)
+        ? cur.filter((x) => x !== option)
+        : [...cur, option];
+      return { ...prev, [qUuid]: next };
+    });
+  };
+  const onTextChange = (qUuid: string, text: string) => {
+    setAnswers((prev) => ({ ...prev, [qUuid]: text }));
+  };
+
+  const sharedAt = quiz.shared_at ? new Date(quiz.shared_at) : null;
+  const progress =
+    quiz.questions.length === 0
+      ? 0
+      : Math.round((totalAnswered / quiz.questions.length) * 100);
+
+  return (
+    <div className={`sqv-root ${jakarta.variable} ${jetbrains.variable}`}>
+      {/* ── Theme toggle (floating, Apple style) ──── */}
+      <button
+        type="button"
+        onClick={toggle}
+        className="sqv-theme-toggle"
+        aria-label={theme === "dark" ? "切换到浅色" : "切换到深色"}
+        title={theme === "dark" ? "浅色模式" : "深色模式"}
+      >
+        {theme === "dark" ? <SunIcon /> : <MoonIcon />}
+      </button>
+
+      {/* ── Hero ───────────────────────────────────── */}
+      <header className="sqv-hero">
+        <div className="sqv-hero__inner">
+          <span className="sqv-eyebrow">
+            <span className="sqv-eyebrow__dot" />
+            共享题目集
+          </span>
+
+          <h1 className="sqv-hero__title">{quiz.title}</h1>
+
+          <p className="sqv-hero__subtitle">
+            {quiz.question_count} 道题目
+            {quiz.total_score > 0 && ` · 满分 ${quiz.total_score}`}
+            {sharedAt &&
+              ` · ${sharedAt.getFullYear()} 年 ${sharedAt.getMonth() + 1} 月 ${sharedAt.getDate()} 日分享`}
+          </p>
+
+          <div className="sqv-hero__chips">
+            <span className="sqv-chip">
+              {DIFFICULTY_LABEL[quiz.difficulty] ?? quiz.difficulty}
+            </span>
+            {Object.entries(typeDistribution).map(([t, n]) => (
+              <span key={t} className="sqv-chip sqv-chip--ghost">
+                {TYPE_LABEL[t] ?? t}
+                <span className="sqv-chip__count">{n}</span>
+              </span>
+            ))}
+          </div>
+        </div>
+      </header>
+
+      {/* ── Questions ──────────────────────────────── */}
+      <section className="sqv-list">
+        {quiz.questions.map((q, idx) => (
+          <QuestionCard
+            key={q.question_uuid}
+            index={idx + 1}
+            question={q}
+            answer={answers[q.question_uuid]}
+            onSelectSingle={(opt) => onSelectSingle(q.question_uuid, opt)}
+            onSelectMulti={(opt) => onSelectMulti(q.question_uuid, opt)}
+            onTextChange={(text) => onTextChange(q.question_uuid, text)}
+          />
+        ))}
+      </section>
+
+      {/* ── Foot note ──────────────────────────────── */}
+      <div className="sqv-footnote">
+        <p>
+          此为分享自测视图，仅展示题目。正确答案与解析不公开，
+          你的作答保留在浏览器内，不会上传。
+        </p>
+      </div>
+
+      {/* ── Sticky progress (Apple solid bar) ─────── */}
+      <div className="sqv-dock">
+        <div className="sqv-dock__inner">
+          <div className="sqv-dock__count">
+            <span className="sqv-dock__done">{totalAnswered}</span>
+            <span className="sqv-dock__sep">/</span>
+            <span className="sqv-dock__total">{quiz.questions.length}</span>
+            <span className="sqv-dock__label">已作答 · {progress}%</span>
+          </div>
+          <div className="sqv-dock__bar" aria-hidden>
+            <div
+              className="sqv-dock__fill"
+              style={{ width: `${progress}%` }}
+            />
+          </div>
+          <button
+            type="button"
+            className="sqv-dock__submit"
+            disabled
+            title="分享视图不提交批改"
+          >
+            提交
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface QuestionCardProps {
+  index: number;
+  question: SharedQuizQuestion;
+  answer: string | string[] | undefined;
+  onSelectSingle: (option: string) => void;
+  onSelectMulti: (option: string) => void;
+  onTextChange: (text: string) => void;
+}
+
+function QuestionCard({
+  index,
+  question,
+  answer,
+  onSelectSingle,
+  onSelectMulti,
+  onTextChange,
+}: QuestionCardProps) {
+  const qType = question.question_type;
+  const options = normalizeOptions(question.options);
+  const isMulti = qType === "multi_choice";
+  const isText = qType === "short_answer" || qType === "essay";
+
+  const selectedSet = useMemo(
+    () => new Set(Array.isArray(answer) ? answer : []),
+    [answer],
+  );
+  const hasAnswer = isMulti
+    ? selectedSet.size > 0
+    : isText
+      ? typeof answer === "string" && answer.trim() !== ""
+      : typeof answer === "string" && answer !== "";
+
+  return (
+    <article className={`sqv-q ${hasAnswer ? "sqv-q--done" : ""}`}>
+      <div className="sqv-q__head">
+        <span className="sqv-q__num">第 {index} 题</span>
+        <span className="sqv-q__dot" aria-hidden />
+        <span className="sqv-q__type">
+          {TYPE_LABEL[qType] ?? qType}
+        </span>
+        {question.difficulty && (
+          <>
+            <span className="sqv-q__dot" aria-hidden />
+            <span className="sqv-q__diff">
+              {DIFFICULTY_LABEL[question.difficulty] ?? question.difficulty}
+            </span>
+          </>
+        )}
+      </div>
+
+      <p className="sqv-q__text">{question.question_text}</p>
+
+      {isText ? (
+        <textarea
+          className="sqv-textarea"
+          rows={4}
+          placeholder="在此作答（分享视图不提交）"
+          value={typeof answer === "string" ? answer : ""}
+          onChange={(e) => onTextChange(e.target.value)}
+        />
+      ) : options.length > 0 ? (
+        <ul className="sqv-options">
+          {options.map((opt) => {
+            const checked = isMulti
+              ? selectedSet.has(opt.value)
+              : (answer as string | undefined) === opt.value;
+            return (
+              <li key={opt.value}>
+                <button
+                  type="button"
+                  className={`sqv-opt ${checked ? "sqv-opt--on" : ""}`}
+                  onClick={() =>
+                    isMulti ? onSelectMulti(opt.value) : onSelectSingle(opt.value)
+                  }
+                  aria-pressed={checked}
+                >
+                  <span className="sqv-opt__letter">{opt.label}</span>
+                  <span className="sqv-opt__text">{opt.text}</span>
+                  <span className="sqv-opt__check" aria-hidden>
+                    {isMulti ? (
+                      <svg viewBox="0 0 16 16" width="14" height="14">
+                        <path
+                          d="M3.5 8.5l3 3 6-7"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                        />
+                      </svg>
+                    ) : (
+                      <span className="sqv-opt__radio" />
+                    )}
+                  </span>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      ) : null}
+    </article>
+  );
+}
+
+interface NormalizedOption {
+  label: string;
+  value: string;
+  text: string;
+}
+
+function normalizeOptions(
+  options: SharedQuizQuestion["options"],
+): NormalizedOption[] {
+  if (!options) return [];
+  if (Array.isArray(options)) {
+    return options.map((opt, i) => {
+      const label = String.fromCharCode(65 + i);
+      return { label, value: label, text: typeof opt === "string" ? opt : String(opt) };
+    });
+  }
+  if (typeof options === "object") {
+    return Object.entries(options).map(([key, val]) => ({
+      label: key,
+      value: key,
+      text: typeof val === "string" ? val : String(val),
+    }));
+  }
+  return [];
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1155,6 +1155,48 @@ export interface WrongAnswerResponse {
     total: number;
 }
 
+export interface QuizShareResponse {
+    quiz_uuid: string;
+    share_token: string;
+    shared_at: string | null;
+    share_expires_at: string | null;
+}
+
+export interface QuizShareStatus {
+    quiz_uuid: string;
+    shared: boolean;
+    share_token?: string;
+    shared_at?: string | null;
+    share_expires_at?: string | null;
+    expired?: boolean;
+}
+
+export interface QuizShareRevokeResponse {
+    quiz_uuid: string;
+    shared: boolean;
+}
+
+export interface SharedQuizQuestion {
+    question_uuid: string;
+    question_type: string;
+    difficulty: string;
+    question_text: string;
+    options?: string[] | Record<string, string>;
+}
+
+export interface SharedQuizData {
+    quiz_uuid: string;
+    title: string;
+    question_count: number;
+    type_distribution?: Record<string, number>;
+    difficulty: string;
+    total_score: number;
+    passing_score: number;
+    source_type?: string;
+    shared_at: string | null;
+    questions: SharedQuizQuestion[];
+}
+
 export const quizApi = {
     generate: (params: Omit<QuizGenerateParams, "session_id">) => {
         const sp = new URLSearchParams();
@@ -1211,6 +1253,31 @@ export const quizApi = {
         if (!res.ok) throw new Error("导出失败");
         return res.blob();
     },
+
+    createShare: (quizUuid: string, expiresInDays?: number | null) =>
+        request<QuizShareResponse>(`/quiz/${quizUuid}/share`, {
+            method: "POST",
+            headers: getAuthHeaders(),
+            body: JSON.stringify(
+                expiresInDays === undefined
+                    ? {}
+                    : { expires_in_days: expiresInDays ?? null }
+            ),
+        }),
+
+    getShareStatus: (quizUuid: string) =>
+        request<QuizShareStatus>(`/quiz/${quizUuid}/share`, {
+            headers: getAuthHeaders(),
+        }),
+
+    revokeShare: (quizUuid: string) =>
+        request<QuizShareRevokeResponse>(`/quiz/${quizUuid}/share`, {
+            method: "DELETE",
+            headers: getAuthHeaders(),
+        }),
+
+    getSharedQuiz: (shareToken: string) =>
+        request<SharedQuizData>(`/quiz/shared/${encodeURIComponent(shareToken)}`),
 };
 
 // ==================== 用户信息修改 ====================

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -207,7 +207,20 @@ http {
             proxy_pass http://backend;
         }
 
-        # Quiz — moderate
+        # Public shared quiz — cacheable (no auth, content is public).
+        # MUST come before /quiz — nginx longest-prefix match means /quiz/shared/xxx
+        # would otherwise hit the /quiz block (which has no cache).
+        location /quiz/shared/ {
+            limit_req zone=api burst=5 nodelay;
+            proxy_cache api_cache;
+            proxy_cache_key "$host$request_uri";
+            proxy_cache_valid 200 60s;
+            proxy_cache_valid 404 10s;   # absorb token-guessing traffic
+            add_header X-Cache-Status $upstream_cache_status;
+            proxy_pass http://backend;
+        }
+
+        # Quiz (authed endpoints) — moderate, no cache
         location /quiz {
             limit_req zone=api burst=10 nodelay;
             proxy_pass http://backend;


### PR DESCRIPTION
## Summary

  为已生成的题目集新增**分享功能**：题目所有者可生成不可枚举的分享链接，
  未登录用户在独立视图页自测作答；答案 / 解析 / 关键词永不公开。
  边缘 nginx、Redis L2、浏览器三层缓存，撤销 / 轮换时立即失效。

  - **数据层**：独立 `share_token`（`secrets.token_urlsafe`，~122 bits），与 `quiz_uuid` 解耦，防止 UUID 枚举
  - **接口层**：owner 管理（创建/轮换/撤销/状态查询）+ 公开只读端点，router 瘦身委托 repository
  - **缓存层**：nginx `api_cache` 60s + Redis L2 60s + 浏览器 `Cache-Control: public, max-age=60`，撤销时主动删 Redis
  - **前端**：历史列表内嵌 ShareModal（时长选择 / 复制 / 撤销 / 重生成）+ 独立 `/quiz/share-view/[token]` 自测视图

  ## Security

  - `share_token` 与 `quiz_uuid` 解耦：公开端点无法通过猜测 UUID4 枚举分享
  - 公开端点返回**不含** `correct_answer` / `explanation` / `keywords`，仅题目 + 选项
  - 无效 / 已撤销 / 已过期 token 统一返回 404，防止 token 状态枚举
  - owner 端点全部 `uid` 作用域（IDOR 防护）
  - 公开端点限流 2 rps burst 5（middleware + nginx 双重），吸收 token 猜测流量
  - 404 缓存 10s，进一步吸收枚举噪音

  ## Caching Strategy

  | 层级 | 位置 | TTL | 失效方式 |
  |------|------|-----|---------|
  | L0 边缘 | nginx `api_cache` | 60s | TTL 过期 |
  | L1 浏览器 | `Cache-Control: max-age=60` | 60s | TTL 过期 |
  | L2 应用 | Redis `quiz_share:{token}` | 60s | 撤销/轮换时主动 `DEL` |

  撤销 / 轮换时 Redis 立即失效；nginx 与浏览器最坏 60s 陈旧 —— 对非敏感题目内容可接受。

  ## API Changes

  | Method | Path | Auth | 说明 |
  |--------|------|------|------|
  | POST | `/quiz/{quiz_uuid}/share` | ✓ | 创建/轮换 token，body: `{"expires_in_days": int\|null}` |
  | GET | `/quiz/{quiz_uuid}/share` | ✓ | owner 查询当前分享状态 |
  | DELETE | `/quiz/{quiz_uuid}/share` | ✓ | 撤销（幂等） |
  | GET | `/quiz/shared/{share_token}` | ✗ | 公开只读，60s 缓存 |