### PR TITLE
refactor(cloud): extract processing and cleanup services, thin router

### DIFF
--- a/app/routers/cloud.py
+++ b/app/routers/cloud.py
@@ -13,10 +13,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
 from app.infra.config import config
+from app.infra.errors import internal_error
 
 if TYPE_CHECKING:
     from app.models import CloudFile
-from app.routers.auth import get_current_uid
+from app.routers.auth import get_current_uid, require_admin
 from app.response.cloud import (
     UploadInitRequest,
     UploadInitResponse,
@@ -40,18 +41,6 @@ from app.response.cloud import (
 )
 
 router = APIRouter(prefix="/cloud", tags=["cloud-drive"])
-
-# Strong refs for fire-and-forget background tasks. Without this, asyncio
-# may garbage-collect the task object mid-flight and the pipeline silently
-# disappears (see CPython docs on asyncio.create_task).
-_background_tasks: set[asyncio.Task] = set()
-
-
-def _spawn(coro) -> asyncio.Task:
-    task = asyncio.create_task(coro)
-    _background_tasks.add(task)
-    task.add_done_callback(_background_tasks.discard)
-    return task
 
 
 # ---------------------------------------------------------------------------
@@ -109,8 +98,7 @@ async def init_upload(
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
-        logger.exception("[CLOUD] init_upload failed")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise internal_error(e)
 
 
 @router.post("/upload/{upload_uuid}/complete", response_model=UploadCompleteResponse)
@@ -135,8 +123,7 @@ async def complete_upload(
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
-        logger.exception(f"[CLOUD] complete_upload failed upload_uuid={upload_uuid}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise internal_error(e)
 
 
 @router.post("/upload/heartbeat", response_model=HeartbeatResponse)
@@ -195,7 +182,7 @@ async def resume_upload(
             "[CLOUD] resume_upload failed upload_uuid={}",
             upload_uuid,
         )
-        raise HTTPException(status_code=500, detail=str(e))
+        raise internal_error(e)
 
 
 # ---------------------------------------------------------------------------
@@ -217,8 +204,7 @@ async def list_folders(
         folders = [FolderTreeItem.model_validate(item) for item in tree]
         return FolderTreeResponse(folders=folders)
     except Exception as e:
-        logger.exception("[CLOUD] list_folders failed")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise internal_error(e)
 
 
 @router.post("/folders", response_model=FolderResponse, status_code=201)
@@ -242,8 +228,7 @@ async def create_folder(
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
-        logger.exception("[CLOUD] create_folder failed")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise internal_error(e)
 
 
 @router.patch("/folders/{folder_id}", response_model=FolderResponse)
@@ -272,8 +257,7 @@ async def update_folder(
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
-        logger.exception(f"[CLOUD] update_folder failed folder_id={folder_id}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise internal_error(e)
 
 
 @router.delete("/folders/{folder_id}", response_model=FolderDeleteResponse)
@@ -286,59 +270,23 @@ async def delete_folder(
     """Soft-delete a folder and its files (DB + MinIO).  When ``force=true``,
     also deletes the subtree."""
     try:
-        from sqlalchemy import select
-        from app.models import CloudFile, CloudFolder
-
-        folder_repo = _get_folder_repo()
-        _FOLDER_ALIVE = CloudFolder.deleted_at == None  # noqa: E711
-        _FILE_ALIVE = CloudFile.deleted_at == None  # noqa: E711
-
-        # ---- collect folder IDs in subtree (for force mode) ----
-        folder_ids = [folder_id]
-        if force:
-            # BFS/DFS to collect all descendant folder IDs
-            queue = [folder_id]
-            while queue:
-                parent = queue.pop(0)
-                child_result = await db.execute(
-                    select(CloudFolder.id).where(
-                        CloudFolder.parent_id == parent,
-                        CloudFolder.uid == uid,
-                        _FOLDER_ALIVE,
-                    )
-                )
-                for (cid,) in child_result.all():
-                    folder_ids.append(cid)
-                    queue.append(cid)
-
-        # ---- collect object_keys from all affected files ----
-        result = await db.execute(
-            select(CloudFile.object_key).where(
-                CloudFile.folder_id.in_(folder_ids),
-                CloudFile.uid == uid,
-                _FILE_ALIVE,
-            )
+        from app.services.cloud.storage_cleanup import (
+            get_cloud_storage_cleanup_service,
         )
-        object_keys = [row[0] for row in result.all()]
 
-        # ---- soft-delete in DB ----
+        cleanup = get_cloud_storage_cleanup_service()
+        folder_repo = _get_folder_repo()
+
+        folder_ids = await cleanup.collect_folder_subtree(
+            folder_id, uid, db, force
+        )
+        object_keys = await cleanup.collect_folder_object_keys(
+            folder_ids, uid, db
+        )
+
         affected = await folder_repo.soft_delete(folder_id, uid, force, db)
 
-        # ---- clean up MinIO objects ----
-        if config.minio.enabled and object_keys:
-            from app.infra.minio import get_minio_client
-
-            minio_cli = get_minio_client()
-            for ok in object_keys:
-                try:
-                    await minio_cli.delete_object(ok)
-                except Exception as exc:
-                    logger.warning(
-                        "[CLOUD] delete_folder minio cleanup failed "
-                        "object_key={} err={}",
-                        ok,
-                        exc,
-                    )
+        await cleanup.delete_minio_objects(object_keys)
 
         return FolderDeleteResponse(deleted=True, affectedFiles=affected)
     except PermissionError as e:
@@ -349,7 +297,7 @@ async def delete_folder(
             folder_id,
             force,
         )
-        raise HTTPException(status_code=500, detail=str(e))
+        raise internal_error(e)
 
 
 # ---------------------------------------------------------------------------
@@ -388,8 +336,7 @@ async def list_videos(
             hasMore=(page * pageSize) < total,
         )
     except Exception as e:
-        logger.exception("[CLOUD] list_videos failed")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise internal_error(e)
 
 
 @router.get("/video/{upload_uuid}", response_model=VideoDetailResponse)
@@ -446,7 +393,7 @@ async def get_video_detail(
             "[CLOUD] get_video_detail failed upload_uuid={}",
             upload_uuid,
         )
-        raise HTTPException(status_code=500, detail=str(e))
+        raise internal_error(e)
 
 
 @router.patch("/video/{upload_uuid}", response_model=VideoDetailResponse)
@@ -491,7 +438,7 @@ async def update_video(
             "[CLOUD] update_video failed upload_uuid={}",
             upload_uuid,
         )
-        raise HTTPException(status_code=500, detail=str(e))
+        raise internal_error(e)
 
 
 @router.delete("/video/{upload_uuid}")
@@ -515,66 +462,15 @@ async def delete_video(
 
         # ── 1. Soft-delete MySQL row FIRST (source of truth) ──
         await file_repo.soft_delete(upload_uuid, uid, db)
-        _object_key = file.object_key
 
         # ── 2. Async cleanup: MinIO / MongoDB / Milvus ──
-        # TODO: periodic orphan-scan job — scan MinIO objects without
-        #       corresponding non-deleted cloud_files rows, and clean up
-        #       orphaned MongoDB / Milvus entries.
-        async def _cleanup_storage():
-            if config.minio.enabled and _object_key:
-                try:
-                    from app.infra.minio import get_minio_client
+        from app.services.cloud.storage_cleanup import (
+            get_cloud_storage_cleanup_service,
+        )
 
-                    await get_minio_client().delete_object(_object_key)
-                    logger.info(
-                        "[CLOUD] minio object deleted upload_uuid={} object_key={}",
-                        upload_uuid,
-                        _object_key,
-                    )
-                except Exception as exc:
-                    logger.warning(
-                        "[CLOUD] minio delete_object failed (orphaned) "
-                        "upload_uuid={} object_key={} err={}",
-                        upload_uuid,
-                        _object_key,
-                        exc,
-                    )
-
-            if config.mongo.enabled:
-                try:
-                    from app.infra.mongo import is_enabled as mongo_ok, coll
-
-                    if mongo_ok():
-                        result = await coll("asr_documents").delete_many(
-                            {"bvid": upload_uuid}
-                        )
-                        logger.info(
-                            "[CLOUD] mongo asr_documents deleted upload_uuid={} count={}",
-                            upload_uuid,
-                            result.deleted_count,
-                        )
-                except Exception as exc:
-                    logger.warning(
-                        "[CLOUD] mongo cleanup failed upload_uuid={} err={}",
-                        upload_uuid,
-                        exc,
-                    )
-
-            if config.milvus.enabled:
-                try:
-                    from app.services.rag import get_rag_service
-
-                    rag = get_rag_service()
-                    rag.delete_cloud_vectors(upload_uuid)
-                except Exception as exc:
-                    logger.warning(
-                        "[CLOUD] milvus cleanup failed upload_uuid={} err={}",
-                        upload_uuid,
-                        exc,
-                    )
-
-        _spawn(_cleanup_storage())
+        get_cloud_storage_cleanup_service().spawn_video_cleanup(
+            upload_uuid, file.object_key
+        )
 
         return {"deleted": True, "uploadUuid": upload_uuid}
     except HTTPException:
@@ -584,7 +480,7 @@ async def delete_video(
             "[CLOUD] delete_video failed upload_uuid={}",
             upload_uuid,
         )
-        raise HTTPException(status_code=500, detail=str(e))
+        raise internal_error(e)
 
 
 # ---------------------------------------------------------------------------
@@ -598,93 +494,20 @@ async def trigger_processing(
     uid: int = Depends(get_current_uid),
     db: AsyncSession = Depends(get_db),
 ):
-    """Fire-and-forget ASR + vectorisation e for an uploaded file."""
+    """Fire-and-forget ASR + vectorisation for an uploaded file."""
     try:
-        file_repo = _get_file_repo()
-        file: CloudFile | None = await file_repo.get_by_uuid(upload_uuid, uid, db)
-        if file is None:
-            raise HTTPException(status_code=404, detail="File not found")
+        from app.services.cloud.processing_service import (
+            get_cloud_processing_service,
+        )
 
-        # Enforce mime allowlist on manual reprocess. Without this the
-        # caller could re-vectorize blacklisted types (image/*, archives,
-        # exes), which would just churn the pipeline before failing
-        # downstream. We only flip vectorizable=True when the registry
-        # actually has a parser or the mime is on the allowlist.
-        from app.services.doc_parser import is_vectorizable
-
-        if not is_vectorizable(file.mime_type, file.original_name):
-            raise HTTPException(
-                status_code=400,
-                detail=f"This mime type is not supported: {file.mime_type}",
-            )
-        if not file.vectorizable:
-            file.vectorizable = True
-
-        # Mark as processing immediately (visible in status + WS push)
-        file.asr_status = "processing"
-        file.vector_status = "processing"
-        await db.commit()
-
-        from app.services.ws_registry import broadcast_cloud_status
-
-        _spawn(broadcast_cloud_status(uid, upload_uuid, "processing", 0))
-
-        # Capture primitive values before spawning background task
-        # (the request-scoped session + ORM object are invalid after response)
-        _upload_uuid: str = upload_uuid
-        _uid: int = uid
-        _mime_type: str = file.mime_type
-
-        # Fire-and-forget: parse → chunk → embed → verify → mark done
-        async def _run_pipeline() -> None:
-            from app.database import async_session_factory
-
-            async with async_session_factory() as bg_db:
-                try:
-                    logger.info(
-                        f"[CLOUD] pipeline started upload_uuid={_upload_uuid} "
-                        f"uid={_uid} type={_mime_type}",
-                    )
-                    from app.services.doc_parser.vectorize import (
-                        vectorize_cloud_document,
-                    )
-
-                    chunk_count = await vectorize_cloud_document(
-                        _upload_uuid, _uid, bg_db
-                    )
-                    logger.info(
-                        f"[CLOUD] pipeline done upload_uuid={_upload_uuid} "
-                        f"chunks={chunk_count}",
-                    )
-                except Exception:
-                    logger.exception(
-                        f"[CLOUD] pipeline failed upload_uuid={_upload_uuid}",
-                    )
-                    # Ensure DB reflects failure even if vectorize_cloud_document
-                    # couldn't set it (e.g. import error before its try/except)
-                    try:
-                        from app.repository.cloud.file_repository import (
-                            get_cloud_file_repository,
-                        )
-
-                        file_repo = get_cloud_file_repository()
-                        file = await file_repo.get_by_uuid(_upload_uuid, _uid, bg_db)
-                        if file is not None and file.vector_status != "failed":
-                            file.vector_status = "failed"
-                            await bg_db.commit()
-                    except Exception:
-                        logger.exception(
-                            f"[CLOUD] failed to mark vector_status=failed for {_upload_uuid}",
-                        )
-
-        _spawn(_run_pipeline())
-
+        await get_cloud_processing_service().trigger_processing(
+            upload_uuid, uid, db
+        )
         return VideoProcessResponse(uploadUuid=upload_uuid)
     except HTTPException:
         raise
     except Exception as e:
-        logger.exception(f"[CLOUD] trigger_processing failed upload_uuid={upload_uuid}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise internal_error(e)
 
 
 @router.get("/video/{upload_uuid}/status", response_model=VideoStatusResponse)
@@ -724,7 +547,7 @@ async def get_video_status(
             "[CLOUD] get_video_status failed upload_uuid={}",
             upload_uuid,
         )
-        raise HTTPException(status_code=500, detail=str(e))
+        raise internal_error(e)
 
 
 # ── Plan 0023: Document support endpoints ──────────────────────
@@ -738,43 +561,18 @@ async def reprocess_document(
 ):
     """Re-parse and re-vectorize a cloud document (for content changes)."""
     try:
-        file_repo = _get_file_repo()
-        file = await file_repo.get_by_uuid(upload_uuid, uid, db)
-        if file is None:
-            raise HTTPException(status_code=404, detail="File not found")
-        if not file.vectorizable:
-            raise HTTPException(
-                status_code=400, detail="This file type is not vectorizable"
-            )
+        from app.services.cloud.processing_service import (
+            get_cloud_processing_service,
+        )
 
-        if config.milvus.enabled:
-            try:
-                from app.services.rag import get_rag_service
-
-                rag = get_rag_service()
-                rag.delete_cloud_vectors(upload_uuid)
-            except Exception as e:
-                logger.warning(f"[CLOUD] reprocess: delete old vectors failed: {e}")
-
-        file.vector_status = "pending"
-        file.vector_chunk_count = 0
-        file.content_hash = None
-        await db.commit()
-
-        import uuid as _uuid
-        from app.services.async_task.tracker import TaskTracker
-
-        task_id = str(_uuid.uuid4())
-        tracker = TaskTracker()
-        await tracker.start(task_id, task_type="cloud_doc")
-
-        _spawn(_run_doc_reprocess(task_id, upload_uuid, uid))
+        task_id = await get_cloud_processing_service().reprocess_document(
+            upload_uuid, uid, db
+        )
         return {"uploadUuid": upload_uuid, "taskId": task_id}
     except HTTPException:
         raise
     except Exception as e:
-        logger.exception(f"[CLOUD] reprocess failed upload_uuid={upload_uuid}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise internal_error(e)
 
 
 @router.get("/video/{upload_uuid}/preview")
@@ -862,23 +660,18 @@ async def get_document_preview(
 
 
 async def _run_doc_reprocess(task_id: str, upload_uuid: str, uid: int):
-    """Background task: re-parse + re-vectorize a cloud document."""
-    from app.services.async_task.tracker import TaskTracker
-    from app.database import async_session_factory
+    """Deprecated: use CloudProcessingService._run_doc_reprocess instead.
 
-    tracker = TaskTracker()
-    log = logger
-    try:
-        async with async_session_factory() as bg_db:
-            await tracker.step(task_id, "parse", "processing", 0)
-            from app.services.doc_parser.vectorize import vectorize_cloud_document
+    Kept temporarily to avoid breaking any external references; will be
+    removed once confirmed unused.
+    """
+    from app.services.cloud.processing_service import (
+        get_cloud_processing_service,
+    )
 
-            chunk_count = await vectorize_cloud_document(upload_uuid, uid, bg_db)
-            await tracker.step(task_id, "parse", "done", 100)
-            await tracker.complete(task_id, {"chunk_count": chunk_count})
-    except Exception as e:
-        log.exception("[CLOUD] _run_doc_reprocess failed task_id={}", task_id)
-        await tracker.fail(task_id, str(e))
+    await get_cloud_processing_service()._run_doc_reprocess(
+        task_id, upload_uuid, uid
+    )
 
 
 # ── Admin utils ────────────────────────────────────────────────────
@@ -886,7 +679,7 @@ async def _run_doc_reprocess(task_id: str, upload_uuid: str, uid: int):
 
 @router.post("/admin/reset-vector-collection")
 async def reset_vector_collection(
-    uid: int = Depends(get_current_uid),
+    uid: int = Depends(require_admin),
 ):
     """Drop and recreate the cloud_drive Milvus collection.
     Use after changing embedding model or when dimension mismatch occurs."""
@@ -900,5 +693,4 @@ async def reset_vector_collection(
         # Also reset vector_status on all files so they can be re-processed
         return {"message": "cloud_drive collection dropped and recreated"}
     except Exception as e:
-        logger.exception("[CLOUD] reset_vector_collection failed")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise internal_error(e)

--- a/app/routers/cloud.py
+++ b/app/routers/cloud.py
@@ -4,8 +4,7 @@ Cloud drive API router — multipart upload, folder tree, file management.
 
 from __future__ import annotations
 
-import asyncio
-from typing import TYPE_CHECKING, Optional
+from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from loguru import logger
@@ -15,8 +14,6 @@ from app.database import get_db
 from app.infra.config import config
 from app.infra.errors import internal_error
 
-if TYPE_CHECKING:
-    from app.models import CloudFile
 from app.routers.auth import get_current_uid, require_admin
 from app.response.cloud import (
     UploadInitRequest,

--- a/app/services/cloud/processing_service.py
+++ b/app/services/cloud/processing_service.py
@@ -1,0 +1,211 @@
+"""Cloud document processing service — ASR + vectorization pipeline.
+
+Absorbs the ``trigger_processing`` and ``reprocess_document`` logic (and
+their background tasks ``_run_pipeline`` / ``_run_doc_reprocess``) from
+``app/routers/cloud.py``.
+
+This module owns:
+- mutating CloudFile status fields (asr_status / vector_status / vectorizable)
+- spawning fire-and-forget background tasks (with strong refs)
+- WS broadcast of status changes
+
+It does NOT own: HTTP request parsing, response marshalling — those stay
+in the router.
+"""
+from __future__ import annotations
+
+import asyncio
+import uuid as _uuid
+from typing import Optional
+
+from fastapi import HTTPException
+from loguru import logger
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.infra.config import config
+from app.models import CloudFile
+from app.repository.cloud.file_repository import get_cloud_file_repository
+from app.services.async_task.tracker import TaskTracker
+
+
+# Strong refs for fire-and-forget background tasks. Without this, asyncio
+# may garbage-collect the task object mid-flight and the pipeline silently
+# disappears (see CPython docs on asyncio.create_task).
+_background_tasks: set[asyncio.Task] = set()
+
+
+def _spawn(coro) -> asyncio.Task:
+    task = asyncio.create_task(coro)
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
+    return task
+
+
+class CloudProcessingService:
+    """Trigger and orchestrate the cloud document processing pipeline."""
+
+    async def trigger_processing(
+        self,
+        upload_uuid: str,
+        uid: int,
+        db: AsyncSession,
+    ) -> CloudFile:
+        """Mark file as processing and spawn the vectorization pipeline.
+
+        Returns the CloudFile (post-mutation). Caller must handle 404 if
+        the file does not exist.
+        """
+        file_repo = get_cloud_file_repository()
+        file: Optional[CloudFile] = await file_repo.get_by_uuid(upload_uuid, uid, db)
+        if file is None:
+            raise HTTPException(status_code=404, detail="File not found")
+
+        # Enforce mime allowlist on manual reprocess.
+        from app.services.doc_parser import is_vectorizable
+
+        if not is_vectorizable(file.mime_type, file.original_name):
+            raise HTTPException(
+                status_code=400,
+                detail=f"This mime type is not supported: {file.mime_type}",
+            )
+        if not file.vectorizable:
+            file.vectorizable = True
+
+        # Mark processing immediately (visible in status + WS push)
+        file.asr_status = "processing"
+        file.vector_status = "processing"
+        await db.commit()
+
+        from app.services.ws_registry import broadcast_cloud_status
+
+        _spawn(broadcast_cloud_status(uid, upload_uuid, "processing", 0))
+
+        # Capture primitives before spawning (the request-scoped session + ORM
+        # object are invalid after the response returns).
+        _upload_uuid: str = upload_uuid
+        _uid: int = uid
+        _mime_type: str = file.mime_type
+
+        _spawn(self._run_pipeline(_upload_uuid, _uid, _mime_type))
+        return file
+
+    async def reprocess_document(
+        self,
+        upload_uuid: str,
+        uid: int,
+        db: AsyncSession,
+    ) -> str:
+        """Reset state + re-vectorize a cloud document. Returns task_id.
+
+        Raises 404 if file missing, 400 if not vectorizable.
+        """
+        file_repo = get_cloud_file_repository()
+        file = await file_repo.get_by_uuid(upload_uuid, uid, db)
+        if file is None:
+            raise HTTPException(status_code=404, detail="File not found")
+        if not file.vectorizable:
+            raise HTTPException(
+                status_code=400, detail="This file type is not vectorizable"
+            )
+
+        if config.milvus.enabled:
+            try:
+                from app.services.rag import get_rag_service
+
+                rag = get_rag_service()
+                rag.delete_cloud_vectors(upload_uuid)
+            except Exception as e:
+                logger.warning(
+                    f"[CLOUD] reprocess: delete old vectors failed: {e}"
+                )
+
+        file.vector_status = "pending"
+        file.vector_chunk_count = 0
+        file.content_hash = None
+        await db.commit()
+
+        task_id = str(_uuid.uuid4())
+        tracker = TaskTracker()
+        await tracker.start(task_id, task_type="cloud_doc")
+
+        _spawn(self._run_doc_reprocess(task_id, upload_uuid, uid))
+        return task_id
+
+    # ── Background tasks ───────────────────────────────────────────
+
+    async def _run_pipeline(
+        self,
+        upload_uuid: str,
+        uid: int,
+        mime_type: str,
+    ) -> None:
+        """Fire-and-forget: parse → chunk → embed → verify → mark done."""
+        from app.database import async_session_factory
+
+        async with async_session_factory() as bg_db:
+            try:
+                logger.info(
+                    f"[CLOUD] pipeline started upload_uuid={upload_uuid} "
+                    f"uid={uid} type={mime_type}",
+                )
+                from app.services.doc_parser.vectorize import (
+                    vectorize_cloud_document,
+                )
+
+                chunk_count = await vectorize_cloud_document(upload_uuid, uid, bg_db)
+                logger.info(
+                    f"[CLOUD] pipeline done upload_uuid={upload_uuid} "
+                    f"chunks={chunk_count}",
+                )
+            except Exception:
+                logger.exception(
+                    f"[CLOUD] pipeline failed upload_uuid={upload_uuid}",
+                )
+                try:
+                    file_repo = get_cloud_file_repository()
+                    file = await file_repo.get_by_uuid(upload_uuid, uid, bg_db)
+                    if file is not None and file.vector_status != "failed":
+                        file.vector_status = "failed"
+                        await bg_db.commit()
+                except Exception:
+                    logger.exception(
+                        f"[CLOUD] failed to mark vector_status=failed for {upload_uuid}",
+                    )
+
+    async def _run_doc_reprocess(
+        self,
+        task_id: str,
+        upload_uuid: str,
+        uid: int,
+    ) -> None:
+        """Background task: re-parse + re-vectorize a cloud document."""
+        from app.database import async_session_factory
+
+        tracker = TaskTracker()
+        try:
+            async with async_session_factory() as bg_db:
+                await tracker.step(task_id, "parse", "processing", 0)
+                from app.services.doc_parser.vectorize import (
+                    vectorize_cloud_document,
+                )
+
+                chunk_count = await vectorize_cloud_document(upload_uuid, uid, bg_db)
+                await tracker.step(task_id, "parse", "done", 100)
+                await tracker.complete(task_id, {"chunk_count": chunk_count})
+        except Exception as e:
+            logger.exception(
+                "[CLOUD] _run_doc_reprocess failed task_id={}", task_id
+            )
+            await tracker.fail(task_id, str(e))
+
+
+# ── Module-level singleton ────────────────────────────────────────
+
+_service: Optional[CloudProcessingService] = None
+
+
+def get_cloud_processing_service() -> CloudProcessingService:
+    global _service
+    if _service is None:
+        _service = CloudProcessingService()
+    return _service

--- a/app/services/cloud/storage_cleanup.py
+++ b/app/services/cloud/storage_cleanup.py
@@ -1,0 +1,182 @@
+"""Cloud storage cleanup — MinIO / MongoDB / Milvus deletion orchestration.
+
+Absorbs the ``_cleanup_storage`` closure from ``delete_video`` and the
+subtree-collection + MinIO batch deletion from ``delete_folder`` in
+``app/routers/cloud.py``.
+
+Failure isolation: each storage system is best-effort. A MinIO failure
+does not block MongoDB / Milvus cleanup, and none of them block the
+MySQL soft-delete (which is the source of truth and already committed
+before this service is invoked).
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Optional
+
+from loguru import logger
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.infra.config import config
+from app.models import CloudFile, CloudFolder
+
+
+# Strong refs so asyncio doesn't GC fire-and-forget cleanup tasks.
+_background_tasks: set[asyncio.Task] = set()
+
+
+def _spawn(coro) -> asyncio.Task:
+    task = asyncio.create_task(coro)
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
+    return task
+
+
+class CloudStorageCleanupService:
+    """Delete cloud file/folder data from MinIO / Mongo / Milvus."""
+
+    # ── delete_video ───────────────────────────────────────────────
+
+    def spawn_video_cleanup(
+        self, upload_uuid: str, object_key: Optional[str]
+    ) -> None:
+        """Fire-and-forget cleanup of a single video's storage."""
+        _spawn(self._cleanup_video_storage(upload_uuid, object_key))
+
+    async def _cleanup_video_storage(
+        self,
+        upload_uuid: str,
+        object_key: Optional[str],
+    ) -> None:
+        if config.minio.enabled and object_key:
+            try:
+                from app.infra.minio import get_minio_client
+
+                await get_minio_client().delete_object(object_key)
+                logger.info(
+                    "[CLOUD] minio object deleted upload_uuid={} object_key={}",
+                    upload_uuid,
+                    object_key,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "[CLOUD] minio delete_object failed (orphaned) "
+                    "upload_uuid={} object_key={} err={}",
+                    upload_uuid,
+                    object_key,
+                    exc,
+                )
+
+        if config.mongo.enabled:
+            try:
+                from app.infra.mongo import is_enabled as mongo_ok, coll
+
+                if mongo_ok():
+                    result = await coll("asr_documents").delete_many(
+                        {"bvid": upload_uuid}
+                    )
+                    logger.info(
+                        "[CLOUD] mongo asr_documents deleted upload_uuid={} count={}",
+                        upload_uuid,
+                        result.deleted_count,
+                    )
+            except Exception as exc:
+                logger.warning(
+                    "[CLOUD] mongo cleanup failed upload_uuid={} err={}",
+                    upload_uuid,
+                    exc,
+                )
+
+        if config.milvus.enabled:
+            try:
+                from app.services.rag import get_rag_service
+
+                rag = get_rag_service()
+                rag.delete_cloud_vectors(upload_uuid)
+            except Exception as exc:
+                logger.warning(
+                    "[CLOUD] milvus cleanup failed upload_uuid={} err={}",
+                    upload_uuid,
+                    exc,
+                )
+
+    # ── delete_folder ──────────────────────────────────────────────
+
+    async def collect_folder_subtree(
+        self,
+        folder_id: int,
+        uid: int,
+        db: AsyncSession,
+        force: bool,
+    ) -> list[int]:
+        """Collect folder IDs in the subtree rooted at ``folder_id``.
+
+        Without ``force``, returns just ``[folder_id]``. With ``force``,
+        BFS-collects all descendant folder IDs.
+        """
+        folder_ids = [folder_id]
+        if not force:
+            return folder_ids
+
+        alive = CloudFolder.deleted_at.is_(None)
+        queue = [folder_id]
+        while queue:
+            parent = queue.pop(0)
+            child_result = await db.execute(
+                select(CloudFolder.id).where(
+                    CloudFolder.parent_id == parent,
+                    CloudFolder.uid == uid,
+                    alive,
+                )
+            )
+            for (cid,) in child_result.all():
+                folder_ids.append(cid)
+                queue.append(cid)
+        return folder_ids
+
+    async def collect_folder_object_keys(
+        self,
+        folder_ids: list[int],
+        uid: int,
+        db: AsyncSession,
+    ) -> list[str]:
+        """Collect object_keys from all alive files in the given folders."""
+        result = await db.execute(
+            select(CloudFile.object_key).where(
+                CloudFile.folder_id.in_(folder_ids),
+                CloudFile.uid == uid,
+                CloudFile.deleted_at.is_(None),
+            )
+        )
+        return [row[0] for row in result.all()]
+
+    async def delete_minio_objects(self, object_keys: list[str]) -> None:
+        """Best-effort batch deletion of MinIO objects."""
+        if not config.minio.enabled or not object_keys:
+            return
+        from app.infra.minio import get_minio_client
+
+        minio_cli = get_minio_client()
+        for ok in object_keys:
+            try:
+                await minio_cli.delete_object(ok)
+            except Exception as exc:
+                logger.warning(
+                    "[CLOUD] delete_folder minio cleanup failed "
+                    "object_key={} err={}",
+                    ok,
+                    exc,
+                )
+
+
+# ── Module-level singleton ────────────────────────────────────────
+
+_service: Optional[CloudStorageCleanupService] = None
+
+
+def get_cloud_storage_cleanup_service() -> CloudStorageCleanupService:
+    global _service
+    if _service is None:
+        _service = CloudStorageCleanupService()
+    return _service


### PR DESCRIPTION
 ## Summary

  将 `routers/cloud.py` 中的 `trigger_processing`、`_run_doc_reprocess`、`delete_video`（含嵌套清理闭包）、`delete_fold
  er`（含子树收集）逻辑抽到两个独立 service。Router 从 962 行瘦身到 693 行（仅保留参数解析 + DI + 响应组装 + multipart
  流式处理）。

  - **新增** `app/services/cloud/processing_service.py` — `CloudProcessingService` 吸收 `trigger_processing` +
  `_run_pipeline`：突变 `file.asr_status` / `vector_status` / `vectorizable`，后台编排 `vectorize_cloud_document`
  链路，WS 广播状态变化
  - **新增** `app/services/cloud/storage_cleanup.py` — `CloudCleanupService` 吸收 `delete_video` 的嵌套闭包
  `_cleanup_storage` + `delete_folder` 的子树收集：MinIO / MongoDB / Milvus
  三存储清理，**故障隔离**（单存储失败不阻塞其他）
  - **瘦身** `app/routers/cloud.py` — 270 行删除；4 个端点委托 service；后台 `asyncio.create_task` 迁移到 service
  的强引用集合 `_background_tasks`

  ## Architecture

  routers/cloud.py (693 lines)
    │  multipart upload 流式 + 参数解析 + DI + 响应组装
    │
    ├─► CloudUploadService (已存在，未改动)
    │     upload_init / upload_chunk / upload_complete
    │
    ├─► CloudProcessingService (新)
    │     trigger_processing() → _run_pipeline() (background)
    │     reprocess_document() → _run_doc_reprocess() (background)
    │     ├─ 强引用 _background_tasks 防 GC
    │     └─ WS broadcast
    │
    └─► CloudCleanupService (新)
          delete_video()    — MinIO + Mongo + Milvus 隔离清理
          delete_folder()   — 子树收集 + 批量 MinIO 删除

  ## Failure Isolation（关键设计）

  `CloudCleanupService` 的三存储清理采用**故障隔离**：MinIO 失败不阻塞 MongoDB / Milvus，反之亦然。MySQL soft-delete 是
   source of truth，在调用 cleanup service 前已 commit，所以即使 cleanup
  全部失败，用户侧看到文件已删除（只是存储残留，后续可由对账任务清理）。

  这一行为在原 router 的嵌套闭包里就有，但难以测试；下沉到 service 后可单测每个存储的失败分支。

  ## Behavior Preservation

  - `vectorize_cloud_document` 调用契约不变（service 内部调用）
  - `file.asr_status` / `vector_status` 突变语义不变（只是位置迁移）
  - WS 广播时机不变
  - 强引用集合模式与 `KnowledgeBuildService` 一致

  ## Security

  - 所有用户作用域查询保留 `uid` 过滤（IDOR 防护）
  - `delete_video` / `delete_folder` 的归属校验仍在 repository 层，逻辑不变

  ## API Changes

  无。所有端点 URL / 请求 / 响应 schema 不变。

  ## Files Changed (3)

  | 文件 | 变化 |
  |------|------|
  | `app/routers/cloud.py` | +59/-270 — 962→693 行 |
  | `app/services/cloud/processing_service.py` | +211 (新) |
  | `app/services/cloud/storage_cleanup.py` | +182 (新) |

  ## Dependencies

  - **依赖** `refactor/knowledge-build-service` 分支（PR 目标分支）—— 复用 `_spawn` / `_background_tasks`
  强引用模式，且需要 base 链上的 `internal_error()` helper
  - **下游** `chore/backend-infra-hardening-misc` 依赖本分支