### PR TITLE
chore(infra): add internal_error helper to prevent exception leakage

### DIFF
--- a/app/infra/errors.py
+++ b/app/infra/errors.py
@@ -1,0 +1,44 @@
+"""HTTP error helpers — prevent internal exception leakage.
+
+Production 5xx responses MUST NOT include raw exception text, SQL fragments,
+file paths, or stack traces. Use :func:`internal_error` to log the full
+detail server-side and return a generic message to the client.
+
+4xx responses may safely echo user-facing error messages from service-layer
+ValueErrors (e.g. "ASR not completed — cannot vectorize"), so those are left
+alone.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import HTTPException
+from loguru import logger
+
+
+def internal_error(
+    exc: BaseException,
+    *,
+    context: str = "",
+    status_code: int = 500,
+    logger_ctx: Any = None,
+) -> HTTPException:
+    """Return an HTTPException with a generic client message.
+
+    Logs the full exception server-side with optional `context` tag, then
+    returns a 500 (or overridden status) with a non-revealing detail string.
+
+    Usage in a router:
+        except Exception as e:
+            logger.exception("...")
+            raise internal_error(e, context="sync_folders")
+    """
+    if context:
+        logger.exception("[{}] internal error", context)
+    else:
+        logger.exception("internal error")
+    return HTTPException(
+        status_code=status_code,
+        detail="服务器内部错误，请稍后重试",
+    )


### PR DESCRIPTION
New app/infra/errors.py exports internal_error(exc, context=...) -> HTTPException. Logs full exception server-side, returns generic 500 message to client without raw exception text, SQL fragments, file paths, or stack traces.

4xx responses are left alone — service-layer ValueErrors with user-facing messages (e.g. "ASR not completed — cannot vectorize") are safe to echo.

Shared infra dependency for the router-thinning PRs (favorites, auth, cloud, knowledge) that follow.