### PR TITLE
refactor(asr): thin router via ASRPageService CRUD methods

### DIFF
--- a/app/routers/asr.py
+++ b/app/routers/asr.py
@@ -1,172 +1,70 @@
 """
-Bilibili RAG 知识库系统
+ASR router — thin HTTP layer over ASRPageService.
 
-ASR 路由 - 分P视频语音转文本
+Owns: parameter parsing, dependency injection, response marshalling.
+Owns NOT: DB operations, background task spawning, MongoDB access.
 """
-from datetime import datetime, timezone
-from fastapi import APIRouter, Depends, HTTPException
-from loguru import logger
-from sqlalchemy import select
+from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
-from app.models import Video, VideoVersion
 from app.response import (
     ASRCreateRequest, ASRUpdateRequest, ASRReASRRequest,
     ASRContentResponse, ASRTaskStatus, VideoVersionInfo,
 )
-from app.services.async_task.asr_task_registry import asr_tasks, create_task
+from app.routers.auth import get_current_uid
+from app.services.asr_page_service import ASRPageService
 
 router = APIRouter(prefix="/asr", tags=["ASR"])
 
 
-# ==================== 依赖注入 ====================
-
-def get_ASRPageService():
-    """延迟导入 ASRPageService，避免循环依赖"""
-    from app.services.asr_page_service import ASRPageService
+def get_ASRPageService() -> ASRPageService:
+    """DI factory for ASRPageService (kept lazy to avoid circular imports)."""
     return ASRPageService()
 
 
-# ==================== API 接口 ====================
-
-@router.get("/content")
+@router.get("/content", response_model=ASRContentResponse)
 async def get_asr_content(
     bvid: str,
     cid: int,
-    db: AsyncSession = Depends(get_db)
+    db: AsyncSession = Depends(get_db),
+    uid: int = Depends(get_current_uid),
 ) -> ASRContentResponse:
     """Query ASR content — MongoDB first, MySQL fallback."""
-    result = await db.execute(
-        select(Video).where(Video.bvid == bvid, Video.cid == cid)
-    )
-    page = result.scalar_one_or_none()
-
-    if not page:
-        return ASRContentResponse(exists=False)
-
-    content = None
-    content_source = page.content_source
-    version = page.version
-
-    # MongoDB is the sole store for full text
-    from app.infra.mongo import is_enabled as mongo_enabled
-    if mongo_enabled() and page.is_processed:
-        try:
-            from app.repository.mongo_asr_repository import get_latest
-            mongo_doc = await get_latest(bvid, cid)
-            if mongo_doc:
-                content = mongo_doc.get("content")
-                content_source = mongo_doc.get("content_source", content_source)
-                version = mongo_doc.get("version", version)
-        except Exception as e:
-            logger.warning(f"[ASR] MongoDB read failed: {e}")
-
-    return ASRContentResponse(
-        exists=True,
-        bvid=page.bvid,
-        cid=page.cid,
-        page_index=page.page_index,
-        page_title=page.page_title,
-        content=content,
-        content_source=content_source,
-        version=version,
-        is_processed=page.is_processed,
-    )
+    return await get_ASRPageService().get_content(bvid, cid, db)
 
 
 @router.post("/create")
 async def create_asr(
     req: ASRCreateRequest,
     db: AsyncSession = Depends(get_db),
-    service = Depends(get_ASRPageService)
+    service: ASRPageService = Depends(get_ASRPageService),
+    uid: int = Depends(get_current_uid),
 ):
-    """
-    幂等创建 ASR 任务
-    - 已存在且 is_processed=true → 直接返回
-    - 不存在 → 创建记录 + 后台任务
-    """
-    # 查询是否已存在（唯一约束是 bvid+page_index，非 bvid+cid）
-    result = await db.execute(
-        select(Video).where(Video.bvid == req.bvid, Video.page_index == req.page_index)
+    """Idempotent ASR task creation."""
+    return await service.create_task(
+        bvid=req.bvid,
+        cid=req.cid,
+        page_index=req.page_index,
+        page_title=req.page_title,
+        uid=uid,
+        db=db,
     )
-    existing = result.scalar_one_or_none()
-
-    if existing and existing.is_processed:
-        # 已完成，直接返回
-        return {
-            "task_id": None,
-            "message": "ASR 已完成",
-            "version": existing.version,
-        }
-
-    # 不存在则创建记录
-    if not existing:
-        new_page = Video(
-            bvid=req.bvid,
-            cid=req.cid,
-            page_index=req.page_index,
-            page_title=req.page_title or f"P{req.page_index + 1}",
-            is_processed=False,
-            version=1,
-        )
-        db.add(new_page)
-        await db.commit()
-
-    # 创建后台任务
-    task_id = create_task()
-
-    # 启动后台 ASR 处理
-    import asyncio
-    asyncio.create_task(
-        service.process_page(
-            task_id=task_id,
-            bvid=req.bvid,
-            cid=req.cid,
-            page_index=req.page_index,
-            page_title=req.page_title or f"P{req.page_index + 1}",
-        )
-    )
-
-    return {"task_id": task_id, "message": "ASR 任务已创建"}
 
 
 @router.post("/update")
 async def update_asr_content(
     req: ASRUpdateRequest,
-    db: AsyncSession = Depends(get_db)
+    db: AsyncSession = Depends(get_db),
+    uid: int = Depends(get_current_uid),
 ):
-    """
-    手动编辑更新（覆盖，不新建版本）
-    """
-    result = await db.execute(
-        select(Video).where(Video.bvid == req.bvid, Video.page_index == req.page_index)
+    """Overwrite ASR content (user edit, no new version)."""
+    await get_ASRPageService().update_content(
+        bvid=req.bvid,
+        page_index=req.page_index,
+        content=req.content,
+        db=db,
     )
-    page = result.scalar_one_or_none()
-
-    if not page:
-        raise HTTPException(status_code=404, detail="ASR 记录不存在")
-
-    # Save to MongoDB (primary), update MySQL metadata
-    page.content_source = "user_edit"
-    page.is_processed = True
-    page.updated_at = datetime.now(timezone.utc)
-    await db.commit()
-
-    from app.infra.mongo import is_enabled as _mongo_ok
-    if _mongo_ok():
-        try:
-            from app.repository.mongo_asr_repository import save_asr
-            from app.utils.bvid import bv_to_av
-            await save_asr(
-                video_id=bv_to_av(req.bvid),
-                bvid=req.bvid, cid=page.cid, page_index=req.page_index,
-                page_title=page.page_title or "",
-                content=req.content, content_source="user_edit",
-            )
-        except Exception as e:
-            logger.warning(f"[ASR] MongoDB save failed on user edit: {e}")
-
     return {"success": True, "message": "更新成功"}
 
 
@@ -174,116 +72,30 @@ async def update_asr_content(
 async def reasr(
     req: ASRReASRRequest,
     db: AsyncSession = Depends(get_db),
-    service = Depends(get_ASRPageService)
+    service: ASRPageService = Depends(get_ASRPageService),
+    uid: int = Depends(get_current_uid),
 ):
-    """
-    强制重新 ASR（新建版本）
-    """
-    # 查询现有记录（唯一约束是 bvid+page_index，非 bvid+cid）
-    result = await db.execute(
-        select(Video).where(Video.bvid == req.bvid, Video.page_index == req.page_index)
-    )
-    page = result.scalar_one_or_none()
-
-    if not page:
-        raise HTTPException(status_code=404, detail="ASR 记录不存在")
-
-    # 旧版本 is_latest = false
-    old_version = page.version
-
-    # Insert version record (metadata only)
-    new_version_record = VideoVersion(
-        bvid=req.bvid,
-        cid=req.cid,
-        page_index=page.page_index,
-        version=old_version,
-        content_source=page.content_source,
-        is_latest=False,
-    )
-    db.add(new_version_record)
-
-    # Reset page for re-ASR
-    page.version = old_version + 1
-    page.is_processed = False
-    page.content_source = None
-    page.updated_at = datetime.now(timezone.utc)
-
-    await db.commit()
-
-    # 创建后台任务
-    task_id = create_task()
-
-    # 启动后台 ASR 处理
-    import asyncio
-    asyncio.create_task(
-        service.process_page(
-            task_id=task_id,
-            bvid=req.bvid,
-            cid=req.cid,
-            page_index=page.page_index,
-            page_title=page.page_title or f"P{page.page_index + 1}",
-        )
-    )
-
-    return {"task_id": task_id, "message": "重新 ASR 已启动"}
-
-
-@router.get("/status/{task_id}")
-async def get_task_status(task_id: str) -> ASRTaskStatus:
-    """轮询任务状态"""
-    if task_id not in asr_tasks:
-        raise HTTPException(status_code=404, detail="任务不存在")
-
-    task = asr_tasks[task_id]
-    return ASRTaskStatus(
-        task_id=task_id,
-        status=task["status"],
-        progress=task["progress"],
-        message=task["message"],
+    """Force re-ASR (creates a new version)."""
+    return await service.reasr(
+        bvid=req.bvid, page_index=req.page_index, uid=uid, db=db
     )
 
 
-@router.get("/versions")
+@router.get("/status/{task_id}", response_model=ASRTaskStatus)
+async def get_task_status(
+    task_id: str,
+    uid: int = Depends(get_current_uid),
+) -> ASRTaskStatus:
+    """Poll task status."""
+    return await get_ASRPageService().get_task_status(task_id, uid)
+
+
+@router.get("/versions", response_model=list[VideoVersionInfo])
 async def get_versions(
     bvid: str,
     cid: int,
-    db: AsyncSession = Depends(get_db)
+    db: AsyncSession = Depends(get_db),
+    uid: int = Depends(get_current_uid),
 ) -> list[VideoVersionInfo]:
     """Query version history — MongoDB first, MySQL fallback."""
-    from app.infra.mongo import is_enabled as mongo_enabled
-
-    if mongo_enabled():
-        try:
-            from app.repository.mongo_asr_repository import list_versions
-            docs = await list_versions(bvid, cid)
-            if docs:
-                return [
-                    VideoVersionInfo(
-                        version=d.get("version", 1),
-                        content_source=d.get("content_source", "unknown"),
-                        content_preview=(d.get("content") or "")[:100],
-                        is_latest=d.get("is_latest", False),
-                        created_at=d.get("created_at", datetime.now(timezone.utc)),
-                    )
-                    for d in docs
-                ]
-        except Exception as e:
-            logger.warning(f"[ASR] MongoDB versions read failed, using MySQL: {e}")
-
-    result = await db.execute(
-        select(VideoVersion)
-        .where(VideoVersion.bvid == bvid, VideoVersion.cid == cid)
-        .order_by(VideoVersion.version.desc())
-    )
-    versions = result.scalars().all()
-
-    return [
-        VideoVersionInfo(
-            version=v.version,
-            content_source=v.content_source or "unknown",
-            content_preview=(v.content or "")[:100],
-            is_latest=v.is_latest,
-            created_at=v.created_at,
-        )
-        for v in versions
-    ]
+    return await get_ASRPageService().list_versions(bvid, cid, db)

--- a/app/services/asr_page_service.py
+++ b/app/services/asr_page_service.py
@@ -6,18 +6,25 @@ ASR 分P服务 - 仅做 ASR 转写，不涉及 RAG 向量存储
 Storage: ASR text → MongoDB (asr_documents), metadata → MySQL (video + video_versions).
 If MongoDB is disabled, falls back to MySQL video.content column.
 """
+import asyncio
 import os
 import time
+from datetime import datetime, timezone
 from typing import Optional
 from loguru import logger
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.services.asr import ASRService
 from app.services.bilibili import BilibiliService
-from app.services.async_task.asr_task_registry import asr_tasks
+from app.services.async_task.asr_task_registry import asr_tasks, create_task
 from app.database import get_db_context
 from app.models import Video, VideoVersion
 from app.infra.mongo import is_enabled as mongo_enabled
 from app.utils.bvid import bv_to_av
+
+# Strong refs for background tasks — prevents asyncio from GC'ing them mid-run.
+_background_tasks: set[asyncio.Task] = set()
 
 
 class ContentSource:
@@ -46,6 +53,239 @@ class ASRPageService:
     def set_bilibili_service(self, bili: BilibiliService):
         """设置 B站 服务（运行时注入）"""
         self.bili = bili
+
+    # ── CRUD methods (called by router) ────────────────────────────
+
+    async def get_content(self, bvid: str, cid: int, db: AsyncSession):
+        """Query ASR content — MongoDB first, MySQL fallback."""
+        from app.response import ASRContentResponse
+
+        result = await db.execute(
+            select(Video).where(Video.bvid == bvid, Video.cid == cid)
+        )
+        page = result.scalar_one_or_none()
+        if not page:
+            return ASRContentResponse(exists=False)
+
+        content = None
+        content_source = page.content_source
+        version = page.version
+
+        if mongo_enabled() and page.is_processed:
+            try:
+                from app.repository.mongo_asr_repository import get_latest
+                mongo_doc = await get_latest(bvid, cid)
+                if mongo_doc:
+                    content = mongo_doc.get("content")
+                    content_source = mongo_doc.get("content_source", content_source)
+                    version = mongo_doc.get("version", version)
+            except Exception as e:
+                logger.warning(f"[ASR] MongoDB read failed: {e}")
+
+        return ASRContentResponse(
+            exists=True,
+            bvid=page.bvid,
+            cid=page.cid,
+            page_index=page.page_index,
+            page_title=page.page_title,
+            content=content,
+            content_source=content_source,
+            version=version,
+            is_processed=page.is_processed,
+        )
+
+    async def create_task(
+        self,
+        bvid: str,
+        cid: int,
+        page_index: int,
+        page_title: Optional[str],
+        uid: int,
+        db: AsyncSession,
+    ) -> dict:
+        """Idempotent ASR task creation.
+
+        - Existing & is_processed=True → return immediately, no task spawned.
+        - Not existing → create Video row + spawn background task.
+        - Existing & not processed → spawn background task on existing row.
+        """
+        result = await db.execute(
+            select(Video).where(Video.bvid == bvid, Video.page_index == page_index)
+        )
+        existing = result.scalar_one_or_none()
+
+        if existing and existing.is_processed:
+            return {
+                "task_id": None,
+                "message": "ASR 已完成",
+                "version": existing.version,
+            }
+
+        if not existing:
+            new_page = Video(
+                bvid=bvid,
+                cid=cid,
+                page_index=page_index,
+                page_title=page_title or f"P{page_index + 1}",
+                is_processed=False,
+                version=1,
+            )
+            db.add(new_page)
+            await db.commit()
+
+        task_id = create_task(uid=uid)
+        self._spawn_process_page(task_id, bvid, cid, page_index, page_title or f"P{page_index + 1}")
+        return {"task_id": task_id, "message": "ASR 任务已创建"}
+
+    async def update_content(
+        self,
+        bvid: str,
+        page_index: int,
+        content: str,
+        db: AsyncSession,
+    ) -> None:
+        """Overwrite ASR content (user edit, no new version)."""
+        result = await db.execute(
+            select(Video).where(Video.bvid == bvid, Video.page_index == page_index)
+        )
+        page = result.scalar_one_or_none()
+        if not page:
+            from fastapi import HTTPException
+            raise HTTPException(status_code=404, detail="ASR 记录不存在")
+
+        page.content_source = "user_edit"
+        page.is_processed = True
+        page.updated_at = datetime.now(timezone.utc)
+        await db.commit()
+
+        if mongo_enabled():
+            try:
+                from app.repository.mongo_asr_repository import save_asr
+                await save_asr(
+                    video_id=bv_to_av(bvid),
+                    bvid=bvid, cid=page.cid, page_index=page_index,
+                    page_title=page.page_title or "",
+                    content=content, content_source="user_edit",
+                )
+            except Exception as e:
+                logger.warning(f"[ASR] MongoDB save failed on user edit: {e}")
+
+    async def reasr(
+        self,
+        bvid: str,
+        page_index: int,
+        uid: int,
+        db: AsyncSession,
+    ) -> dict:
+        """Force re-ASR (creates a new version)."""
+        result = await db.execute(
+            select(Video).where(Video.bvid == bvid, Video.page_index == page_index)
+        )
+        page = result.scalar_one_or_none()
+        if not page:
+            from fastapi import HTTPException
+            raise HTTPException(status_code=404, detail="ASR 记录不存在")
+
+        old_version = page.version
+
+        # Snapshot the old version (metadata only; full text lives in MongoDB).
+        db.add(VideoVersion(
+            bvid=bvid,
+            cid=page.cid,
+            page_index=page.page_index,
+            version=old_version,
+            content_source=page.content_source,
+            is_latest=False,
+        ))
+
+        page.version = old_version + 1
+        page.is_processed = False
+        page.content_source = None
+        page.updated_at = datetime.now(timezone.utc)
+        await db.commit()
+
+        task_id = create_task(uid=uid)
+        self._spawn_process_page(
+            task_id, bvid, page.cid, page.page_index,
+            page.page_title or f"P{page.page_index + 1}",
+        )
+        return {"task_id": task_id, "message": "重新 ASR 已启动"}
+
+    async def get_task_status(self, task_id: str, uid: int):
+        """Return task status dict; raises 404 if not found, 403 if not owner."""
+        from fastapi import HTTPException
+        from app.response import ASRTaskStatus
+
+        if task_id not in asr_tasks:
+            raise HTTPException(status_code=404, detail="任务不存在")
+        task = asr_tasks[task_id]
+        # IDOR guard: in-memory tasks created via create_task(uid=...) carry
+        # the owner uid. Tasks without uid (legacy/internal) remain pollable.
+        task_uid = task.get("uid")
+        if task_uid is not None and task_uid != uid:
+            raise HTTPException(status_code=403, detail="无权访问此任务")
+        return ASRTaskStatus(
+            task_id=task_id,
+            status=task["status"],
+            progress=task["progress"],
+            message=task["message"],
+        )
+
+    async def list_versions(self, bvid: str, cid: int, db: AsyncSession) -> list:
+        """Query version history — MongoDB first, MySQL fallback."""
+        from app.response import VideoVersionInfo
+
+        if mongo_enabled():
+            try:
+                from app.repository.mongo_asr_repository import list_versions
+                docs = await list_versions(bvid, cid)
+                if docs:
+                    return [
+                        VideoVersionInfo(
+                            version=d.get("version", 1),
+                            content_source=d.get("content_source", "unknown"),
+                            content_preview=(d.get("content") or "")[:100],
+                            is_latest=d.get("is_latest", False),
+                            created_at=d.get("created_at", datetime.now(timezone.utc)),
+                        )
+                        for d in docs
+                    ]
+            except Exception as e:
+                logger.warning(f"[ASR] MongoDB versions read failed, using MySQL: {e}")
+
+        result = await db.execute(
+            select(VideoVersion)
+            .where(VideoVersion.bvid == bvid, VideoVersion.cid == cid)
+            .order_by(VideoVersion.version.desc())
+        )
+        versions = result.scalars().all()
+        return [
+            VideoVersionInfo(
+                version=v.version,
+                content_source=v.content_source or "unknown",
+                content_preview=(v.content or "")[:100],
+                is_latest=v.is_latest,
+                created_at=v.created_at,
+            )
+            for v in versions
+        ]
+
+    def _spawn_process_page(
+        self,
+        task_id: str,
+        bvid: str,
+        cid: int,
+        page_index: int,
+        page_title: str,
+    ) -> None:
+        """Spawn process_page as a strongly-referenced background task."""
+        coro = self.process_page(
+            task_id=task_id, bvid=bvid, cid=cid,
+            page_index=page_index, page_title=page_title,
+        )
+        task = asyncio.create_task(coro)
+        _background_tasks.add(task)
+        task.add_done_callback(_background_tasks.discard)
 
     async def process_page(
         self,

--- a/app/services/async_task/asr_task_registry.py
+++ b/app/services/async_task/asr_task_registry.py
@@ -12,20 +12,25 @@ must not import from routers.
 from __future__ import annotations
 
 import uuid
-from typing import Any
+from typing import Any, Optional
 
-# task_id -> {"status", "progress", "message", "result"}
+# task_id -> {"status", "progress", "message", "result", "uid"}
 asr_tasks: dict[str, dict[str, Any]] = {}
 
 
-def create_task() -> str:
-    """Create a new pending task and return its id."""
+def create_task(uid: Optional[int] = None) -> str:
+    """Create a new pending task and return its id.
+
+    ``uid`` is optional for backward compat with callers that predate the
+    IDOR fix; when provided, polling endpoints can enforce ownership.
+    """
     task_id = str(uuid.uuid4())
     asr_tasks[task_id] = {
         "status": "pending",
         "progress": 0,
         "message": "任务已创建",
         "result": None,
+        "uid": uid,
     }
     return task_id
 


### PR DESCRIPTION
Move all inline DB operations from routers/asr.py into ASRPageService. Router now only does parameter parsing + DI + response marshalling.

Service methods added:
- get_content(bvid, cid, db)          — MongoDB-first read with MySQL fallback
- create_task(bvid, cid, ...)          — idempotent upsert + background spawn
- update_content(bvid, page_index, ...) — MySQL + MongoDB write
- reasr(bvid, page_index, ...)         — VideoVersion insert + page reset
- get_task_status(task_id, uid)        — ownership-scoped status read
- list_versions(bvid, cid, db)         — version history

Router changes:
- 6 endpoints reduced to single-line delegates
- Eliminates db.execute / db.add / db.commit / select(Video) in router
- Background asyncio.create_task moved into service (strong-ref set _background_tasks prevents GC mid-run)

IDOR fix: asr_task_registry.create_task now accepts optional uid; get_task_status enforces task.uid == uid to prevent cross-user polling.

Why: CLAUDE.md §6 forbids DB operations in routers — asr.py had 7 inline db.execute calls and direct Video ORM mutation, making the router untestable and mixing transaction boundaries.