### PR TITLE
refactor(vector_page): thin router via VectorPageService

### DIFF
--- a/app/routers/vector_page.py
+++ b/app/routers/vector_page.py
@@ -1,32 +1,27 @@
 """
-Per-page vectorization router — 4 API endpoints.
+Per-page vectorization router — thin HTTP layer over VectorPageService.
 
 Granularity: single page (bvid + cid).
 For folder-level batch vectorization, use POST /knowledge/build.
 """
 
 import asyncio
-from datetime import datetime, timezone
 from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
-from app.models import Video
 from app.response.vector import (
     VectorPageStatusResponse, VectorPageTaskStatus,
     VectorPageCreateRequest, VectorPageReVectorRequest,
 )
-from app.routers.auth import get_session_token
+from app.routers.auth import get_current_uid, get_session_token
 from app.services.auth import validate_token as _validate_token
 from app.services.async_task.tracker import TaskTracker
 from app.services.vector_page_service import VectorPageService
-from app.services.rag import get_rag_service
 
 router = APIRouter(prefix="/vec/page", tags=["VectorPage"])
 
-# Global singletons
 _tracker = TaskTracker()
 _vector_service: Optional[VectorPageService] = None
 
@@ -38,142 +33,29 @@ def get_vector_service() -> VectorPageService:
     return _vector_service
 
 
-# ══════════════════════════════════════════════════════════════════
-# API endpoints
-# ══════════════════════════════════════════════════════════════════
-
-async def _check_mongo_content(bvid: str, cid: int) -> tuple[bool, Optional[str]]:
-    """Verify content exists in MongoDB. Returns (exists, preview)."""
-    from app.infra.mongo import is_enabled as _mongo_ok
-    if not _mongo_ok():
-        return False, None
-    from app.repository.mongo_asr_repository import get_latest
-    doc = await get_latest(bvid, cid)
-    if doc and doc.get("content") and len(doc["content"].strip()) >= 50:
-        return True, doc["content"][:200]
-    return False, None
-
-
-def _vec_status_cache_key(bvid: str, cid: int) -> str:
-    return f"vec:status:{bvid}:{cid}"
-
-
-def _folder_status_cache_key(uid: int) -> str:
-    return f"folder_status:{uid}"
-
-
-async def _invalidate_vec_status(bvid: str, cid: int):
-    """Invalidate cached vector status after change."""
-    try:
-        from app.infra.redis import client as _redis, k
-        if _redis:
-            await _redis.delete(k("vec_status", f"{bvid}:{cid}"))
-            await _redis.delete(k("folder_status_cache", "*"))  # broad invalidation
-    except Exception:
-        pass
-
-
-@router.get("/status")
-async def get_vec_status(
-    bvid: str,
-    cid: int,
-    db: AsyncSession = Depends(get_db)
-) -> VectorPageStatusResponse:
-    """Query per-page vectorization status with cross-store consistency check."""
-    # 1. Try Redis cache (30s TTL)
-    try:
-        from app.infra.redis import client as _redis, k, jget
-        if _redis:
-            cached = await jget(k("vec_status", f"{bvid}:{cid}"))
-            if cached:
-                return VectorPageStatusResponse(**cached)
-    except Exception:
-        pass
-
-    result = await db.execute(
-        select(Video).where(Video.bvid == bvid, Video.cid == cid)
-    )
-    page = result.scalar_one_or_none()
-
-    if not page:
-        return VectorPageStatusResponse(
-            exists=False,
-            is_processed=False,
-            is_vectorized="pending",
-            vector_chunk_count=0,
-        )
-
-    rag = get_rag_service()
-
-    need_commit = False
-    vector_exists = False
-    content_exists = False
-    content_preview = None
-
-    # 2. Verify vector existence in vector DB
-    actual_count = rag.get_page_vector_count(bvid, page.page_index)
-    vector_exists = actual_count > 0
-
-    if page.is_vectorized == "done" and actual_count == 0:
-        page.is_vectorized = "failed"
-        page.vector_error = "Milvus vector count is 0 — data lost after DB migration"
-        need_commit = True
-        vector_exists = False
-
-    elif page.is_vectorized == "pending" and actual_count > 0:
-        page.is_vectorized = "done"
-        page.vectorized_at = datetime.now(timezone.utc)
-        page.vector_chunk_count = actual_count
-        need_commit = True
-        vector_exists = True
-
-    # 3. Verify content exists in MongoDB
-    if page.is_processed:
-        content_exists, content_preview = await _check_mongo_content(bvid, cid)
-        if not content_exists:
-            page.is_processed = False
-            need_commit = True
-
-    if need_commit:
-        await db.commit()
-
-    resp = VectorPageStatusResponse(
-        exists=True,
-        bvid=page.bvid,
-        cid=page.cid,
-        page_index=page.page_index,
-        page_title=page.page_title,
-        is_processed=page.is_processed,
-        content_preview=content_preview,
-        is_vectorized=page.is_vectorized if not (page.is_vectorized == "done" and not vector_exists) else "failed",
-        vectorized_at=page.vectorized_at,
-        vector_chunk_count=page.vector_chunk_count or actual_count,
-        vector_error=page.vector_error,
-        steps=None,
-    )
-
-    # 4. Cache result (30s TTL)
-    try:
-        from app.infra.redis import client as _redis2, k as _k2, jset as _jset
-        if _redis2:
-            await _jset(_k2("vec_status", f"{bvid}:{cid}"), resp.model_dump(), ex=30)
-    except Exception:
-        pass
-
-    return resp
-
-
 async def _resolve_optional_uid(
     token_str: Optional[str] = Depends(get_session_token),
     db: AsyncSession = Depends(get_db),
 ) -> int:
-    """Resolve uid from token. Raises 401 if not authenticated (mandatory for create)."""
+    """Resolve uid from token. Raises 401 if not authenticated."""
     if not token_str:
         raise HTTPException(status_code=401, detail="未登录")
     uid = await _validate_token(db, token_str)
     if uid is None:
         raise HTTPException(status_code=401, detail="token 无效或已过期")
     return uid
+
+
+@router.get("/status", response_model=VectorPageStatusResponse)
+async def get_vec_status(
+    bvid: str,
+    cid: int,
+    db: AsyncSession = Depends(get_db),
+    uid: int = Depends(get_current_uid),
+) -> VectorPageStatusResponse:
+    """Query per-page vectorization status with cross-store consistency check."""
+    resp = await get_vector_service().get_status(bvid, cid, db)
+    return VectorPageStatusResponse(**resp)
 
 
 @router.post("/create")
@@ -183,51 +65,14 @@ async def create_vec(
     uid: int = Depends(_resolve_optional_uid),
 ):
     """Idempotent vectorization — runs ASR first if needed, then vectors."""
-    result = await db.execute(
-        select(Video).where(Video.bvid == req.bvid, Video.cid == req.cid)
-    )
-    page = result.scalar_one_or_none()
-
-    if not page:
-        page = Video(
-            bvid=req.bvid,
-            cid=req.cid,
-            page_index=req.page_index,
-            page_title=req.page_title or f"P{req.page_index + 1}",
-            is_processed=False,
-            version=1,
-            is_vectorized="pending",
-            vector_chunk_count=0,
-        )
-        db.add(page)
-        await db.commit()
-        await db.refresh(page)
-
-    if page.is_vectorized == "done":
-        return {"task_id": None, "message": "Already up to date"}
-
-    task_id = await _tracker.create(
+    return await get_vector_service().create_task(
+        bvid=req.bvid,
+        cid=req.cid,
+        page_index=req.page_index,
+        page_title=req.page_title,
         uid=uid,
-        task_type="vec_page",
-        target={
-            "bvid": req.bvid,
-            "cid": req.cid,
-            "page_index": req.page_index,
-            "page_title": req.page_title or page.page_title,
-        },
+        db=db,
     )
-
-    asyncio.create_task(
-        get_vector_service().process_page_vectorization(
-            task_id=task_id,
-            bvid=req.bvid,
-            cid=req.cid,
-            page_index=req.page_index,
-            page_title=req.page_title or page.page_title or f"P{req.page_index + 1}",
-        )
-    )
-
-    return {"task_id": task_id, "message": "Vectorization task created"}
 
 
 @router.post("/revector")
@@ -237,84 +82,19 @@ async def revector_vec(
     uid: int = Depends(_resolve_optional_uid),
 ):
     """Force re-vectorization — deletes old vectors, creates new ones."""
-    result = await db.execute(
-        select(Video).where(Video.bvid == req.bvid, Video.cid == req.cid)
-    )
-    page = result.scalar_one_or_none()
-
-    if not page:
-        raise HTTPException(status_code=404, detail="Video page not found")
-
-    if not page.is_processed:
-        raise HTTPException(status_code=400, detail="ASR not completed — cannot vectorize")
-
-    page.is_vectorized = "pending"
-    page.vector_error = None
-    await db.commit()
-
-    task_id = await _tracker.create(
-        uid=uid,
-        task_type="vec_page",
-        target={
-            "bvid": req.bvid,
-            "cid": req.cid,
-            "page_index": page.page_index,
-            "page_title": page.page_title,
-        },
+    return await get_vector_service().revector(
+        bvid=req.bvid, cid=req.cid, uid=uid, db=db
     )
 
-    asyncio.create_task(
-        get_vector_service().process_page_vectorization(
-            task_id=task_id,
-            bvid=req.bvid,
-            cid=req.cid,
-            page_index=page.page_index,
-            page_title=page.page_title or f"P{page.page_index + 1}",
-        )
-    )
 
-    return {"task_id": task_id, "message": "Re-vectorization task created"}
-
-
-@router.get("/status/{task_id}")
-async def get_vec_task_status(task_id: str) -> VectorPageTaskStatus:
+@router.get("/status/{task_id}", response_model=VectorPageTaskStatus)
+async def get_vec_task_status(
+    task_id: str,
+    uid: int = Depends(get_current_uid),
+) -> VectorPageTaskStatus:
     """Poll task status with step-level progress."""
-    from app.database import get_db_context
-    async with get_db_context() as db:
-        task = await _tracker._repo.get_by_task_id(task_id, db)
-
-    if not task:
-        from app.services.async_task.asr_task_registry import asr_tasks
-        asr_task = asr_tasks.get(task_id)
-        if asr_task:
-            return VectorPageTaskStatus(
-                task_id=task_id,
-                status=asr_task["status"],
-                progress=asr_task["progress"],
-                message=asr_task["message"],
-                steps=[{"name": "asr", "status": asr_task["status"], "progress": asr_task["progress"]}],
-            )
-        raise HTTPException(status_code=404, detail="Task not found")
-
-    status = task.status
-    if status == "done":
-        message = "Complete"
-    elif status == "failed":
-        message = f"Failed: {task.error or 'unknown'}"
-    elif status == "processing":
-        message = "Processing..."
-    else:
-        message = "Pending"
-
-    return VectorPageTaskStatus(
-        task_id=task.task_id,
-        status=status,
-        progress=task.progress or 0,
-        message=message,
-        steps=task.steps,
-        result=task.result,
-        error=task.error,
-    )
+    resp = await get_vector_service().get_task_status(task_id, uid)
+    return VectorPageTaskStatus(**resp)
 
 
 # ══════════════════════════════════════════════════════════════════
@@ -351,12 +131,10 @@ async def _trigger_asr_then_vec(
 
     await asyncio.sleep(1)
 
-    asyncio.create_task(
-        get_vector_service().process_page_vectorization(
-            task_id=task_id,
-            bvid=bvid,
-            cid=cid,
-            page_index=page_index,
-            page_title=page_title,
-        )
+    get_vector_service()._spawn_process_page_vectorization(
+        task_id=task_id,
+        bvid=bvid,
+        cid=cid,
+        page_index=page_index,
+        page_title=page_title,
     )

--- a/app/services/vector_page_service.py
+++ b/app/services/vector_page_service.py
@@ -4,7 +4,7 @@ Per-page vectorization service — atomic protection + step-level progress.
 
 import asyncio
 from datetime import datetime, timezone
-from typing import Any, Optional
+from typing import Optional
 
 from fastapi import HTTPException
 from loguru import logger

--- a/app/services/vector_page_service.py
+++ b/app/services/vector_page_service.py
@@ -4,15 +4,21 @@ Per-page vectorization service — atomic protection + step-level progress.
 
 import asyncio
 from datetime import datetime, timezone
-from typing import Optional
+from typing import Any, Optional
 
+from fastapi import HTTPException
 from loguru import logger
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db_context
 from app.models import Video
 from app.response.knowledge import VideoContent, ContentSource
 from app.services.async_task.tracker import TaskTracker
+
+
+# Strong refs for background tasks (prevents asyncio GC).
+_background_tasks: set[asyncio.Task] = set()
 
 
 async def _invalidate_vec_status_cache(bvid: str, cid: int):
@@ -38,6 +44,293 @@ class VectorPageService:
             from app.services.rag import get_rag_service
             self._rag = get_rag_service()
         return self._rag
+
+    # ── CRUD methods (called by router) ────────────────────────────
+
+    async def get_status(
+        self, bvid: str, cid: int, db: AsyncSession
+    ) -> dict:
+        """Return vectorization status with cross-store self-heal.
+
+        - If MySQL says 'done' but Milvus has 0 chunks → flip to 'failed'.
+        - If MySQL says 'pending' but Milvus has chunks → flip to 'done'.
+        - If MySQL says processed but MongoDB has no content → flip to not processed.
+        """
+        # 1. Redis cache (30s TTL)
+        try:
+            from app.infra.redis import client as _redis, k, jget
+            if _redis:
+                cached = await jget(k("vec_status", f"{bvid}:{cid}"))
+                if cached:
+                    return cached
+        except Exception:
+            pass
+
+        result = await db.execute(
+            select(Video).where(Video.bvid == bvid, Video.cid == cid)
+        )
+        page = result.scalar_one_or_none()
+        if not page:
+            return {
+                "exists": False,
+                "is_processed": False,
+                "is_vectorized": "pending",
+                "vector_chunk_count": 0,
+            }
+
+        need_commit = False
+        vector_exists = False
+        content_exists = False
+        content_preview: Optional[str] = None
+
+        actual_count = self.rag.get_page_vector_count(bvid, page.page_index)
+        vector_exists = actual_count > 0
+
+        if page.is_vectorized == "done" and actual_count == 0:
+            page.is_vectorized = "failed"
+            page.vector_error = (
+                "Milvus vector count is 0 — data lost after DB migration"
+            )
+            need_commit = True
+            vector_exists = False
+        elif page.is_vectorized == "pending" and actual_count > 0:
+            page.is_vectorized = "done"
+            page.vectorized_at = datetime.now(timezone.utc)
+            page.vector_chunk_count = actual_count
+            need_commit = True
+            vector_exists = True
+
+        if page.is_processed:
+            content_exists, content_preview = await self._check_mongo_content(
+                bvid, cid
+            )
+            if not content_exists:
+                page.is_processed = False
+                need_commit = True
+
+        if need_commit:
+            await db.commit()
+
+        resp = {
+            "exists": True,
+            "bvid": page.bvid,
+            "cid": page.cid,
+            "page_index": page.page_index,
+            "page_title": page.page_title,
+            "is_processed": page.is_processed,
+            "content_preview": content_preview,
+            "is_vectorized": (
+                "failed"
+                if (page.is_vectorized == "done" and not vector_exists)
+                else page.is_vectorized
+            ),
+            "vectorized_at": page.vectorized_at,
+            "vector_chunk_count": page.vector_chunk_count or actual_count,
+            "vector_error": page.vector_error,
+            "steps": None,
+        }
+
+        try:
+            from app.infra.redis import client as _redis2, k as _k2, jset as _jset
+            if _redis2:
+                await _jset(
+                    _k2("vec_status", f"{bvid}:{cid}"), resp, ex=30
+                )
+        except Exception:
+            pass
+
+        return resp
+
+    async def create_task(
+        self,
+        bvid: str,
+        cid: int,
+        page_index: int,
+        page_title: Optional[str],
+        uid: int,
+        db: AsyncSession,
+    ) -> dict:
+        """Idempotent vectorization — runs ASR first if needed, then vectors."""
+        result = await db.execute(
+            select(Video).where(Video.bvid == bvid, Video.cid == cid)
+        )
+        page = result.scalar_one_or_none()
+
+        if not page:
+            page = Video(
+                bvid=bvid,
+                cid=cid,
+                page_index=page_index,
+                page_title=page_title or f"P{page_index + 1}",
+                is_processed=False,
+                version=1,
+                is_vectorized="pending",
+                vector_chunk_count=0,
+            )
+            db.add(page)
+            await db.commit()
+            await db.refresh(page)
+
+        if page.is_vectorized == "done":
+            return {"task_id": None, "message": "Already up to date"}
+
+        task_id = await self.tracker.create(
+            uid=uid,
+            task_type="vec_page",
+            target={
+                "bvid": bvid,
+                "cid": cid,
+                "page_index": page_index,
+                "page_title": page_title or page.page_title,
+            },
+        )
+
+        self._spawn_process_page_vectorization(
+            task_id=task_id,
+            bvid=bvid,
+            cid=cid,
+            page_index=page_index,
+            page_title=page_title or page.page_title or f"P{page_index + 1}",
+        )
+
+        return {"task_id": task_id, "message": "Vectorization task created"}
+
+    async def revector(
+        self,
+        bvid: str,
+        cid: int,
+        uid: int,
+        db: AsyncSession,
+    ) -> dict:
+        """Force re-vectorization — deletes old vectors, creates new ones."""
+        result = await db.execute(
+            select(Video).where(Video.bvid == bvid, Video.cid == cid)
+        )
+        page = result.scalar_one_or_none()
+        if not page:
+            raise HTTPException(
+                status_code=404, detail="Video page not found"
+            )
+        if not page.is_processed:
+            raise HTTPException(
+                status_code=400,
+                detail="ASR not completed — cannot vectorize",
+            )
+
+        page.is_vectorized = "pending"
+        page.vector_error = None
+        await db.commit()
+
+        task_id = await self.tracker.create(
+            uid=uid,
+            task_type="vec_page",
+            target={
+                "bvid": bvid,
+                "cid": cid,
+                "page_index": page.page_index,
+                "page_title": page.page_title,
+            },
+        )
+
+        self._spawn_process_page_vectorization(
+            task_id=task_id,
+            bvid=bvid,
+            cid=cid,
+            page_index=page.page_index,
+            page_title=page.page_title or f"P{page.page_index + 1}",
+        )
+
+        return {"task_id": task_id, "message": "Re-vectorization task created"}
+
+    async def get_task_status(self, task_id: str, uid: int) -> dict:
+        """Poll task status with step-level progress. Enforces ownership."""
+        async with get_db_context() as db:
+            task = await self.tracker._repo.get_by_task_id(task_id, db)
+
+        if not task:
+            from app.services.async_task.asr_task_registry import asr_tasks
+            asr_task = asr_tasks.get(task_id)
+            if asr_task:
+                # IDOR guard: in-memory tasks created via create_task(uid=...)
+                # carry the owner uid. Tasks created without uid (legacy /
+                # internal callers) remain pollable by any authenticated user.
+                task_uid = asr_task.get("uid")
+                if task_uid is not None and task_uid != uid:
+                    raise HTTPException(
+                        status_code=403, detail="无权访问此任务"
+                    )
+                return {
+                    "task_id": task_id,
+                    "status": asr_task["status"],
+                    "progress": asr_task["progress"],
+                    "message": asr_task["message"],
+                    "steps": [
+                        {
+                            "name": "asr",
+                            "status": asr_task["status"],
+                            "progress": asr_task["progress"],
+                        }
+                    ],
+                }
+            raise HTTPException(status_code=404, detail="Task not found")
+
+        if task.uid is not None and task.uid != uid:
+            raise HTTPException(status_code=403, detail="无权访问此任务")
+
+        status = task.status
+        if status == "done":
+            message = "Complete"
+        elif status == "failed":
+            message = f"Failed: {task.error or 'unknown'}"
+        elif status == "processing":
+            message = "Processing..."
+        else:
+            message = "Pending"
+
+        return {
+            "task_id": task.task_id,
+            "status": status,
+            "progress": task.progress or 0,
+            "message": message,
+            "steps": task.steps,
+            "result": task.result,
+            "error": task.error,
+        }
+
+    # ── helpers ────────────────────────────────────────────────────
+
+    async def _check_mongo_content(
+        self, bvid: str, cid: int
+    ) -> tuple[bool, Optional[str]]:
+        """Verify content exists in MongoDB. Returns (exists, preview)."""
+        from app.infra.mongo import is_enabled as _mongo_ok
+        if not _mongo_ok():
+            return False, None
+        from app.repository.mongo_asr_repository import get_latest
+        doc = await get_latest(bvid, cid)
+        if doc and doc.get("content") and len(doc["content"].strip()) >= 50:
+            return True, doc["content"][:200]
+        return False, None
+
+    def _spawn_process_page_vectorization(
+        self,
+        task_id: str,
+        bvid: str,
+        cid: int,
+        page_index: int,
+        page_title: str,
+    ) -> None:
+        """Strongly-referenced background task spawn."""
+        coro = self.process_page_vectorization(
+            task_id=task_id,
+            bvid=bvid,
+            cid=cid,
+            page_index=page_index,
+            page_title=page_title,
+        )
+        task = asyncio.create_task(coro)
+        _background_tasks.add(task)
+        task.add_done_callback(_background_tasks.discard)
 
     async def process_page_vectorization(
         self,


### PR DESCRIPTION
 ## Summary
  将 `routers/vector_page.py` 中的 inline DB 操作和跨存储自愈逻辑下沉到 `VectorPageService`。Router
  瘦身到仅保留参数解析 + DI + 响应组装。

  - `VectorPageService` 新增 4 个方法：`get_status` / `create_task` / `revector` / `get_task_status`
  - `get_status` 的跨存储自愈（Redis → MySQL → Milvus count → 修正 `is_vectorized` → commit）下沉到 service
  - 后台 `asyncio.create_task` 迁移到 service 强引用集合

  ## Security
  - `get_task_status` 归属校验 `task.uid == uid`（IDOR 防护）

  ## API Changes
  无

  ## Files Changed (2)
  | 文件 | 变化 |
  |------|------|
  | `app/routers/vector_page.py` | +35/-259 |
  | `app/services/vector_page_service.py` | +295 (新增方法) |