### PR TITLE
refactor(knowledge): extract build/sync services

### DIFF
--- a/app/repository/knowledge_repository.py
+++ b/app/repository/knowledge_repository.py
@@ -1,0 +1,187 @@
+"""Knowledge query repository — MySQL read access for knowledge endpoints.
+
+Absorbs the inline SQL/ORM that previously lived in ``app/routers/knowledge.py``
+for ``get_folder_status``, ``get_vectorized_pages``, ``get_build_status``,
+and the bvid ownership check in ``delete_video_from_knowledge``.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import select, func, or_, delete
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import FavoriteFolder, Collection, Video, AsyncTask
+
+
+class KnowledgeRepository:
+    """Read-side data access for the knowledge module."""
+
+    # ── Folder status ──────────────────────────────────────────────
+
+    async def list_folder_status(
+        self, uid: int, db: AsyncSession
+    ) -> list[dict]:
+        """For each alive folder of this user, count how many bvids have
+        *all* their pages vectorized (is_vectorized='done').
+
+        Returns a list of dicts: {media_id, indexed_count, media_count, last_sync_at}.
+        """
+        folders_result = await db.execute(
+            select(
+                FavoriteFolder.media_id,
+                FavoriteFolder.media_count,
+                FavoriteFolder.last_sync_at,
+            ).where(
+                FavoriteFolder.uid == uid,
+                FavoriteFolder.deleted_at.is_(None),
+            )
+        )
+        folders = folders_result.all()
+        if not folders:
+            return []
+
+        folder_meta = {
+            row.media_id: (row.media_count, row.last_sync_at) for row in folders
+        }
+        media_ids = list(folder_meta.keys())
+
+        incomplete_sub = (
+            select(Video.bvid)
+            .where(
+                or_(
+                    Video.is_vectorized != "done",
+                    Video.is_vectorized.is_(None),
+                )
+            )
+            .subquery()
+        )
+        counts_result = await db.execute(
+            select(
+                Collection.media_id,
+                func.count(func.distinct(Video.bvid)),
+            )
+            .select_from(Collection)
+            .join(Video, Video.bvid == Collection.bvid)
+            .where(
+                Collection.media_id.in_(media_ids),
+                ~Video.bvid.in_(select(incomplete_sub.c.bvid)),
+            )
+            .group_by(Collection.media_id)
+        )
+        count_map = {row[0]: row[1] for row in counts_result.all()}
+
+        return [
+            {
+                "media_id": media_id,
+                "indexed_count": count_map.get(media_id, 0),
+                "media_count": meta[0],
+                "last_sync_at": meta[1],
+            }
+            for media_id, meta in folder_meta.items()
+        ]
+
+    # ── Vectorized pages ───────────────────────────────────────────
+
+    async def list_vectorized_pages(
+        self, uid: int, db: AsyncSession
+    ) -> list[dict]:
+        """Return all fully-vectorized pages belonging to this user's folders."""
+        folders_result = await db.execute(
+            select(FavoriteFolder.media_id).where(
+                FavoriteFolder.uid == uid,
+                FavoriteFolder.deleted_at.is_(None),
+            )
+        )
+        media_ids = [row[0] for row in folders_result.all()]
+        if not media_ids:
+            return []
+
+        bvids_result = await db.execute(
+            select(Collection.bvid).where(Collection.media_id.in_(media_ids))
+        )
+        bvids = list({row[0] for row in bvids_result.all() if row[0]})
+        if not bvids:
+            return []
+
+        pages_result = await db.execute(
+            select(Video)
+            .where(Video.bvid.in_(bvids), Video.is_vectorized == "done")
+            .order_by(Video.bvid, Video.page_index)
+        )
+        pages = pages_result.scalars().all()
+        if not pages:
+            return []
+
+        bvid_set = {p.bvid for p in pages}
+        titles_result = await db.execute(
+            select(Collection.bvid, Collection.title).where(
+                Collection.bvid.in_(bvid_set)
+            )
+        )
+        title_map = {row[0]: row[1] for row in titles_result.all()}
+
+        return [
+            {
+                "bvid": p.bvid,
+                "cid": p.cid,
+                "page_index": p.page_index,
+                "page_title": p.page_title,
+                "video_title": title_map.get(p.bvid, ""),
+                "vector_chunk_count": p.vector_chunk_count or 0,
+                "vectorized_at": p.vectorized_at,
+            }
+            for p in pages
+        ]
+
+    # ── Build status ───────────────────────────────────────────────
+
+    async def get_build_status_row(
+        self, task_id: str, uid: int, db: AsyncSession
+    ) -> Optional[AsyncTask]:
+        """Fetch the persisted AsyncTask row for a build task, if any.
+
+        Scoped by uid to prevent IDOR — callers don't need to remember to
+        add the ownership check; this returns None if the task belongs to
+        another user.
+        """
+        result = await db.execute(
+            select(AsyncTask).where(
+                AsyncTask.task_id == task_id,
+                AsyncTask.uid == uid,
+            )
+        )
+        return result.scalar_one_or_none()
+
+    # ── Ownership check for delete_video ───────────────────────────
+
+    async def bvid_belongs_to_user(
+        self, bvid: str, uid: int, db: AsyncSession
+    ) -> bool:
+        """True iff ``bvid`` is in any of the caller's alive favorite folders."""
+        result = await db.execute(
+            select(Collection)
+            .join(
+                FavoriteFolder, FavoriteFolder.media_id == Collection.media_id
+            )
+            .where(
+                Collection.bvid == bvid,
+                FavoriteFolder.uid == uid,
+                FavoriteFolder.deleted_at.is_(None),
+            )
+            .limit(1)
+        )
+        return result.scalar_one_or_none() is not None
+
+
+# ── Module-level singleton ────────────────────────────────────────
+
+_repo: Optional[KnowledgeRepository] = None
+
+
+def get_knowledge_repository() -> KnowledgeRepository:
+    global _repo
+    if _repo is None:
+        _repo = KnowledgeRepository()
+    return _repo

--- a/app/repository/knowledge_repository.py
+++ b/app/repository/knowledge_repository.py
@@ -6,10 +6,9 @@ and the bvid ownership check in ``delete_video_from_knowledge``.
 """
 from __future__ import annotations
 
-from datetime import datetime
 from typing import Optional
 
-from sqlalchemy import select, func, or_, delete
+from sqlalchemy import select, func, or_
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models import FavoriteFolder, Collection, Video, AsyncTask

--- a/app/routers/knowledge.py
+++ b/app/routers/knowledge.py
@@ -10,7 +10,7 @@ import re
 from datetime import datetime
 from typing import List, Optional
 
-from fastapi import APIRouter, HTTPException, BackgroundTasks, Depends
+from fastapi import APIRouter, HTTPException, Depends
 from loguru import logger
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -21,7 +21,7 @@ from app.response.knowledge import VideoInfo, VideosResponse
 from app.services.bilibili import BilibiliService
 from app.services.asr import ASRService
 from app.services.content_fetcher import ContentFetcher
-from app.services.rag import RAGService, get_rag_service
+from app.services.rag import get_rag_service
 from app.routers.auth import get_current_uid, require_admin, _get_bili_cookies_by_uid
 from app.utils.cache import cache_dependency_singleton
 

--- a/app/routers/knowledge.py
+++ b/app/routers/knowledge.py
@@ -1,69 +1,61 @@
 """
-Bilibili RAG 知识库系统
+Knowledge router — thin HTTP layer over KnowledgeSyncService,
+KnowledgeBuildService, and KnowledgeRepository.
 
-知识库路由 - 构建和管理知识库
+Owns: parameter parsing, dependency injection, response marshalling,
+cache wiring, B站 service acquisition.
+Owns NOT: DB operations, vector store access, background task orchestration.
 """
-import asyncio
-import random
 import re
-from datetime import datetime, timezone
+from datetime import datetime
+from typing import List, Optional
+
 from fastapi import APIRouter, HTTPException, BackgroundTasks, Depends
 from loguru import logger
-from typing import List, Optional, Callable
 from pydantic import BaseModel
-from sqlalchemy import select, func, delete, or_
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db, get_db_context
-from app.models import FavoriteFolder, Collection, Video
-from app.response.knowledge import ContentSource, VideoInfo, VideosResponse
-from app.services.async_task.tracker import TaskTracker
+from app.infra.errors import internal_error
+from app.response.knowledge import VideoInfo, VideosResponse
 from app.services.bilibili import BilibiliService
-from app.services.content_fetcher import ContentFetcher
 from app.services.asr import ASRService
+from app.services.content_fetcher import ContentFetcher
 from app.services.rag import RAGService, get_rag_service
-from app.routers.auth import get_current_uid, _get_bili_cookies_by_uid
-from app.utils.bvid import bv_to_av
+from app.routers.auth import get_current_uid, require_admin, _get_bili_cookies_by_uid
 from app.utils.cache import cache_dependency_singleton
+
+# Re-export for existing importers (chat.py imports get_rag_service from here).
+__all__ = [
+    "router",
+    "get_rag_service",
+    "PAGES_CACHE_KEY",
+    "PAGES_CACHE_TTL",
+    "BuildRequest",
+    "BuildStatus",
+    "FolderStatus",
+    "SyncRequest",
+    "SyncResult",
+    "VectorizedPageItem",
+]
 
 router = APIRouter(prefix="/knowledge", tags=["知识库"])
 
-# Build task state (legacy in-memory)
-build_tasks = {}
 
 # ---------------------------------------------------------------------------
-# Process-wide singleton lock for /knowledge/build.
-#
-# B站 throttles concurrent requests aggressively. Letting two build jobs run
-# in parallel hits the same SESSDATA twice and triggers RST mid-download.
-# We keep at most ONE active build per process, identified by task_id.
+# Request / response schemas (kept here — they're the HTTP contract)
 # ---------------------------------------------------------------------------
-_active_build_task_id: Optional[str] = None
-_active_build_uid: Optional[int] = None
-_active_build_lock = asyncio.Lock()
-
-
-def _is_build_active() -> bool:
-    """Whether a build task is currently in flight in this process."""
-    return _active_build_task_id is not None
-
-
-async def _human_pause(min_s: float, max_s: float) -> None:
-    """Random sleep between min_s and max_s seconds — mimics human pacing."""
-    await asyncio.sleep(random.uniform(min_s, max_s))
 
 
 class BuildRequest(BaseModel):
-    """知识库构建请求"""
-    folder_ids: List[int]  # 要处理的收藏夹 ID 列表
-    exclude_bvids: Optional[List[str]] = None  # 排除的视频
+    folder_ids: List[int]
+    exclude_bvids: Optional[List[str]] = None
 
 
 class BuildStatus(BaseModel):
-    """构建状态"""
     task_id: str
-    status: str  # pending / running / completed / failed
-    progress: int  # 0-100
+    status: str
+    progress: int
     current_step: str
     total_videos: int
     processed_videos: int
@@ -71,7 +63,6 @@ class BuildStatus(BaseModel):
 
 
 class FolderStatus(BaseModel):
-    """收藏夹入库状态"""
     media_id: int
     indexed_count: int
     media_count: Optional[int] = None
@@ -79,12 +70,10 @@ class FolderStatus(BaseModel):
 
 
 class SyncRequest(BaseModel):
-    """同步请求"""
     folder_ids: Optional[List[int]] = None
 
 
 class SyncResult(BaseModel):
-    """同步结果"""
     folder_id: int
     total: int
     added: int
@@ -94,475 +83,7 @@ class SyncResult(BaseModel):
     last_sync_at: Optional[datetime] = None
 
 
-async def _get_or_create_folder(
-    db: AsyncSession,
-    uid: int,
-    media_id: int,
-    title: Optional[str] = None,
-    media_count: Optional[int] = None,
-) -> FavoriteFolder:
-    """获取或创建收藏夹记录 (uid-based)"""
-    result = await db.execute(
-        select(FavoriteFolder).where(
-            FavoriteFolder.uid == uid,
-            FavoriteFolder.media_id == media_id,
-        )
-    )
-    folder = result.scalar_one_or_none()
-
-    if folder is None:
-        folder = FavoriteFolder(
-            uid=uid,
-            media_id=media_id,
-            title=title or "",
-            media_count=media_count or 0,
-            is_selected=True,
-        )
-        db.add(folder)
-        await db.flush()
-    else:
-        if title:
-            folder.title = title
-        if media_count is not None:
-            folder.media_count = media_count
-
-    return folder
-
-
-def _extract_video_info(media: dict) -> tuple[str, str, Optional[int]]:
-    """抽取视频关键信息"""
-    bvid = media.get("bvid") or media.get("bv_id")
-    title = media.get("title", bvid)
-    cid = None
-    ugc = media.get("ugc") or {}
-    if ugc.get("first_cid"):
-        cid = ugc.get("first_cid")
-    else:
-        cid = media.get("cid") or media.get("id")
-    return bvid, title, cid
-
-
-async def _upsert_collection(db: AsyncSession, media_id: int, bvid: str, meta: dict) -> None:
-    """写入或更新 collection 视频元数据（key: media_id + bvid）"""
-    result = await db.execute(
-        select(Collection).where(Collection.media_id == media_id, Collection.bvid == bvid)
-    )
-    row = result.scalar_one_or_none()
-
-    if row is None:
-        row = Collection(
-            media_id=media_id,
-            bvid=bvid,
-            title=meta.get("title") or bvid,
-            description=meta.get("intro"),
-            owner_name=meta.get("owner_name"),
-            owner_mid=meta.get("owner_mid"),
-            duration=meta.get("duration"),
-            cover=meta.get("cover"),
-        )
-        db.add(row)
-        return
-
-    if meta.get("title"):
-        row.title = meta["title"]
-    if meta.get("intro") is not None:
-        row.description = meta["intro"]
-    if meta.get("owner_name") is not None:
-        row.owner_name = meta["owner_name"]
-    if meta.get("owner_mid") is not None:
-        row.owner_mid = meta["owner_mid"]
-    if meta.get("duration") is not None:
-        row.duration = meta["duration"]
-    if meta.get("cover") is not None:
-        row.cover = meta["cover"]
-
-
-async def _sync_folder(
-    db: AsyncSession,
-    bili: BilibiliService,
-    rag: RAGService,
-    content_fetcher: ContentFetcher,
-    uid: int,
-    folder_id: int,
-    exclude_bvids: Optional[set[str]] = None,
-    progress_callback: Optional[Callable[[str], None]] = None,
-) -> dict:
-    """同步单个收藏夹到向量库"""
-    info = {}
-    try:
-        info_result = await bili.get_favorite_content(folder_id, pn=1, ps=1)
-        info = info_result.get("info", {})
-    except Exception as e:
-        logger.warning(f"获取收藏夹信息失败 [{folder_id}]: {e}")
-
-    videos = await bili.get_all_favorite_videos(folder_id)
-    total_in_folder = info.get("media_count", len(videos))
-
-    # 保护：接口异常返回空列表时，避免误删
-    if not videos:
-        if total_in_folder and total_in_folder > 0:
-            logger.warning(f"[{folder_id}] 收藏夹返回空列表，跳过删除逻辑")
-            existing_count = await db.scalar(
-                select(func.count()).where(Collection.media_id == folder_id)
-            )
-            return {
-                "folder_id": folder_id,
-                "total": total_in_folder,
-                "added": 0,
-                "removed": 0,
-                "indexed": existing_count or 0,
-                "message": "本次同步异常：空列表，已跳过",
-                "last_sync_at": datetime.now(timezone.utc),
-            }
-
-    video_map = {}
-    skipped_invalid = 0
-    for media in videos:
-        bvid, title, cid = _extract_video_info(media)
-        if not bvid:
-            continue
-        if exclude_bvids and bvid in exclude_bvids:
-            continue
-        
-        # 过滤失效视频（被删除、下架等）
-        # attr 字段: 0=正常, 9=已失效, 1=私密等
-        attr = media.get("attr", 0)
-        if attr == 9 or title in ["已失效视频", "已删除视频"]:
-            skipped_invalid += 1
-            logger.debug(f"跳过失效视频: {bvid} - {title}")
-            continue
-        
-        owner = media.get("upper") or {}
-        video_map[bvid] = {
-            "title": title,
-            "cid": cid,
-            "intro": media.get("intro"),
-            "cover": media.get("cover"),
-            "duration": media.get("duration"),
-            "owner_name": owner.get("name"),
-            "owner_mid": owner.get("mid"),
-        }
-    
-    if skipped_invalid > 0:
-        logger.info(f"[{folder_id}] 过滤了 {skipped_invalid} 个失效视频")
-
-    # 以有效视频数作为统计口径（过滤失效视频）
-    valid_count = len(video_map)
-    current_bvids = set(video_map.keys())
-
-    folder = await _get_or_create_folder(
-        db,
-        uid=uid,
-        media_id=folder_id,
-        title=info.get("title"),
-        media_count=valid_count,
-    )
-
-    # 查 collection 中该 media_id 已有的 bvid
-    existing_rows = await db.execute(
-        select(Collection.bvid).where(Collection.media_id == folder_id)
-    )
-    existing_bvids = {row[0] for row in existing_rows.fetchall()}
-
-    added = current_bvids - existing_bvids
-    removed = existing_bvids - current_bvids
-
-    # 写入 collection 元数据
-    for bvid, meta in video_map.items():
-        await _upsert_collection(db, folder_id, bvid, meta)
-
-    source_priority = {
-        ContentSource.BASIC_INFO.value: 1,
-        ContentSource.AI_SUMMARY.value: 2,
-        ContentSource.SUBTITLE.value: 3,
-        ContentSource.ASR.value: 4,
-    }
-
-    def _is_better_source(new_source: str, old_source: Optional[str]) -> bool:
-        return source_priority.get(new_source, 0) > source_priority.get(old_source or "", 0)
-
-    async def _get_content_text(bvid: str, cid: int, title: str, content_fetcher, meta: dict) -> tuple[str, str]:
-        """Get ASR text for a video. Tries MongoDB → fetch → save to MongoDB.
-        Returns (text, source).
-        Full text lives in MongoDB only, never written to MySQL.
-        """
-        from app.infra.mongo import is_enabled as _mongo_ok
-        from app.repository.mongo_asr_repository import get_latest, save_asr
-        # 1. Try MongoDB (shared across users — deduplication)
-        if _mongo_ok():
-            try:
-                doc = await get_latest(bvid, cid)
-                if doc and doc.get("content") and len(doc["content"].strip()) >= 50:
-                    logger.info(f"[{bvid}] content found in MongoDB (shared)")
-                    return doc["content"], doc.get("content_source", "asr")
-            except Exception as e:
-                logger.warning(f"[{bvid}] MongoDB read failed: {e}")
-
-        # 2. Fetch from Bilibili (ASR / subtitle / AI summary)
-        content = await content_fetcher.fetch_content(bvid, cid=cid, title=title)
-        text = (content.content or "").strip() if content else ""
-        source = content.source.value if content else ContentSource.BASIC_INFO.value
-
-        if not text or len(text) < 50:
-            logger.warning(f"[{bvid}] fetched content too short ({len(text)} chars)")
-            return text, source
-
-        # 3. Save to MongoDB (shared — future users skip ASR)
-        if _mongo_ok():
-            try:
-                await save_asr(
-                    video_id=bv_to_av(bvid),
-                    bvid=bvid, cid=cid or 0, page_index=0,
-                    page_title=meta.get("title", title),
-                    content=text, content_source=source,
-                )
-                logger.info(f"[{bvid}] content saved to MongoDB (shared)")
-            except Exception as e:
-                logger.warning(f"[{bvid}] MongoDB save failed: {e}")
-
-        return text, source
-
-    # ── Per-page vectorization ──
-    # Three-layer ingestion: collection (folder) → video (bvid) → page (cid).
-    # For each bvid we materialize all pages into the `video` table, then
-    # serially feed every still-pending page into vector_page_service so it
-    # runs through ASR + vectorization with proper task tracking.
-    from app.services.video.service import VideoService
-    from app.services.vector_page_service import VectorPageService
-
-    video_service = VideoService()
-    page_tracker = TaskTracker()
-    vector_service = VectorPageService(page_tracker, rag=rag)
-
-    # Walk every video in this folder so newly-added pages of previously-known
-    # bvids also get picked up. Already-done pages will be skipped cheaply.
-    targets = list(current_bvids)
-    total_targets = len(targets)
-    processed_targets = 0
-    if progress_callback:
-        progress_callback("准备处理", processed_targets, total_targets)
-
-    failed_pages: list[tuple[str, int]] = []
-
-    for bvid in targets:
-        meta = video_map[bvid]
-
-        try:
-            # 1) Materialize all pages of this bvid into `video` table
-            pages_info = await video_service.list_pages_by_bvid(bvid, bili, db)
-            pages = pages_info.get("pages") or []
-
-            # 2) Filter pages that still need vectorization
-            todo = [p for p in pages if p.get("is_vectorized") != "done"]
-            if not todo:
-                logger.info(
-                    f"[{bvid}] all {len(pages)} page(s) already vectorized, skipping"
-                )
-            else:
-                logger.info(
-                    f"[{bvid}] queue {len(todo)}/{len(pages)} page(s) for vectorization"
-                )
-                for p_idx, p in enumerate(todo):
-                    cid = p["cid"]
-                    page_index = p["page_index"]
-                    page_title = p.get("page_title") or f"P{page_index + 1}"
-
-                    vec_task_id = await page_tracker.create(
-                        uid=uid,
-                        task_type="vec_page",
-                        target={
-                            "bvid": bvid,
-                            "cid": cid,
-                            "page_index": page_index,
-                            "page_title": page_title,
-                        },
-                    )
-                    try:
-                        await vector_service.process_page_vectorization(
-                            task_id=vec_task_id,
-                            bvid=bvid,
-                            cid=cid,
-                            page_index=page_index,
-                            page_title=page_title,
-                        )
-                    except Exception as page_err:
-                        # Failed page is already marked is_vectorized=failed in
-                        # vector_page_service; just log and move on.
-                        logger.warning(
-                            f"[{bvid}] page cid={cid} idx={page_index} failed: {page_err}"
-                        )
-                        failed_pages.append((bvid, cid))
-
-                    # Inter-page pause: 1-3s human pacing per the spec.
-                    if p_idx < len(todo) - 1:
-                        await _human_pause(1.0, 3.0)
-
-        except Exception as e:
-            logger.warning(f"[{bvid}] enumerate/process pages failed: {e}")
-            failed_pages.append((bvid, -1))
-
-        processed_targets += 1
-        if progress_callback:
-            progress_callback(meta["title"], processed_targets, total_targets)
-
-        # Inter-video pause to keep load steady across the whole folder.
-        if processed_targets < total_targets:
-            await _human_pause(1.5, 4.0)
-
-    if failed_pages:
-        logger.warning(
-            f"[{folder_id}] {len(failed_pages)} page(s) failed during vectorization"
-        )
-
-    # 删除已移除的视频
-    if removed:
-        for bvid in removed:
-            other_count = await db.scalar(
-                select(func.count())
-                .select_from(Collection)
-                .where(Collection.bvid == bvid, Collection.media_id != folder_id)
-            )
-            if other_count == 0:
-                try:
-                    rag.delete_video(bvid)
-                except Exception as e:
-                    logger.warning(f"删除向量失败 [{bvid}]: {e}")
-
-        await db.execute(
-            delete(Collection).where(
-                Collection.media_id == folder_id,
-                Collection.bvid.in_(removed),
-            )
-        )
-
-    folder.last_sync_at = datetime.now(timezone.utc)
-    await db.commit()
-
-    # 清除 Redis 缓存（folder_status + vec_status）
-    try:
-        from app.infra.redis import client as _redis, k as _rk
-        if _redis:
-            await _redis.delete(_rk("folder_status", str(uid)))
-    except Exception:
-        pass
-
-    indexed_count = await db.scalar(
-        select(func.count(func.distinct(Collection.bvid)))
-        .select_from(Collection)
-        .where(Collection.media_id == folder_id)
-    )
-
-    return {
-        "folder_id": folder_id,
-        "total": valid_count,
-        "added": len(added),
-        "removed": len(removed),
-        "indexed": indexed_count or 0,
-        "message": "同步完成",
-        "last_sync_at": folder.last_sync_at,
-    }
-
-
-@router.get("/stats")
-async def get_knowledge_stats(uid: int = Depends(get_current_uid)):
-    """获取知识库统计信息"""
-    try:
-        rag = get_rag_service()
-        stats = rag.get_collection_stats()
-        return stats
-    except Exception as e:
-        logger.exception("Failed to get knowledge stats")
-        raise HTTPException(status_code=500, detail=str(e))
-
-
-@router.get("/folders/status", response_model=List[FolderStatus])
-async def get_folder_status(
-    uid: int = Depends(get_current_uid),
-    db: AsyncSession = Depends(get_db),
-):
-    """获取收藏夹入库状态 — 按「所有分P均已向量化」的视频数统计"""
-
-    # 0. 尝试 Redis 缓存（30s TTL）
-    try:
-        from app.infra.redis import client as _redis, k as _rk, jget as _rjget, jset as _rjset
-        cache_key = _rk("folder_status", str(uid))
-        if _redis:
-            cached = await _rjget(cache_key)
-            if cached:
-                return [FolderStatus(**item) for item in cached]
-    except Exception:
-        pass
-
-    # 1. 查该用户所有有效收藏夹
-    folders_result = await db.execute(
-        select(
-            FavoriteFolder.media_id,
-            FavoriteFolder.media_count,
-            FavoriteFolder.last_sync_at,
-        ).where(
-            FavoriteFolder.uid == uid,
-            FavoriteFolder.deleted_at.is_(None),
-        )
-    )
-    folders = folders_result.all()
-    if not folders:
-        return []
-
-    # {media_id: (media_count, last_sync_at)}
-    folder_meta = {
-        row.media_id: (row.media_count, row.last_sync_at)
-        for row in folders
-    }
-    media_ids = list(folder_meta.keys())
-
-    # 2. 统计每个收藏夹中「所有分P均已向量化」的视频数（bvid 级别）
-    incomplete_sub = (
-        select(Video.bvid)
-        .where(
-            or_(
-                Video.is_vectorized != "done",
-                Video.is_vectorized.is_(None),
-            )
-        )
-        .subquery()
-    )
-    counts_result = await db.execute(
-        select(
-            Collection.media_id,
-            func.count(func.distinct(Video.bvid)),
-        ).select_from(Collection).join(
-            Video,
-            Video.bvid == Collection.bvid,
-        ).where(
-            Collection.media_id.in_(media_ids),
-            ~Video.bvid.in_(select(incomplete_sub.c.bvid)),
-        ).group_by(Collection.media_id)
-    )
-    count_map = {row[0]: row[1] for row in counts_result.all()}
-
-    # 3. 组装返回
-    result = [
-        FolderStatus(
-            media_id=media_id,
-            indexed_count=count_map.get(media_id, 0),
-            media_count=meta[0],
-            last_sync_at=meta[1],
-        )
-        for media_id, meta in folder_meta.items()
-    ]
-
-    # 4. 写入 Redis 缓存（30s TTL）
-    try:
-        if _redis:
-            await _rjset(cache_key, [r.model_dump() for r in result], ex=30)
-    except Exception:
-        pass
-
-    return result
-
-
 class VectorizedPageItem(BaseModel):
-    """向量化分P项"""
     bvid: str
     cid: int
     page_index: int
@@ -572,58 +93,69 @@ class VectorizedPageItem(BaseModel):
     vectorized_at: Optional[datetime] = None
 
 
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("/stats")
+async def get_knowledge_stats(uid: int = Depends(get_current_uid)):
+    """获取知识库统计信息"""
+    try:
+        rag = get_rag_service()
+        return rag.get_collection_stats()
+    except Exception as e:
+        raise internal_error(e)
+
+
+@router.get("/folders/status", response_model=List[FolderStatus])
+async def get_folder_status(
+    uid: int = Depends(get_current_uid),
+    db: AsyncSession = Depends(get_db),
+):
+    """获取收藏夹入库状态 — 按「所有分P均已向量化」的视频数统计"""
+    from app.repository.knowledge_repository import get_knowledge_repository
+
+    # Redis cache (30s TTL)
+    try:
+        from app.infra.redis import (
+            client as _redis,
+            k as _rk,
+            jget as _rjget,
+            jset as _rjset,
+        )
+        cache_key = _rk("folder_status", str(uid))
+        if _redis:
+            cached = await _rjget(cache_key)
+            if cached:
+                return [FolderStatus(**item) for item in cached]
+    except Exception:
+        pass
+
+    rows = await get_knowledge_repository().list_folder_status(uid, db)
+    result = [FolderStatus(**r) for r in rows]
+
+    try:
+        if _redis:
+            await _rjset(
+                cache_key, [r.model_dump() for r in result], ex=30
+            )
+    except Exception:
+        pass
+
+    return result
+
+
 @router.get("/pages/vectorized", response_model=List[VectorizedPageItem])
 async def get_vectorized_pages(
     uid: int = Depends(get_current_uid),
     db: AsyncSession = Depends(get_db),
 ):
     """Get vectorized pages for the current user (uid-scoped)."""
-    # 1. Get all media_ids for this user
-    folders_result = await db.execute(
-        select(FavoriteFolder.media_id)
-        .where(FavoriteFolder.uid == uid, FavoriteFolder.deleted_at.is_(None))
-    )
-    media_ids = [row[0] for row in folders_result.all()]
-    if not media_ids:
-        return []
+    from app.repository.knowledge_repository import get_knowledge_repository
 
-    # 2. Get all bvids belonging to user's collections
-    bvids_result = await db.execute(
-        select(Collection.bvid)
-        .where(Collection.media_id.in_(media_ids))
-    )
-    bvids = list(set(row[0] for row in bvids_result.all() if row[0]))
-    if not bvids:
-        return []
-
-    # 3. Get vectorized pages from video table
-    pages_result = await db.execute(
-        select(Video)
-        .where(Video.bvid.in_(bvids), Video.is_vectorized == "done")
-        .order_by(Video.bvid, Video.page_index)
-    )
-    pages = pages_result.scalars().all()
-
-    # 4. Resolve video titles from collection
-    bvid_set = {p.bvid for p in pages}
-    titles_result = await db.execute(
-        select(Collection.bvid, Collection.title)
-        .where(Collection.bvid.in_(bvid_set))
-    )
-    title_map = {row[0]: row[1] for row in titles_result.all()}
-
-    return [
-        VectorizedPageItem(
-            bvid=p.bvid,
-            cid=p.cid,
-            page_index=p.page_index,
-            page_title=p.page_title,
-            video_title=title_map.get(p.bvid, ""),
-            vector_chunk_count=p.vector_chunk_count or 0,
-            vectorized_at=p.vectorized_at,
-        )
-        for p in pages
-    ]
+    rows = await get_knowledge_repository().list_vectorized_pages(uid, db)
+    return [VectorizedPageItem(**r) for r in rows]
 
 
 @router.post("/folders/sync", response_model=List[SyncResult])
@@ -633,28 +165,25 @@ async def sync_folders(
     db: AsyncSession = Depends(get_db),
 ):
     """同步收藏夹到向量库"""
-    bili, bili_mid = await _get_bili_cookies_by_uid(uid, db)
+    from app.services.knowledge_build import KnowledgeSyncService
 
+    bili, bili_mid = await _get_bili_cookies_by_uid(uid, db)
     rag = get_rag_service()
     asr_service = ASRService()
     content_fetcher = ContentFetcher(bili, asr_service)
+    sync_service = KnowledgeSyncService()
 
     try:
         folder_ids = request.folder_ids or []
         if not folder_ids:
             folders = await bili.get_user_favorites(mid=bili_mid)
-            folder_ids = [folder.get("id") for folder in folders if folder.get("id")]
+            folder_ids = [f.get("id") for f in folders if f.get("id")]
 
         results: List[SyncResult] = []
         for folder_id in folder_ids:
             try:
-                result = await _sync_folder(
-                    db,
-                    bili,
-                    rag,
-                    content_fetcher,
-                    uid,
-                    folder_id,
+                result = await sync_service.sync_folder(
+                    db, bili, rag, content_fetcher, uid, folder_id
                 )
                 results.append(SyncResult(**result))
             except Exception as e:
@@ -679,309 +208,53 @@ async def sync_folders(
 @router.post("/build")
 async def build_knowledge_base(
     request: BuildRequest,
-    background_tasks: BackgroundTasks,
     uid: int = Depends(get_current_uid),
     db: AsyncSession = Depends(get_db),
 ):
-    """构建知识库（后台任务，写入 async_tasks 表）。
+    """构建知识库（后台任务）。
 
     全局单例：同一进程同一时刻只允许一个 build 任务在跑。重复点击直接
-    返回当前活跃的 task_id，而不是再起一个新的——避免对 B站 CDN 的并发
-    请求触发限流。
+    复用当前活跃的 task_id，避免对 B站 CDN 的并发请求触发限流。
     """
-    global _active_build_task_id, _active_build_uid
+    from app.services.knowledge_build import get_build_service
 
-    async with _active_build_lock:
-        if _active_build_task_id is not None:
-            logger.info(
-                f"[build] reuse active task_id={_active_build_task_id} "
-                f"uid={_active_build_uid} (requested by uid={uid})"
-            )
-            return {
-                "task_id": _active_build_task_id,
-                "message": "已有构建任务在运行，复用该任务",
-                "reused": True,
-            }
+    bili, _bili_mid = await _get_bili_cookies_by_uid(uid, db)
+    sessdata = bili.sessdata
+    await bili.close()
 
-        bili, _bili_mid = await _get_bili_cookies_by_uid(uid, db)
-        sessdata = bili.sessdata
-
-        tracker = TaskTracker()
-        task_id = await tracker.create(
-            uid=uid,
-            task_type="build",
-            target={"folder_ids": request.folder_ids},
-        )
-        # Legacy in-memory compat (existing polling endpoint still reads build_tasks)
-        build_tasks[task_id] = build_tasks.get(task_id) or {
-            "status": "pending", "progress": 0, "current_step": "初始化中...",
-            "total_videos": 0, "processed_videos": 0, "message": "",
-        }
-
-        # Mark this task as the active singleton BEFORE scheduling, so a
-        # second click that arrives while we're still in this function still
-        # sees the lock as taken.
-        _active_build_task_id = task_id
-        _active_build_uid = uid
-
-    background_tasks.add_task(
-        _build_knowledge_base_task,
-        task_id,
-        uid,
-        sessdata,
-        request.folder_ids,
-        request.exclude_bvids or [],
+    return await get_build_service().try_start_build(
+        uid=uid,
+        folder_ids=request.folder_ids,
+        exclude_bvids=request.exclude_bvids or [],
+        sessdata=sessdata,
     )
-
-    return {"task_id": task_id, "message": "构建任务已启动", "reused": False}
 
 
 @router.get("/build/active")
 async def get_active_build_task(uid: int = Depends(get_current_uid)):
     """查询当前是否有活跃的 build 任务（前端用来禁用按钮 / 复用 task_id）。"""
-    if _active_build_task_id is None:
-        return {"active": False, "task_id": None, "uid": None}
-    return {
-        "active": True,
-        "task_id": _active_build_task_id,
-        "uid": _active_build_uid,
-        "is_yours": _active_build_uid == uid,
-    }
+    from app.services.knowledge_build import get_build_service
 
-
-async def _build_knowledge_base_task(
-    task_id: str,
-    uid: int,
-    sessdata: str,
-    folder_ids: List[int],
-    exclude_bvids: List[str],
-):
-    """后台构建任务 — 通过 TaskTracker 写入 async_tasks 表，完成后广播 WebSocket。"""
-    from app.services.async_task.tracker import TaskTracker
-    global _active_build_task_id, _active_build_uid
-
-    # Mutable cursor of "where are we right now". Updated as we move between
-    # folders / videos so every _notify() call carries the same context.
-    cursor: dict = {
-        "folder_index": 0,
-        "total_folders": 0,
-        "folder_id": None,
-        "folder_title": None,
-        "video_index": 0,
-        "total_videos_in_folder": 0,
-        "current_video_title": None,
-    }
-
-    def _notify(status: str, **kwargs) -> None:
-        """Update legacy state + broadcast to WebSocket clients.
-
-        Always includes the current folder/video cursor so the frontend can
-        render "收藏夹 A: 3/12 — 正在处理《XXX》" without extra round trips.
-        """
-        # legacy_state only knows a small set of fields; pass them explicitly.
-        legacy_kwargs = {
-            k: v for k, v in kwargs.items()
-            if k in {"progress", "processed", "total_videos", "message"}
-        }
-        if "current_step" in kwargs:
-            legacy_kwargs["step"] = kwargs["current_step"]
-        legacy_state(task_id, status, **legacy_kwargs)
-        try:
-            from app.services.ws_registry import broadcast_task_update
-            import asyncio
-            task_info = {
-                "task_id": task_id, "task_type": "build", "uid": uid,
-                "status": status,
-                **cursor,
-                **kwargs,
-            }
-            asyncio.ensure_future(broadcast_task_update(uid, task_info))
-        except Exception:
-            pass
-
-    tracker = TaskTracker()
-
-    try:
-        await tracker.start(task_id)
-        legacy_state(task_id, "running", "同步收藏夹...")
-
-        bili = BilibiliService(sessdata=sessdata, bili_jct="")
-        asr_service = ASRService()
-        content_fetcher = ContentFetcher(bili, asr_service)
-        rag = get_rag_service()
-
-        try:
-            total_folders = len(folder_ids)
-            if total_folders == 0:
-                await tracker.complete(task_id, {"message": "没有需要处理的收藏夹"})
-                _notify("done", progress=100, current_step="完成")
-                return
-
-            total_videos_processed = 0
-            total_added = 0
-            total_removed = 0
-
-            cursor["total_folders"] = total_folders
-
-            async with get_db_context() as db:
-                for idx, folder_id in enumerate(folder_ids, start=1):
-                    folder_progress = int((idx / total_folders) * 100)
-
-                    # Resolve folder title (best-effort) so the broadcast carries
-                    # human-readable context, not just a numeric id.
-                    folder_title: Optional[str] = None
-                    try:
-                        ff_row = await db.execute(
-                            select(FavoriteFolder.title).where(
-                                FavoriteFolder.media_id == folder_id,
-                                FavoriteFolder.uid == uid,
-                            )
-                        )
-                        folder_title = ff_row.scalar_one_or_none()
-                    except Exception:
-                        folder_title = None
-
-                    cursor.update({
-                        "folder_index": idx,
-                        "folder_id": folder_id,
-                        "folder_title": folder_title,
-                        "video_index": 0,
-                        "total_videos_in_folder": 0,
-                        "current_video_title": None,
-                    })
-
-                    folder_label = folder_title or f"#{folder_id}"
-                    await tracker.step(
-                        task_id,
-                        name=f"folder:{folder_id}",
-                        status="processing",
-                        progress=folder_progress,
-                    )
-                    _notify(
-                        "running",
-                        progress=folder_progress,
-                        current_step=f"收藏夹 {idx}/{total_folders}：{folder_label}",
-                    )
-
-                    def progress_cb(title: str, count: int = 0, total: int = 0):
-                        cursor.update({
-                            "video_index": count,
-                            "total_videos_in_folder": total,
-                            "current_video_title": title,
-                        })
-                        legacy_state(
-                            task_id, "running",
-                            step=f"处理: {title}",
-                            processed=count, total_videos=total,
-                        )
-                        _notify(
-                            "running",
-                            progress=folder_progress,
-                            current_step=f"{folder_label} {count}/{total}：{title}",
-                        )
-
-                    result = await _sync_folder(
-                        db, bili, rag, content_fetcher,
-                        uid, folder_id,
-                        exclude_bvids=set(exclude_bvids),
-                        progress_callback=progress_cb,
-                    )
-
-                    total_videos_processed += result.get("added", 0) + result.get("indexed", 0)
-                    total_added += result["added"]
-                    total_removed += result["removed"]
-
-                    # Human-pace pause between folders so we don't hammer the API.
-                    if idx < total_folders:
-                        wait_s = random.uniform(2.0, 5.0)
-                        _notify(
-                            "running",
-                            progress=folder_progress,
-                            current_step=f"等待 {wait_s:.1f}s 后处理下一个收藏夹",
-                        )
-                        await asyncio.sleep(wait_s)
-
-            await tracker.complete(
-                task_id,
-                result={
-                    "folders_processed": total_folders,
-                    "videos_added": total_added,
-                    "videos_removed": total_removed,
-                },
-            )
-            cursor.update({
-                "video_index": 0,
-                "total_videos_in_folder": 0,
-                "current_video_title": None,
-            })
-            _notify("done", progress=100,
-                    current_step="完成",
-                    message=f"同步完成：新增 {total_added}，移除 {total_removed}")
-
-            # 清除 Redis 缓存
-            try:
-                from app.infra.redis import client as _redis2, k as _rk2
-                if _redis2:
-                    await _redis2.delete(_rk2("folder_status", str(uid)))
-            except Exception:
-                pass
-
-            logger.info(f"知识库构建完成: 新增 {total_added}，移除 {total_removed}")
-        finally:
-            await bili.close()
-
-    except Exception as e:
-        logger.exception("Build task failed")
-        await tracker.fail(task_id, str(e))
-        _notify("failed", message=str(e))
-    finally:
-        # Release the singleton so a new build can be scheduled.
-        async with _active_build_lock:
-            if _active_build_task_id == task_id:
-                _active_build_task_id = None
-                _active_build_uid = None
-                logger.info(f"[build] released singleton task_id={task_id}")
-
-
-def legacy_state(task_id: str, status: str, step: str = "",
-                 progress: int = 0, processed: int = 0, total_videos: int = 0,
-                 message: str = "") -> None:
-    """Update legacy in-memory build_tasks dict for backward compat."""
-    t = build_tasks.setdefault(task_id, {})
-    if status:
-        t["status"] = status
-    if step:
-        t["current_step"] = step
-    if progress is not None:
-        t["progress"] = progress
-    if processed:
-        t["processed_videos"] = processed
-    if total_videos:
-        t["total_videos"] = total_videos
-    if message:
-        t["message"] = message
+    return get_build_service().get_active_build(uid)
 
 
 @router.get("/build/status/{task_id}", response_model=BuildStatus)
 async def get_build_status(task_id: str, uid: int = Depends(get_current_uid)):
     """获取构建任务状态 — async_tasks 表优先，build_tasks 内存兜底"""
+    from app.repository.knowledge_repository import get_knowledge_repository
+    from app.services.knowledge_build.build_service import build_tasks
+
     # 1. Try async_tasks table (persisted)
     try:
-        from app.database import get_db_context
-        from sqlalchemy import select
-        from app.models import AsyncTask
-
         async with get_db_context() as db:
-            result = await db.execute(
-                select(AsyncTask).where(AsyncTask.task_id == task_id)
+            row = await get_knowledge_repository().get_build_status_row(
+                task_id, uid, db
             )
-            row = result.scalar_one_or_none()
             if row:
                 current_step = ""
                 if row.steps:
                     last = row.steps[-1] if row.steps else {}
                     current_step = last.get("name", "")
-                # `total_videos` is a count, not the folder list itself.
                 folder_ids = (row.target or {}).get("folder_ids") or []
                 return BuildStatus(
                     task_id=task_id,
@@ -1012,27 +285,48 @@ async def get_build_status(task_id: str, uid: int = Depends(get_current_uid)):
 
 
 @router.delete("/clear")
-async def clear_knowledge_base(uid: int = Depends(get_current_uid)):
-    """清空知识库"""
+async def clear_knowledge_base(uid: int = Depends(require_admin)):
+    """清空知识库（全局破坏性操作，仅管理员）"""
     try:
         rag = get_rag_service()
         rag.clear_collection()
         return {"message": "知识库已清空"}
     except Exception as e:
-        logger.exception("Failed to clear knowledge base")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise internal_error(e)
 
 
 @router.delete("/video/{bvid}")
-async def delete_video_from_knowledge(bvid: str, uid: int = Depends(get_current_uid)):
-    """从知识库中删除指定视频"""
+async def delete_video_from_knowledge(
+    bvid: str,
+    uid: int = Depends(get_current_uid),
+    db: AsyncSession = Depends(get_db),
+):
+    """从知识库中删除指定视频。
+
+    安全约束：bvid 必须属于当前用户的某个有效收藏夹（通过 collection +
+    favorite_folder 联表校验），否则拒绝。管理员旁路。
+    """
+    from app.repository.knowledge_repository import get_knowledge_repository
+    from app.repository.rbac_repository import get_rbac_repository
+
     try:
+        if not await get_knowledge_repository().bvid_belongs_to_user(
+            bvid, uid, db
+        ):
+            roles = await get_rbac_repository().get_user_roles(uid, db)
+            if "admin" not in roles:
+                raise HTTPException(
+                    status_code=403,
+                    detail="无权删除：该视频不在你的收藏夹中",
+                )
+
         rag = get_rag_service()
         rag.delete_video(bvid)
         return {"message": f"已删除视频 {bvid}"}
+    except HTTPException:
+        raise
     except Exception as e:
-        logger.exception("Failed to delete video")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise internal_error(e)
 
 
 # ==================== 视频分P旁路缓存 ====================
@@ -1047,37 +341,27 @@ async def get_video(
     cache=Depends(cache_dependency_singleton()),
     uid: int = Depends(get_current_uid),
 ):
-    """
-    获取视频全部分P信息（旁路缓存策略）
-
-    缓存未命中 → 调 B站 API → 写入缓存（TTL=24h）→ 返回
-    缓存命中 → 直接返回
-    """
-    # 1. 校验 bvid 格式
+    """获取视频全部分P信息（旁路缓存策略）"""
     if not re.match(r"^[Bb][Vv][a-zA-Z0-9]{10}$", bvid):
         raise HTTPException(status_code=400, detail="Invalid bvid format")
 
     cache_key = PAGES_CACHE_KEY.format(bvid=bvid)
-
-    # 2. 查缓存
     cached = cache.get(cache_key)
     if cached:
         return VideosResponse(**cached)
 
-    # 3. 缓存未命中，调 B站 API
     bili = BilibiliService()
     try:
         video_info = await bili.get_video_info(bvid)
-    except Exception as e:
+    except Exception:
         logger.exception("[PAGES] Bilibili API call failed bvid={}", bvid)
-        raise HTTPException(status_code=502, detail=f"B站 API 调用失败: {e}")
+        raise HTTPException(status_code=502, detail="B站 API 调用失败，请稍后重试")
     finally:
         await bili.close()
 
     pages_raw = video_info.get("pages") or []
     page_count = len(pages_raw) if pages_raw else 1
 
-    # 4. 构建响应数据
     data = {
         "bvid": bvid,
         "title": video_info.get("title", ""),
@@ -1093,11 +377,9 @@ async def get_video(
         "page_count": page_count,
     }
 
-    # 5. 写入缓存（降级：缓存失败仍返回数据）
     try:
         cache.set(cache_key, data)
     except Exception as e:
         logger.warning(f"[PAGES] 缓存写入失败 bvid={bvid}: {e}")
 
     return VideosResponse(**data)
-

--- a/app/services/knowledge_build/__init__.py
+++ b/app/services/knowledge_build/__init__.py
@@ -1,0 +1,15 @@
+"""Knowledge build services — sync + build orchestration.
+
+Split out of ``app/routers/knowledge.py`` to keep the router a thin HTTP layer.
+"""
+from app.services.knowledge_build.sync_service import KnowledgeSyncService
+from app.services.knowledge_build.build_service import (
+    KnowledgeBuildService,
+    get_build_service,
+)
+
+__all__ = [
+    "KnowledgeSyncService",
+    "KnowledgeBuildService",
+    "get_build_service",
+]

--- a/app/services/knowledge_build/build_service.py
+++ b/app/services/knowledge_build/build_service.py
@@ -1,0 +1,357 @@
+"""Knowledge build service — orchestrates the multi-folder build background task.
+
+Absorbs ``_build_knowledge_base_task``, ``legacy_state``, ``build_tasks``,
+and the process-wide singleton lock (``_active_build_*``) from
+``app/routers/knowledge.py``.
+
+The singleton lock guarantees at most one build per process: B站 throttles
+concurrent requests aggressively, and parallel builds hit the same SESSDATA
+twice triggering RST mid-download.
+"""
+from __future__ import annotations
+
+import asyncio
+import random
+from typing import Any, Optional
+
+from loguru import logger
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db_context
+from app.models import FavoriteFolder
+from app.services.async_task.tracker import TaskTracker
+from app.services.bilibili import BilibiliService
+from app.services.content_fetcher import ContentFetcher
+from app.services.asr import ASRService
+from app.services.rag import get_rag_service
+from app.services.knowledge_build.sync_service import KnowledgeSyncService
+
+
+# Legacy in-memory build task state (kept for backward compat with older
+# polling clients that don't read the async_tasks table).
+build_tasks: dict[str, dict[str, Any]] = {}
+
+# Strong refs for background tasks — prevents asyncio from GC'ing them
+# mid-flight. Without this, _run_build_task could be collected at an await
+# point, the singleton lock would never release, and every subsequent
+# /knowledge/build call would "reuse" the dead task_id forever.
+_background_tasks: set[asyncio.Task] = set()
+
+
+def _spawn(coro) -> asyncio.Task:
+    task = asyncio.create_task(coro)
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
+    return task
+
+
+def legacy_state(
+    task_id: str,
+    status: str,
+    step: str = "",
+    progress: int = 0,
+    processed: int = 0,
+    total_videos: int = 0,
+    message: str = "",
+) -> None:
+    """Update legacy in-memory build_tasks dict for backward compat."""
+    t = build_tasks.setdefault(task_id, {})
+    if status:
+        t["status"] = status
+    if step:
+        t["current_step"] = step
+    if progress is not None:
+        t["progress"] = progress
+    if processed:
+        t["processed_videos"] = processed
+    if total_videos:
+        t["total_videos"] = total_videos
+    if message:
+        t["message"] = message
+
+
+class KnowledgeBuildService:
+    """Singleton-style orchestrator for the /knowledge/build background task."""
+
+    def __init__(self) -> None:
+        self._active_build_task_id: Optional[str] = None
+        self._active_build_uid: Optional[int] = None
+        self._lock = asyncio.Lock()
+        self._sync_service = KnowledgeSyncService()
+
+    def is_build_active(self) -> bool:
+        return self._active_build_task_id is not None
+
+    async def try_start_build(
+        self,
+        uid: int,
+        folder_ids: list[int],
+        exclude_bvids: list[str],
+        sessdata: str,
+    ) -> dict:
+        """Acquire the singleton lock and schedule the build task.
+
+        Returns ``{"task_id", "message", "reused"}``. If a build is already
+        running, reuses that task_id instead of starting a new one.
+        """
+        async with self._lock:
+            if self._active_build_task_id is not None:
+                logger.info(
+                    f"[build] reuse active task_id={self._active_build_task_id} "
+                    f"uid={self._active_build_uid} (requested by uid={uid})"
+                )
+                return {
+                    "task_id": self._active_build_task_id,
+                    "message": "已有构建任务在运行，复用该任务",
+                    "reused": True,
+                }
+
+            tracker = TaskTracker()
+            task_id = await tracker.create(
+                uid=uid,
+                task_type="build",
+                target={"folder_ids": folder_ids},
+            )
+            build_tasks[task_id] = build_tasks.get(task_id) or {
+                "status": "pending",
+                "progress": 0,
+                "current_step": "初始化中...",
+                "total_videos": 0,
+                "processed_videos": 0,
+                "message": "",
+            }
+
+            # Mark active BEFORE scheduling so a concurrent caller sees the lock taken.
+            self._active_build_task_id = task_id
+            self._active_build_uid = uid
+
+        # Schedule the background task (strongly referenced via _spawn).
+        _spawn(
+            self._run_build_task(
+                task_id, uid, sessdata, folder_ids, exclude_bvids
+            )
+        )
+
+        return {"task_id": task_id, "message": "构建任务已启动", "reused": False}
+
+    def get_active_build(self, uid: int) -> dict:
+        """Return the currently active build task, if any."""
+        if self._active_build_task_id is None:
+            return {"active": False, "task_id": None, "uid": None}
+        return {
+            "active": True,
+            "task_id": self._active_build_task_id,
+            "uid": self._active_build_uid,
+            "is_yours": self._active_build_uid == uid,
+        }
+
+    async def _run_build_task(
+        self,
+        task_id: str,
+        uid: int,
+        sessdata: str,
+        folder_ids: list[int],
+        exclude_bvids: list[str],
+    ) -> None:
+        """Background build task — writes to async_tasks table, broadcasts WS."""
+        cursor: dict[str, Any] = {
+            "folder_index": 0,
+            "total_folders": 0,
+            "folder_id": None,
+            "folder_title": None,
+            "video_index": 0,
+            "total_videos_in_folder": 0,
+            "current_video_title": None,
+        }
+
+        def _notify(status: str, **kwargs: Any) -> None:
+            legacy_kwargs = {
+                k: v
+                for k, v in kwargs.items()
+                if k in {"progress", "processed", "total_videos", "message"}
+            }
+            if "current_step" in kwargs:
+                legacy_kwargs["step"] = kwargs["current_step"]
+            legacy_state(task_id, status, **legacy_kwargs)
+            try:
+                from app.services.ws_registry import broadcast_task_update
+                task_info = {
+                    "task_id": task_id,
+                    "task_type": "build",
+                    "uid": uid,
+                    "status": status,
+                    **cursor,
+                    **kwargs,
+                }
+                _spawn(broadcast_task_update(uid, task_info))
+            except Exception:
+                pass
+
+        tracker = TaskTracker()
+
+        try:
+            await tracker.start(task_id)
+            legacy_state(task_id, "running", "同步收藏夹...")
+
+            bili = BilibiliService(sessdata=sessdata, bili_jct="")
+            asr_service = ASRService()
+            content_fetcher = ContentFetcher(bili, asr_service)
+            rag = get_rag_service()
+
+            try:
+                total_folders = len(folder_ids)
+                if total_folders == 0:
+                    await tracker.complete(
+                        task_id, {"message": "没有需要处理的收藏夹"}
+                    )
+                    _notify("done", progress=100, current_step="完成")
+                    return
+
+                total_added = 0
+                total_removed = 0
+                cursor["total_folders"] = total_folders
+
+                async with get_db_context() as db:
+                    for idx, folder_id in enumerate(folder_ids, start=1):
+                        folder_progress = int((idx / total_folders) * 100)
+
+                        folder_title: Optional[str] = None
+                        try:
+                            ff_row = await db.execute(
+                                select(FavoriteFolder.title).where(
+                                    FavoriteFolder.media_id == folder_id,
+                                    FavoriteFolder.uid == uid,
+                                )
+                            )
+                            folder_title = ff_row.scalar_one_or_none()
+                        except Exception:
+                            folder_title = None
+
+                        cursor.update(
+                            {
+                                "folder_index": idx,
+                                "folder_id": folder_id,
+                                "folder_title": folder_title,
+                                "video_index": 0,
+                                "total_videos_in_folder": 0,
+                                "current_video_title": None,
+                            }
+                        )
+
+                        folder_label = folder_title or f"#{folder_id}"
+                        await tracker.step(
+                            task_id,
+                            name=f"folder:{folder_id}",
+                            status="processing",
+                            progress=folder_progress,
+                        )
+                        _notify(
+                            "running",
+                            progress=folder_progress,
+                            current_step=f"收藏夹 {idx}/{total_folders}：{folder_label}",
+                        )
+
+                        def progress_cb(
+                            title: str, count: int = 0, total: int = 0
+                        ) -> None:
+                            cursor.update(
+                                {
+                                    "video_index": count,
+                                    "total_videos_in_folder": total,
+                                    "current_video_title": title,
+                                }
+                            )
+                            legacy_state(
+                                task_id,
+                                "running",
+                                step=f"处理: {title}",
+                                processed=count,
+                                total_videos=total,
+                            )
+                            _notify(
+                                "running",
+                                progress=folder_progress,
+                                current_step=f"{folder_label} {count}/{total}：{title}",
+                            )
+
+                        result = await self._sync_service.sync_folder(
+                            db,
+                            bili,
+                            rag,
+                            content_fetcher,
+                            uid,
+                            folder_id,
+                            exclude_bvids=set(exclude_bvids),
+                            progress_callback=progress_cb,
+                        )
+
+                        total_added += result["added"]
+                        total_removed += result["removed"]
+
+                        if idx < total_folders:
+                            wait_s = random.uniform(2.0, 5.0)
+                            _notify(
+                                "running",
+                                progress=folder_progress,
+                                current_step=f"等待 {wait_s:.1f}s 后处理下一个收藏夹",
+                            )
+                            await asyncio.sleep(wait_s)
+
+                await tracker.complete(
+                    task_id,
+                    result={
+                        "folders_processed": total_folders,
+                        "videos_added": total_added,
+                        "videos_removed": total_removed,
+                    },
+                )
+                cursor.update(
+                    {
+                        "video_index": 0,
+                        "total_videos_in_folder": 0,
+                        "current_video_title": None,
+                    }
+                )
+                _notify(
+                    "done",
+                    progress=100,
+                    current_step="完成",
+                    message=f"同步完成：新增 {total_added}，移除 {total_removed}",
+                )
+
+                try:
+                    from app.infra.redis import client as _redis, k as _rk
+                    if _redis:
+                        await _redis.delete(_rk("folder_status", str(uid)))
+                except Exception:
+                    pass
+
+                logger.info(
+                    f"知识库构建完成: 新增 {total_added}，移除 {total_removed}"
+                )
+            finally:
+                await bili.close()
+
+        except Exception as e:
+            logger.exception("Build task failed")
+            await tracker.fail(task_id, str(e))
+            _notify("failed", message=str(e))
+        finally:
+            async with self._lock:
+                if self._active_build_task_id == task_id:
+                    self._active_build_task_id = None
+                    self._active_build_uid = None
+                    logger.info(f"[build] released singleton task_id={task_id}")
+
+
+# ── Module-level singleton ────────────────────────────────────────
+
+_build_service: Optional[KnowledgeBuildService] = None
+
+
+def get_build_service() -> KnowledgeBuildService:
+    global _build_service
+    if _build_service is None:
+        _build_service = KnowledgeBuildService()
+    return _build_service

--- a/app/services/knowledge_build/build_service.py
+++ b/app/services/knowledge_build/build_service.py
@@ -16,7 +16,6 @@ from typing import Any, Optional
 
 from loguru import logger
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db_context
 from app.models import FavoriteFolder

--- a/app/services/knowledge_build/sync_service.py
+++ b/app/services/knowledge_build/sync_service.py
@@ -1,0 +1,345 @@
+"""Knowledge sync service — synchronize a single Bilibili favorite folder.
+
+Absorbs ``_sync_folder`` (and its helpers ``_extract_video_info``,
+``_upsert_collection``, ``_get_or_create_folder``, ``_human_pause``)
+from ``app/routers/knowledge.py``.
+
+Per CLAUDE.md §6, this is service-layer code: it orchestrates B站 API,
+MongoDB, MySQL, and the vector pipeline. The router calls into this;
+this module never touches HTTP.
+"""
+from __future__ import annotations
+
+import asyncio
+import random
+from datetime import datetime, timezone
+from typing import Any, Callable, Optional
+
+from loguru import logger
+from sqlalchemy import select, func, delete
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import FavoriteFolder, Collection
+from app.response.knowledge import ContentSource
+from app.services.bilibili import BilibiliService
+from app.services.content_fetcher import ContentFetcher
+from app.services.rag import RAGService
+from app.utils.bvid import bv_to_av
+
+
+async def _human_pause(min_s: float, max_s: float) -> None:
+    """Random sleep between min_s and max_s seconds — mimics human pacing."""
+    await asyncio.sleep(random.uniform(min_s, max_s))
+
+
+def _extract_video_info(media: dict) -> tuple[str, str, Optional[int]]:
+    """Extract (bvid, title, cid) from a B站 media dict."""
+    bvid = media.get("bvid") or media.get("bv_id")
+    title = media.get("title", bvid)
+    cid: Optional[int] = None
+    ugc = media.get("ugc") or {}
+    if ugc.get("first_cid"):
+        cid = ugc.get("first_cid")
+    else:
+        cid = media.get("cid") or media.get("id")
+    return bvid, title, cid
+
+
+async def _get_or_create_folder(
+    db: AsyncSession,
+    uid: int,
+    media_id: int,
+    title: Optional[str] = None,
+    media_count: Optional[int] = None,
+) -> FavoriteFolder:
+    """Get or create a FavoriteFolder row scoped by uid."""
+    result = await db.execute(
+        select(FavoriteFolder).where(
+            FavoriteFolder.uid == uid,
+            FavoriteFolder.media_id == media_id,
+        )
+    )
+    folder = result.scalar_one_or_none()
+
+    if folder is None:
+        folder = FavoriteFolder(
+            uid=uid,
+            media_id=media_id,
+            title=title or "",
+            media_count=media_count or 0,
+            is_selected=True,
+        )
+        db.add(folder)
+        await db.flush()
+    else:
+        if title:
+            folder.title = title
+        if media_count is not None:
+            folder.media_count = media_count
+
+    return folder
+
+
+async def _upsert_collection(
+    db: AsyncSession, media_id: int, bvid: str, meta: dict
+) -> None:
+    """Insert or update a Collection row keyed by (media_id, bvid)."""
+    result = await db.execute(
+        select(Collection).where(
+            Collection.media_id == media_id, Collection.bvid == bvid
+        )
+    )
+    row = result.scalar_one_or_none()
+
+    if row is None:
+        row = Collection(
+            media_id=media_id,
+            bvid=bvid,
+            title=meta.get("title") or bvid,
+            description=meta.get("intro"),
+            owner_name=meta.get("owner_name"),
+            owner_mid=meta.get("owner_mid"),
+            duration=meta.get("duration"),
+            cover=meta.get("cover"),
+        )
+        db.add(row)
+        return
+
+    if meta.get("title"):
+        row.title = meta["title"]
+    if meta.get("intro") is not None:
+        row.description = meta["intro"]
+    if meta.get("owner_name") is not None:
+        row.owner_name = meta["owner_name"]
+    if meta.get("owner_mid") is not None:
+        row.owner_mid = meta["owner_mid"]
+    if meta.get("duration") is not None:
+        row.duration = meta["duration"]
+    if meta.get("cover") is not None:
+        row.cover = meta["cover"]
+
+
+class KnowledgeSyncService:
+    """Synchronize a single favorite folder to the vector store."""
+
+    async def sync_folder(
+        self,
+        db: AsyncSession,
+        bili: BilibiliService,
+        rag: RAGService,
+        content_fetcher: ContentFetcher,
+        uid: int,
+        folder_id: int,
+        exclude_bvids: Optional[set[str]] = None,
+        progress_callback: Optional[Callable[[str, int, int], None]] = None,
+    ) -> dict:
+        """Sync a single folder; returns a result dict.
+
+        Safety: if B站 returns an empty list while media_count > 0 (a known
+        throttle / network symptom), we DO NOT delete existing rows.
+        """
+        info: dict = {}
+        try:
+            info_result = await bili.get_favorite_content(folder_id, pn=1, ps=1)
+            info = info_result.get("info", {})
+        except Exception as e:
+            logger.warning(f"获取收藏夹信息失败 [{folder_id}]: {e}")
+
+        videos = await bili.get_all_favorite_videos(folder_id)
+        total_in_folder = info.get("media_count", len(videos))
+
+        if not videos:
+            if total_in_folder and total_in_folder > 0:
+                logger.warning(f"[{folder_id}] 收藏夹返回空列表，跳过删除逻辑")
+                existing_count = await db.scalar(
+                    select(func.count()).where(Collection.media_id == folder_id)
+                )
+                return {
+                    "folder_id": folder_id,
+                    "total": total_in_folder,
+                    "added": 0,
+                    "removed": 0,
+                    "indexed": existing_count or 0,
+                    "message": "本次同步异常：空列表，已跳过",
+                    "last_sync_at": datetime.now(timezone.utc),
+                }
+
+        video_map: dict[str, dict] = {}
+        skipped_invalid = 0
+        for media in videos or []:
+            bvid, title, cid = _extract_video_info(media)
+            if not bvid:
+                continue
+            if exclude_bvids and bvid in exclude_bvids:
+                continue
+
+            # attr: 0=normal, 9=invalid, 1=private, etc.
+            attr = media.get("attr", 0)
+            if attr == 9 or title in ["已失效视频", "已删除视频"]:
+                skipped_invalid += 1
+                logger.debug(f"跳过失效视频: {bvid} - {title}")
+                continue
+
+            owner = media.get("upper") or {}
+            video_map[bvid] = {
+                "title": title,
+                "cid": cid,
+                "intro": media.get("intro"),
+                "cover": media.get("cover"),
+                "duration": media.get("duration"),
+                "owner_name": owner.get("name"),
+                "owner_mid": owner.get("mid"),
+            }
+
+        if skipped_invalid > 0:
+            logger.info(f"[{folder_id}] 过滤了 {skipped_invalid} 个失效视频")
+
+        valid_count = len(video_map)
+        current_bvids = set(video_map.keys())
+
+        folder = await _get_or_create_folder(
+            db,
+            uid=uid,
+            media_id=folder_id,
+            title=info.get("title"),
+            media_count=valid_count,
+        )
+
+        existing_rows = await db.execute(
+            select(Collection.bvid).where(Collection.media_id == folder_id)
+        )
+        existing_bvids = {row[0] for row in existing_rows.fetchall()}
+
+        added = current_bvids - existing_bvids
+        removed = existing_bvids - current_bvids
+
+        for bvid, meta in video_map.items():
+            await _upsert_collection(db, folder_id, bvid, meta)
+
+        # ── Per-page vectorization ──
+        from app.services.video.service import VideoService
+        from app.services.vector_page_service import VectorPageService
+        from app.services.async_task.tracker import TaskTracker
+
+        video_service = VideoService()
+        page_tracker = TaskTracker()
+        vector_service = VectorPageService(page_tracker, rag=rag)
+
+        targets = list(current_bvids)
+        total_targets = len(targets)
+        processed_targets = 0
+        if progress_callback:
+            progress_callback("准备处理", processed_targets, total_targets)
+
+        failed_pages: list[tuple[str, int]] = []
+
+        for bvid in targets:
+            meta = video_map[bvid]
+            try:
+                pages_info = await video_service.list_pages_by_bvid(bvid, bili, db)
+                pages = pages_info.get("pages") or []
+                todo = [p for p in pages if p.get("is_vectorized") != "done"]
+                if not todo:
+                    logger.info(
+                        f"[{bvid}] all {len(pages)} page(s) already vectorized, skipping"
+                    )
+                else:
+                    logger.info(
+                        f"[{bvid}] queue {len(todo)}/{len(pages)} page(s) for vectorization"
+                    )
+                    for p_idx, p in enumerate(todo):
+                        cid = p["cid"]
+                        page_index = p["page_index"]
+                        page_title = p.get("page_title") or f"P{page_index + 1}"
+
+                        vec_task_id = await page_tracker.create(
+                            uid=uid,
+                            task_type="vec_page",
+                            target={
+                                "bvid": bvid,
+                                "cid": cid,
+                                "page_index": page_index,
+                                "page_title": page_title,
+                            },
+                        )
+                        try:
+                            await vector_service.process_page_vectorization(
+                                task_id=vec_task_id,
+                                bvid=bvid,
+                                cid=cid,
+                                page_index=page_index,
+                                page_title=page_title,
+                            )
+                        except Exception as page_err:
+                            logger.warning(
+                                f"[{bvid}] page cid={cid} idx={page_index} failed: {page_err}"
+                            )
+                            failed_pages.append((bvid, cid))
+
+                        if p_idx < len(todo) - 1:
+                            await _human_pause(1.0, 3.0)
+            except Exception as e:
+                logger.warning(f"[{bvid}] enumerate/process pages failed: {e}")
+                failed_pages.append((bvid, -1))
+
+            processed_targets += 1
+            if progress_callback:
+                progress_callback(meta["title"], processed_targets, total_targets)
+
+            if processed_targets < total_targets:
+                await _human_pause(1.5, 4.0)
+
+        if failed_pages:
+            logger.warning(
+                f"[{folder_id}] {len(failed_pages)} page(s) failed during vectorization"
+            )
+
+        # Delete removed videos (only if not referenced by other folders)
+        if removed:
+            for bvid in removed:
+                other_count = await db.scalar(
+                    select(func.count())
+                    .select_from(Collection)
+                    .where(
+                        Collection.bvid == bvid, Collection.media_id != folder_id
+                    )
+                )
+                if other_count == 0:
+                    try:
+                        rag.delete_video(bvid)
+                    except Exception as e:
+                        logger.warning(f"删除向量失败 [{bvid}]: {e}")
+
+            await db.execute(
+                delete(Collection).where(
+                    Collection.media_id == folder_id,
+                    Collection.bvid.in_(removed),
+                )
+            )
+
+        folder.last_sync_at = datetime.now(timezone.utc)
+        await db.commit()
+
+        # Invalidate Redis cache for folder_status
+        try:
+            from app.infra.redis import client as _redis, k as _rk
+            if _redis:
+                await _redis.delete(_rk("folder_status", str(uid)))
+        except Exception:
+            pass
+
+        indexed_count = await db.scalar(
+            select(func.count(func.distinct(Collection.bvid)))
+            .select_from(Collection)
+            .where(Collection.media_id == folder_id)
+        )
+
+        return {
+            "folder_id": folder_id,
+            "total": valid_count,
+            "added": len(added),
+            "removed": len(removed),
+            "indexed": indexed_count or 0,
+            "message": "同步完成",
+            "last_sync_at": folder.last_sync_at,
+        }

--- a/app/services/knowledge_build/sync_service.py
+++ b/app/services/knowledge_build/sync_service.py
@@ -13,18 +13,16 @@ from __future__ import annotations
 import asyncio
 import random
 from datetime import datetime, timezone
-from typing import Any, Callable, Optional
+from typing import Callable, Optional
 
 from loguru import logger
 from sqlalchemy import select, func, delete
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models import FavoriteFolder, Collection
-from app.response.knowledge import ContentSource
 from app.services.bilibili import BilibiliService
 from app.services.content_fetcher import ContentFetcher
 from app.services.rag import RAGService
-from app.utils.bvid import bv_to_av
 
 
 async def _human_pause(min_s: float, max_s: float) -> None:


### PR DESCRIPTION
## Summary

  将 `routers/knowledge.py` 中 835 行的文件夹同步与知识库构建编排逻辑抽到独立 service 包，router 从 1132 行瘦身到 385
  行（仅保留参数解析 + DI + 响应组装 + SSE/WS 事件转发）。这是 Phase 3，也是整个 router-thinning 计划里最大的一块。

  - **新增** `app/services/knowledge_build/sync_service.py` — `KnowledgeSyncService` 吸收 `_sync_folder`（原 285
  行）：B站视频拉取、collection upsert、空响应保护
  - **新增** `app/services/knowledge_build/build_service.py` — `KnowledgeBuildService` 吸收
  `_build_knowledge_base_task`（原 192 行）：游标跟踪、legacy in-memory state、WS 广播、单例锁
  - **新增** `app/repository/knowledge_repository.py` — 查询端点的 DB
  读取：`get_folder_status`、`get_vectorized_pages`、build 状态查询、bvid 归属校验
  - **瘦身** `app/routers/knowledge.py` — 835 行删除；4 个查询端点委托 repository；2 个 sync/build 端点委托
  service；后台任务强引用集合 `_background_tasks` 迁移到 service

  ## Architecture

  routers/knowledge.py (385 lines, thin HTTP layer)
      │
      ├─► KnowledgeRepository (query endpoints)
      │     get_folder_status / get_vectorized_pages / get_build_status
      │
      ├─► KnowledgeSyncService (folder sync)
      │     sync_folder() — B站 API + collection upsert + empty-response guard
      │
      └─► KnowledgeBuildService (build orchestration, singleton)
            start_build() / run_build_task() / get_active_task()
            ├─ process-wide lock (_active_build_task_id)
            ├─ cursor tracking + legacy state migration
            └─ WS broadcast (stays in router, HTTP-layer concern)

  ## Behavior Preservation

  重构严格保持原有运行时语义，只改代码位置：

  - **单例锁**：`_active_build_task_id` / `_active_build_lock` 从 router 模块级变量迁移到 `KnowledgeBuildService`
  单例，仍为进程级（非 per-user）—— 单 worker 部署可接受
  - **后台任务强引用**：`_background_tasks: set[asyncio.Task]` 随 service 迁移，避免 GC 中断
  - **空响应保护**：B站返回空列表时不清空本地数据（CLAUDE.md §11 防误删机制），逻辑原样保留
  - **WS 广播**：保留在 router 层，因为是 HTTP 层关注点

  ## Security

  - 所有用户作用域查询保留 `uid` 过滤（IDOR 防护）
  - `delete_video_from_knowledge` 的 bvid 归属校验下沉到 repository，逻辑不变

  ## API Changes

  无。所有端点 URL / 请求 / 响应 schema 不变。

  ## Files Changed (5)

  | 文件 | 变化 |
  |------|------|
  | `app/routers/knowledge.py` | +120/-836 — 1132→385 行 |
  | `app/services/knowledge_build/__init__.py` | +15 (新) |
  | `app/services/knowledge_build/sync_service.py` | +343 (新) |
  | `app/services/knowledge_build/build_service.py` | +356 (新) |
  | `app/repository/knowledge_repository.py` | +186 (新) |

  ## Dependencies

  - **依赖** `refactor/auth-thin` 分支（PR 目标分支）—— 需要 `app/infra/errors.py` 的 `internal_error()` 和
  `refactor/auth-thin` 已合并的 base
  - **下游** `refactor/cloud-processing-service` 会复用 `KnowledgeBuildService` 的后台任务模式