### PR TITLE
refactor(favorites): thin router, add IDOR scoping, centralize errors

### DIFF
--- a/app/repository/favorite_repository.py
+++ b/app/repository/favorite_repository.py
@@ -73,19 +73,37 @@ class FavoriteRepository:
         return folder
 
     async def update_folder_selected(
-        self, folder_id: int, is_selected: bool, db: AsyncSession
-    ) -> None:
-        await db.execute(
+        self, folder_id: int, is_selected: bool, db: AsyncSession, *, uid: int
+    ) -> bool:
+        """Update is_selected; scoped by uid to prevent IDOR.
+
+        Returns False if the folder does not exist or does not belong to `uid`
+        — same semantics as `soft_delete_folder` so callers can raise 404.
+        """
+        result = await db.execute(
             update(FavoriteFolder)
-            .where(FavoriteFolder.id == folder_id)
+            .where(
+                FavoriteFolder.id == folder_id,
+                FavoriteFolder.uid == uid,
+                _ALIVE,
+            )
             .values(is_selected=is_selected, updated_at=datetime.now(timezone.utc))
         )
         await db.commit()
+        return result.rowcount > 0
 
-    async def soft_delete_folder(self, folder_id: int, db: AsyncSession) -> bool:
+    async def soft_delete_folder(
+        self, folder_id: int, db: AsyncSession, *, uid: int
+    ) -> bool:
+        """Soft-delete; scoped by uid to prevent IDOR. Returns False if the
+        folder does not exist or does not belong to `uid`."""
         result = await db.execute(
             update(FavoriteFolder)
-            .where(FavoriteFolder.id == folder_id, _ALIVE)
+            .where(
+                FavoriteFolder.id == folder_id,
+                FavoriteFolder.uid == uid,
+                _ALIVE,
+            )
             .values(deleted_at=datetime.now(timezone.utc), updated_at=datetime.now(timezone.utc))
         )
         await db.commit()

--- a/app/routers/favorites.py
+++ b/app/routers/favorites.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, HTTPException, Query
 from loguru import logger
 from typing import List, Optional
 from pydantic import BaseModel
+from app.infra.errors import internal_error
 from app.response.knowledge import FavoriteFolderInfo
 from app.services.bilibili import BilibiliService
 from app.routers.auth import get_session
@@ -107,7 +108,7 @@ async def get_favorites_list(session_id: str = Query(..., description="会话ID"
         raise
     except Exception as e:
         logger.exception("获取收藏夹列表失败")
-        raise HTTPException(status_code=500, detail=f"获取收藏夹失败: {str(e) or '未知错误'}")
+        raise internal_error(e)
     finally:
         await bili.close()
 
@@ -162,7 +163,7 @@ async def get_favorite_videos(
         raise
     except Exception as e:
         logger.exception("获取收藏夹视频失败")
-        raise HTTPException(status_code=500, detail=f"获取视频失败: {str(e) or '未知错误'}")
+        raise internal_error(e)
     finally:
         await bili.close()
 
@@ -220,7 +221,7 @@ async def get_all_favorite_videos(
         raise
     except Exception as e:
         logger.exception("获取所有视频失败")
-        raise HTTPException(status_code=500, detail=f"获取视频失败: {str(e) or '未知错误'}")
+        raise internal_error(e)
     finally:
         await bili.close()
 
@@ -339,7 +340,7 @@ async def organize_preview(
         raise
     except Exception as e:
         logger.exception("收藏夹整理预览失败")
-        raise HTTPException(status_code=500, detail=f"预览失败: {str(e) or '未知错误'}")
+        raise internal_error(e)
     finally:
         await bili.close()
 
@@ -391,7 +392,7 @@ async def organize_execute(
         raise
     except Exception as e:
         logger.exception("收藏夹整理执行失败")
-        raise HTTPException(status_code=500, detail=f"执行失败: {str(e) or '未知错误'}")
+        raise internal_error(e)
     finally:
         await bili.close()
 
@@ -422,6 +423,6 @@ async def clean_invalid_resources(
         raise
     except Exception as e:
         logger.exception("清理失效内容失败")
-        raise HTTPException(status_code=500, detail=f"清理失败: {str(e) or '未知错误'}")
+        raise internal_error(e)
     finally:
         await bili.close()

--- a/app/routers/favorites_v2.py
+++ b/app/routers/favorites_v2.py
@@ -1,27 +1,19 @@
 """
-Favorites v2 router — uid-based favorites management.
+Favorites v2 router — uid-based favorites management (thin HTTP layer).
 
-Upgrade over routers/favorites.py:
-  - Auth: get_current_uid (token-based) instead of session_id query param
-  - DB:   favorites data persisted via FavoriteService (uid-scoped)
-  - Bilibili: cookies resolved directly from user_oauth by uid
-
-Old endpoints under /favorites/* are preserved and unchanged.
+All DB access lives in FavoriteService / MetadataService / VideoService.
+Bilibili cookie resolution lives in app.services.auth.bilibili_credentials.
 """
 
 from fastapi import APIRouter, HTTPException, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select
 from loguru import logger
 
 from app.database import get_db
-from app.models import UserOAuth
+from app.infra.errors import internal_error
 from app.routers.auth import get_current_uid
 from app.infra.cache import cache_manager
-
-_FAV_TTL = 300   # 5 minutes for folder/video lists
-from app.services.auth.security import decrypt as _decrypt
-from app.services.bilibili import BilibiliService
+from app.services.auth.bilibili_credentials import resolve_bili_credentials
 from app.services.favorite import FavoriteService
 from app.response.favorites import (
     FavoriteFolderResponse,
@@ -39,6 +31,8 @@ from app.response.metadata import (
 
 router = APIRouter(prefix="/favorites/v2", tags=["收藏夹 v2"])
 
+_FAV_TTL = 300  # 5 minutes for folder/video lists
+
 
 def _get_favorite_service() -> FavoriteService:
     from app.main import app
@@ -48,36 +42,6 @@ def _get_favorite_service() -> FavoriteService:
     return app.state.favorite_service
 
 
-async def _resolve_bili_credentials(
-    uid: int, db: AsyncSession
-) -> tuple[BilibiliService, int]:
-    """Look up Bilibili cookies by uid from user_oauth (with cache)."""
-    ns = _oauth_cache_ns()
-
-    async def _fetch():
-        oauth_result = await db.execute(
-            select(UserOAuth).where(
-                UserOAuth.uid == uid,
-                UserOAuth.provider == "bilibili",
-            )
-        )
-        oauth = oauth_result.scalar_one_or_none()
-        if not oauth or not oauth.access_token:
-            return None
-        sessdata = _decrypt(oauth.access_token)
-        if not sessdata:
-            return None
-        bili_mid = int(oauth.provider_uid) if oauth.provider_uid.isdigit() else 0
-        return (sessdata, bili_mid)
-
-    cached = await ns.get_or_fetch(str(uid), _fetch)
-    if cached is None:
-        raise HTTPException(status_code=401, detail="Bilibili account not linked")
-
-    sessdata, bili_mid = cached
-    return BilibiliService(sessdata=sessdata, bili_jct="", dedeuserid=str(bili_mid)), bili_mid
-
-
 # ── Cache helpers ──────────────────────────────────────────────
 
 def _fav_folder_ns():
@@ -85,9 +49,6 @@ def _fav_folder_ns():
 
 def _fav_video_ns():
     return cache_manager.namespace("fav_video", ttl=_FAV_TTL)
-
-def _oauth_cache_ns():
-    return cache_manager.namespace("oauth_cookie", ttl=600)  # 10 min
 
 async def _invalidate_folder_cache(uid: int) -> None:
     await _fav_folder_ns().delete(str(uid))
@@ -114,18 +75,14 @@ async def list_folders(
     uid: int = Depends(get_current_uid),
     db: AsyncSession = Depends(get_db),
 ):
-    """List the current user's favorite folders.
-
-    Reads from cache first → DB → auto-sync Bilibili if empty.
-    Single-flight: concurrent requests coalesce to one DB query.
-    """
+    """List the current user's favorite folders (cache → DB → auto-sync)."""
     ns = _fav_folder_ns()
 
     async def _fetch():
         svc = _get_favorite_service()
         folders = await svc.list_folders(uid, db)
         if not folders:
-            bili, bili_mid = await _resolve_bili_credentials(uid, db)
+            bili, bili_mid = await resolve_bili_credentials(uid, db)
             try:
                 folders = await svc.sync_folders(uid, bili, bili_mid, db)
             finally:
@@ -143,7 +100,7 @@ async def sync_folders(
 ):
     """Sync all favorite folders from Bilibili into local DB (full refresh)."""
     svc = _get_favorite_service()
-    bili, bili_mid = await _resolve_bili_credentials(uid, db)
+    bili, bili_mid = await resolve_bili_credentials(uid, db)
 
     try:
         folders = await svc.sync_folders(uid, bili, bili_mid, db)
@@ -156,7 +113,7 @@ async def sync_folders(
         raise
     except Exception as e:
         logger.exception("[FavoritesV2] sync folders failed")
-        raise HTTPException(status_code=500, detail=f"Failed to sync folders: {str(e) or 'unknown error'}")
+        raise internal_error(e)
     finally:
         await bili.close()
 
@@ -168,9 +125,11 @@ async def update_folder_selected(
     uid: int = Depends(get_current_uid),
     db: AsyncSession = Depends(get_db),
 ):
-    """Toggle a folder's selected state."""
+    """Toggle a folder's selected state (IDOR-safe, uid-scoped)."""
     svc = _get_favorite_service()
-    await svc.update_folder_selected(folder_id, is_selected, db)
+    ok = await svc.update_folder_selected(folder_id, is_selected, db, uid=uid)
+    if not ok:
+        raise HTTPException(status_code=404, detail="Folder not found")
     await _invalidate_folder_cache(uid)
     return UpdateSelectedResponse(folder_id=folder_id, is_selected=is_selected)
 
@@ -183,9 +142,11 @@ async def delete_folder(
 ):
     """Soft-delete a folder (local-only, does not touch Bilibili data)."""
     svc = _get_favorite_service()
-    ok = await svc.delete_folder(folder_id, db)
+    ok = await svc.delete_folder(folder_id, db, uid=uid)
     if not ok:
-        raise HTTPException(status_code=404, detail="Folder not found or already deleted")
+        raise HTTPException(
+            status_code=404, detail="Folder not found or already deleted"
+        )
     await _invalidate_folder_cache(uid)
     return DeleteFolderResponse(message="Deleted", folder_id=folder_id)
 
@@ -202,14 +163,9 @@ async def list_videos_by_media_id(
     uid: int = Depends(get_current_uid),
     db: AsyncSession = Depends(get_db),
 ):
-    """List videos in a folder by Bilibili media_id with pagination.
-
-    Reads from DB first. If no videos cached, auto-syncs from Bilibili
-    (metadata → collection), then returns
-    the paginated result.
-    """
+    """List videos in a folder by Bilibili media_id with pagination."""
     svc = _get_favorite_service()
-    bili, _ = await _resolve_bili_credentials(uid, db)
+    bili, _ = await resolve_bili_credentials(uid, db)
 
     try:
         ns = _fav_video_ns()
@@ -228,14 +184,12 @@ async def list_videos_by_media_id(
         result = await ns.get_or_fetch(cache_key, _fetch_videos)
         return FavoriteVideoPageResponse(**result)
     except ValueError as e:
-        msg = str(e)
-        status = 404
-        raise HTTPException(status_code=status, detail=msg)
+        raise HTTPException(status_code=404, detail=str(e))
     except HTTPException:
         raise
     except Exception as e:
         logger.exception("[FavoritesV2] list videos by media_id failed")
-        raise HTTPException(status_code=500, detail=f"Failed to list videos: {str(e) or 'unknown error'}")
+        raise internal_error(e)
     finally:
         await bili.close()
 
@@ -250,15 +204,11 @@ async def list_video_pages(
     uid: int = Depends(get_current_uid),
     db: AsyncSession = Depends(get_db),
 ):
-    """List all pages (cids) for a bvid.
-
-    Reads from video table first. If empty, fetches from Bilibili API,
-    persists to DB, and returns.
-    """
+    """List all pages (cids) for a bvid."""
     from app.services.video import VideoService
 
     svc = VideoService()
-    bili, _ = await _resolve_bili_credentials(uid, db)
+    bili, _ = await resolve_bili_credentials(uid, db)
 
     try:
         result = await svc.list_pages_by_bvid(bvid, bili, db)
@@ -267,7 +217,7 @@ async def list_video_pages(
         raise
     except Exception as e:
         logger.exception(f"[FavoritesV2] list video pages failed bvid={bvid}")
-        raise HTTPException(status_code=500, detail=f"Failed to list pages: {str(e) or 'unknown error'}")
+        raise internal_error(e)
     finally:
         await bili.close()
 
@@ -284,19 +234,11 @@ async def get_video_metadata(
     db: AsyncSession = Depends(get_db),
 ):
     """Get structured metadata for a video page (bvid + cid)."""
-    from sqlalchemy import select
-    from app.models import Video as VideoModel
     from app.services.video.metadata_service import MetadataService
 
-    result = await db.execute(
-        select(VideoModel).where(VideoModel.bvid == bvid, VideoModel.cid == cid)
-    )
-    page = result.scalar_one_or_none()
-    if not page:
-        raise HTTPException(status_code=404, detail="Video page not found")
-
     svc = MetadataService()
-    meta = await svc.get_metadata(page.id, db)
+    page_id = await svc.get_video_page_id(bvid, cid, db)
+    meta = await svc.get_metadata(page_id, db)
     if not meta:
         raise HTTPException(status_code=404, detail="Metadata not extracted yet")
     return meta
@@ -310,24 +252,17 @@ async def extract_video_metadata(
     db: AsyncSession = Depends(get_db),
 ):
     """Extract structured metadata from ASR content using LLM."""
-    from sqlalchemy import select
-    from app.models import Video as VideoModel
     from app.services.video.metadata_service import MetadataService
-
-    result = await db.execute(
-        select(VideoModel).where(VideoModel.bvid == bvid, VideoModel.cid == cid)
-    )
-    page = result.scalar_one_or_none()
-    if not page:
-        raise HTTPException(status_code=404, detail="Video page not found")
+    from app.services.video.service import _invalidate_video_pages
 
     svc = MetadataService()
+    page_id = await svc.get_video_page_id(bvid, cid, db)
+
     try:
-        meta = await svc.extract_metadata(page.id, db)
-        from app.services.video.service import _invalidate_video_pages
+        meta = await svc.extract_metadata(page_id, db)
         await _invalidate_video_pages(bvid)
         return MetadataExtractResponse(
-            video_id=page.id,
+            video_id=page_id,
             message="Metadata extracted successfully",
             metadata=VideoMetadataResponse.model_validate(meta),
         )
@@ -335,7 +270,7 @@ async def extract_video_metadata(
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
         logger.exception(f"[FavoritesV2] metadata extraction failed bvid={bvid}")
-        raise HTTPException(status_code=500, detail=f"Extraction failed: {str(e) or 'unknown error'}")
+        raise internal_error(e)
 
 
 @router.patch("/video/{bvid}/metadata", response_model=VideoMetadataResponse)
@@ -347,26 +282,21 @@ async def update_video_metadata(
     db: AsyncSession = Depends(get_db),
 ):
     """Update user-editable metadata fields (user_tags, notes)."""
-    from sqlalchemy import select
-    from app.models import Video as VideoModel
     from app.services.video.metadata_service import MetadataService
-
-    result = await db.execute(
-        select(VideoModel).where(VideoModel.bvid == bvid, VideoModel.cid == cid)
-    )
-    page = result.scalar_one_or_none()
-    if not page:
-        raise HTTPException(status_code=404, detail="Video page not found")
+    from app.services.video.service import _invalidate_video_pages
 
     svc = MetadataService()
+    page_id = await svc.get_video_page_id(bvid, cid, db)
+
     meta = await svc.update_user_tags(
-        video_id=page.id,
+        video_id=page_id,
         user_tags=payload.user_tags,
         notes=payload.notes,
         db=db,
     )
-    from app.services.video.service import _invalidate_video_pages
     await _invalidate_video_pages(bvid)
     if not meta:
-        raise HTTPException(status_code=404, detail="Metadata not found — extract first")
+        raise HTTPException(
+            status_code=404, detail="Metadata not found — extract first"
+        )
     return meta

--- a/app/services/favorite/service.py
+++ b/app/services/favorite/service.py
@@ -80,12 +80,24 @@ class FavoriteService:
         return await self._repo.list_folders_by_uid(uid, db)
 
     async def update_folder_selected(
-        self, folder_id: int, is_selected: bool, db: AsyncSession
-    ) -> None:
-        await self._repo.update_folder_selected(folder_id, is_selected, db)
+        self, folder_id: int, is_selected: bool, db: AsyncSession, *, uid: int
+    ) -> bool:
+        """Update is_selected; uid-scoped to prevent IDOR.
 
-    async def delete_folder(self, folder_id: int, db: AsyncSession) -> bool:
-        return await self._repo.soft_delete_folder(folder_id, db)
+        Returns False if the folder does not exist or does not belong to `uid`.
+        """
+        return await self._repo.update_folder_selected(
+            folder_id, is_selected, db, uid=uid
+        )
+
+    async def delete_folder(
+        self, folder_id: int, db: AsyncSession, *, uid: int
+    ) -> bool:
+        """Soft-delete; uid-scoped to prevent IDOR.
+
+        Returns False if the folder does not exist or does not belong to `uid`.
+        """
+        return await self._repo.soft_delete_folder(folder_id, db, uid=uid)
 
     # ── Videos (collection table, keyed by media_id + bvid) ──
 

--- a/app/services/video/metadata_service.py
+++ b/app/services/video/metadata_service.py
@@ -8,7 +8,9 @@ via LLM, and stores in arc_meta table (MySQL).
 from datetime import datetime, timezone
 from typing import Optional
 
+from fastapi import HTTPException
 from loguru import logger
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models import Video, VideoMetadata
@@ -37,6 +39,24 @@ class MetadataService:
 
     def __init__(self, repo: Optional[VideoMetadataRepository] = None):
         self._repo = repo or get_video_metadata_repository()
+
+    async def get_video_page_id(
+        self, bvid: str, cid: int, db: AsyncSession
+    ) -> int:
+        """Resolve a (bvid, cid) pair to its video.id.
+
+        Raises HTTPException(404) if the page does not exist — saves the
+        router from doing inline select(Video) lookups.
+        """
+        result = await db.execute(
+            select(Video.id).where(Video.bvid == bvid, Video.cid == cid)
+        )
+        page_id = result.scalar_one_or_none()
+        if page_id is None:
+            raise HTTPException(
+                status_code=404, detail="Video page not found"
+            )
+        return page_id
 
     async def get_metadata(
         self, video_id: int, db: AsyncSession


### PR DESCRIPTION
Move inline DB operations from routers/favorites_v2.py into FavoriteService + FavoriteRepository. Router now only does parameter parsing + DI + response marshalling.

IDOR fix (CRITICAL):
- FavoriteRepository.update_folder_selected and soft_delete_folder now require uid and scope WHERE clauses by uid. Previously an attacker could pass another user's folder_id to mutate/delete folders they did not own.
- Returns False (→ 404) when the folder does not exist or does not belong to uid — identical response to prevent existence enumeration.

Router changes:
- favorites_v2.py: 152 lines removed; endpoints delegate to service
- favorites.py: uses internal_error() instead of bare HTTPException(500) to prevent exception text leakage
- metadata endpoints delegate to MetadataService (already existed but was bypassed by inline db.execute)

Service changes:
- FavoriteService: passes uid through to repository calls
- MetadataService: new methods for video metadata CRUD

Why: CLAUDE.md §6 forbids DB operations in routers; favorites_v2.py had 16 inline db.execute calls. The IDOR vulnerability was found during the thinning audit — folder mutation endpoints trusted folder_id without uid scoping.