### PR TITLE
feat(auth): password login + email verification + rate limiting

### DIFF
--- a/app/config/default.yaml
+++ b/app/config/default.yaml
@@ -185,7 +185,57 @@ session:
 # WARNING: never change this key after deployment — historical data
 # becomes undecryptable.
 # Generate: python -c "import base64,os; print(base64.b64encode(os.urandom(32)).decode())"
-security: {}
+security:
+  # Plan 0028: per-endpoint rate limits + login cooldown.
+  # All windows are seconds. Override via env:
+  #   SECURITY__RATE_LIMIT__LOGIN__IP_MAX=20
+  rate_limit:
+    login:
+      ip_max: 10            # per-IP max attempts per window
+      ip_window: 60         # 60s
+      email_max: 5          # per-email max attempts per window
+      email_window: 300     # 5 minutes
+      cooldown_threshold: 5 # failed attempts before cooldown kicks in
+      cooldown_seconds: 900 # 15 minutes
+    password_reset_request:
+      ip_max: 5
+      ip_window: 3600       # per-IP per hour
+      email_max: 3
+      email_window: 3600
+    password_reset:
+      ip_max: 10
+      ip_window: 3600
+    email_send_code:
+      ip_max: 10
+      ip_window: 60
+      uid_max: 5
+      uid_window: 600       # 10 minutes
+    change_password:
+      uid_max: 3
+      uid_window: 3600
+    email_verify:
+      ip_max: 20
+      ip_window: 60
+
+
+# ---- Email (verification + password reset) ------------------------
+# Uses Resend (https://resend.com). Free tier: 100 emails/day.
+#   1. Sign up at resend.com, create API key
+#   2. (Optional) verify your domain to send from your address
+#   3. For quick testing without domain setup, use the shared address:
+#      from_email: "MindBase <onboarding@resend.dev>"
+# api_key via env: EMAIL__API_KEY
+email:
+  enabled: false                    # set true once API key is configured
+  api_key: ""                       # inject via EMAIL__API_KEY
+  from_email: "MindBase <onboarding@resend.dev>"
+  frontend_url: "http://localhost:3000"  # for reset password link
+  code_ttl_seconds: 300             # 5 minutes
+  code_length: 6                    # 6-digit numeric
+  rate_limit_target_seconds: 60     # min interval between sends to same target
+  rate_limit_uid_minutes: 10        # window for per-uid send count
+  rate_limit_uid_max: 5             # max sends per uid in window
+  max_verify_attempts: 5            # wrong code attempts before code is voided
 
 
 # ---- Rate limiting ------------------------------------------------

--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -188,6 +188,135 @@ class _Settings:
     def api_key_encryption_key(self) -> str:
         return str(_get("security", "api_key_encryption_key", default=""))
 
+    # ── Email ────────────────────────────────────────────────────
+
+    @property
+    def email_enabled(self) -> bool:
+        return bool(_get("email", "enabled", default=False))
+
+    @property
+    def email_api_key(self) -> str:
+        return str(_get("email", "api_key", default=""))
+
+    @property
+    def email_from(self) -> str:
+        return str(_get("email", "from_email",
+                        default="MindBase <onboarding@resend.dev>"))
+
+    @property
+    def email_frontend_url(self) -> str:
+        return str(_get("email", "frontend_url",
+                        default="http://localhost:3000"))
+
+    @property
+    def email_code_ttl_seconds(self) -> int:
+        return int(_get("email", "code_ttl_seconds", default=300))
+
+    @property
+    def email_code_length(self) -> int:
+        return int(_get("email", "code_length", default=6))
+
+    @property
+    def email_rate_limit_target_seconds(self) -> int:
+        return int(_get("email", "rate_limit_target_seconds", default=60))
+
+    @property
+    def email_rate_limit_uid_minutes(self) -> int:
+        return int(_get("email", "rate_limit_uid_minutes", default=10))
+
+    @property
+    def email_rate_limit_uid_max(self) -> int:
+        return int(_get("email", "rate_limit_uid_max", default=5))
+
+    @property
+    def email_max_verify_attempts(self) -> int:
+        return int(_get("email", "max_verify_attempts", default=5))
+
+    # ── Security: rate_limit (Plan 0028) ────────────────────────
+
+    def _rl(self, endpoint: str, key: str, default: int) -> int:
+        return int(_get("security", "rate_limit", endpoint, key, default=default))
+
+    @property
+    def rl_login_ip_max(self) -> int:
+        return self._rl("login", "ip_max", 10)
+
+    @property
+    def rl_login_ip_window(self) -> int:
+        return self._rl("login", "ip_window", 60)
+
+    @property
+    def rl_login_email_max(self) -> int:
+        return self._rl("login", "email_max", 5)
+
+    @property
+    def rl_login_email_window(self) -> int:
+        return self._rl("login", "email_window", 300)
+
+    @property
+    def rl_login_cooldown_threshold(self) -> int:
+        return self._rl("login", "cooldown_threshold", 5)
+
+    @property
+    def rl_login_cooldown_seconds(self) -> int:
+        return self._rl("login", "cooldown_seconds", 900)
+
+    @property
+    def rl_reset_request_ip_max(self) -> int:
+        return self._rl("password_reset_request", "ip_max", 5)
+
+    @property
+    def rl_reset_request_ip_window(self) -> int:
+        return self._rl("password_reset_request", "ip_window", 3600)
+
+    @property
+    def rl_reset_request_email_max(self) -> int:
+        return self._rl("password_reset_request", "email_max", 3)
+
+    @property
+    def rl_reset_request_email_window(self) -> int:
+        return self._rl("password_reset_request", "email_window", 3600)
+
+    @property
+    def rl_reset_ip_max(self) -> int:
+        return self._rl("password_reset", "ip_max", 10)
+
+    @property
+    def rl_reset_ip_window(self) -> int:
+        return self._rl("password_reset", "ip_window", 3600)
+
+    @property
+    def rl_send_code_ip_max(self) -> int:
+        return self._rl("email_send_code", "ip_max", 10)
+
+    @property
+    def rl_send_code_ip_window(self) -> int:
+        return self._rl("email_send_code", "ip_window", 60)
+
+    @property
+    def rl_send_code_uid_max(self) -> int:
+        return self._rl("email_send_code", "uid_max", 5)
+
+    @property
+    def rl_send_code_uid_window(self) -> int:
+        return self._rl("email_send_code", "uid_window", 600)
+
+    @property
+    def rl_change_password_uid_max(self) -> int:
+        return self._rl("change_password", "uid_max", 3)
+
+    @property
+    def rl_change_password_uid_window(self) -> int:
+        return self._rl("change_password", "uid_window", 3600)
+
+    @property
+    def rl_email_verify_ip_max(self) -> int:
+        return self._rl("email_verify", "ip_max", 20)
+
+    @property
+    def rl_email_verify_ip_window(self) -> int:
+        return self._rl("email_verify", "ip_window", 60)
+
 
 # Module-level singleton — the single config access point
 settings = _Settings()

--- a/app/database.py
+++ b/app/database.py
@@ -108,7 +108,37 @@ async def _migrate_add_columns():
         ("quiz_sets", "share_expires_at", "TIMESTAMP"),
         # Quiz quality metrics from generation (traceability_rate, dedup_rate, ...)
         ("quiz_sets", "quality_metrics", "JSON"),
+        # Email verification: brute-force attempt counter + wider code column
+        ("verification_codes", "attempts", "INTEGER DEFAULT 0"),
     ]
+
+    # Column type modifications (widening VARCHAR, etc.)
+    # Uses MySQL syntax MODIFY COLUMN; SQLite needs recreate-and-copy,
+    # so this is best-effort and logs a warning on failure.
+    modify_columns = [
+        # reset tokens are ~43 chars; original VARCHAR(10) truncated them
+        ("verification_codes", "code", "VARCHAR(64) NOT NULL"),
+    ]
+    for table, column, new_type in modify_columns:
+        try:
+            async with engine.begin() as conn:
+                await conn.execute(
+                    text(f"ALTER TABLE {table} MODIFY COLUMN {column} {new_type}")
+                )
+                logger.info(
+                    f"[MIGRATION] Modified column {table}.{column} -> {new_type}"
+                )
+        except Exception as e:
+            err_msg = str(e).lower()
+            if "modify" in err_msg or "syntax" in err_msg:
+                # SQLite doesn't support MODIFY COLUMN; skip silently.
+                logger.debug(
+                    f"[MIGRATION] MODIFY COLUMN not supported here, skipping {table}.{column}"
+                )
+            else:
+                logger.warning(
+                    f"[MIGRATION] Could not modify {table}.{column}: {e}"
+                )
 
     # Plan 0024/0025/0026: drop deprecated content columns & session_id columns
     drop_columns = [
@@ -202,13 +232,31 @@ async def _migrate_add_columns():
                 target VARCHAR(200) NOT NULL,
                 type VARCHAR(20) NOT NULL,
                 purpose VARCHAR(32) NOT NULL,
-                code VARCHAR(10) NOT NULL,
+                code VARCHAR(64) NOT NULL,
                 expires_at TIMESTAMP NOT NULL,
                 used BOOLEAN DEFAULT FALSE,
+                attempts INTEGER DEFAULT 0,
                 created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                 INDEX idx_vc_target_purpose (target, purpose),
                 INDEX idx_vc_uid (uid),
                 FOREIGN KEY (uid) REFERENCES users(uid)
+            )""",
+        ),
+        # Plan 0028: login_attempts — login audit + brute-force cooldown
+        (
+            "login_attempts",
+            """CREATE TABLE IF NOT EXISTS login_attempts (
+                id INT AUTO_INCREMENT PRIMARY KEY,
+                uid BIGINT NULL,
+                email VARCHAR(200) NULL,
+                ip VARCHAR(64) NOT NULL,
+                device_id VARCHAR(64) NULL,
+                success BOOLEAN NOT NULL DEFAULT FALSE,
+                failure_reason VARCHAR(100) NULL,
+                created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                INDEX idx_la_ip_created (ip, created_at),
+                INDEX idx_la_email_created (email, created_at),
+                INDEX idx_la_uid_created (uid, created_at)
             )""",
         ),
         # Plan 0021: Cloud Drive — folder tree

--- a/app/middleware/rate_limit.py
+++ b/app/middleware/rate_limit.py
@@ -13,6 +13,8 @@ from fastapi import Request, Response
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import JSONResponse
 
+from app.utils.request_meta import get_client_ip
+
 logger = logging.getLogger(__name__)
 
 # Endpoint-specific rate limits (requests per second, burst)
@@ -61,7 +63,7 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
             return await call_next(request)
 
         path = request.url.path[:256]
-        client_ip = request.client.host if request.client else "unknown"
+        client_ip = get_client_ip(request)
 
         # Determine rate limit for this path
         rate, burst = _GLOBAL_RATE

--- a/app/models.py
+++ b/app/models.py
@@ -632,15 +632,41 @@ class VerificationCode(Base):
     uid = Column(BigInteger, ForeignKey("users.uid"), nullable=False)
     target = Column(String(200), nullable=False)  # email or phone
     type = Column(String(20), nullable=False)  # email / sms
-    purpose = Column(String(32), nullable=False)  # bind / change / reset_password
-    code = Column(String(10), nullable=False)
+    purpose = Column(String(32), nullable=False)  # bind_email / reset_password / twofa
+    code = Column(String(64), nullable=False)  # 6-digit code or reset token
     expires_at = Column(DateTime, nullable=False)
     used = Column(Boolean, default=False)
+    attempts = Column(Integer, default=0)  # wrong-code attempts (brute-force protection)
     created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
 
     __table_args__ = (
         Index("idx_vc_target_purpose", "target", "purpose"),
         Index("idx_vc_uid", "uid"),
+    )
+
+
+class LoginAttempt(Base):
+    """登录尝试审计表 — 用于失败计数、冷却、风控告警。
+
+    每次 /auth/login 调用写一行（无论成功失败）。
+    失败计数按 ip / email / uid 三维度聚合，超阈值后进入冷却。
+    """
+
+    __tablename__ = "login_attempts"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    uid = Column(BigInteger, nullable=True)  # 登录失败时可能未知
+    email = Column(String(200), nullable=True)
+    ip = Column(String(64), nullable=False)
+    device_id = Column(String(64), nullable=True)
+    success = Column(Boolean, default=False, nullable=False)
+    failure_reason = Column(String(100), nullable=True)  # 防止泄漏细节，仅内部记录
+    created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), nullable=False)
+
+    __table_args__ = (
+        Index("idx_la_ip_created", "ip", "created_at"),
+        Index("idx_la_email_created", "email", "created_at"),
+        Index("idx_la_uid_created", "uid", "created_at"),
     )
 
 

--- a/app/repository/login_attempt_repository.py
+++ b/app/repository/login_attempt_repository.py
@@ -1,0 +1,127 @@
+"""LoginAttemptRepository — login_attempts table CRUD.
+
+Stores one row per login attempt (success or failure). Used by
+RateLimitService to count recent failures by ip / email / uid and
+enforce cooldown after repeated failures.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy import select, func
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import LoginAttempt
+
+
+class LoginAttemptRepository:
+    """Data access for the login_attempts table."""
+
+    async def create(
+        self,
+        db: AsyncSession,
+        *,
+        uid: Optional[int],
+        email: Optional[str],
+        ip: str,
+        device_id: Optional[str],
+        success: bool,
+        failure_reason: Optional[str] = None,
+    ) -> LoginAttempt:
+        """Insert a login attempt record."""
+        now = datetime.now(timezone.utc)
+        la = LoginAttempt(
+            uid=uid,
+            email=email,
+            ip=ip,
+            device_id=device_id,
+            success=success,
+            failure_reason=failure_reason,
+            created_at=now,
+        )
+        db.add(la)
+        await db.flush()
+        return la
+
+    async def count_recent_failures_by_ip(
+        self,
+        db: AsyncSession,
+        *,
+        ip: str,
+        since: datetime,
+    ) -> int:
+        """Count failed login attempts from ip since `since`."""
+        result = await db.execute(
+            select(func.count(LoginAttempt.id)).where(
+                LoginAttempt.ip == ip,
+                LoginAttempt.success.is_(False),
+                LoginAttempt.created_at >= since,
+            )
+        )
+        return int(result.scalar() or 0)
+
+    async def count_recent_failures_by_email(
+        self,
+        db: AsyncSession,
+        *,
+        email: str,
+        since: datetime,
+    ) -> int:
+        """Count failed login attempts for email since `since`."""
+        result = await db.execute(
+            select(func.count(LoginAttempt.id)).where(
+                LoginAttempt.email == email,
+                LoginAttempt.success.is_(False),
+                LoginAttempt.created_at >= since,
+            )
+        )
+        return int(result.scalar() or 0)
+
+    async def count_recent_failures_by_uid(
+        self,
+        db: AsyncSession,
+        *,
+        uid: int,
+        since: datetime,
+    ) -> int:
+        """Count failed login attempts for uid since `since`."""
+        result = await db.execute(
+            select(func.count(LoginAttempt.id)).where(
+                LoginAttempt.uid == uid,
+                LoginAttempt.success.is_(False),
+                LoginAttempt.created_at >= since,
+            )
+        )
+        return int(result.scalar() or 0)
+
+    async def has_recent_success_by_email(
+        self,
+        db: AsyncSession,
+        *,
+        email: str,
+        since: datetime,
+    ) -> bool:
+        """Return True if there's a successful login for email since `since`.
+
+        Used to skip cooldown for accounts that have recently logged in
+        successfully (avoid locking out active users).
+        """
+        result = await db.execute(
+            select(func.count(LoginAttempt.id)).where(
+                LoginAttempt.email == email,
+                LoginAttempt.success.is_(True),
+                LoginAttempt.created_at >= since,
+            )
+        )
+        return int(result.scalar() or 0) > 0
+
+
+_la_repo: Optional[LoginAttemptRepository] = None
+
+
+def get_login_attempt_repository() -> LoginAttemptRepository:
+    global _la_repo
+    if _la_repo is None:
+        _la_repo = LoginAttemptRepository()
+    return _la_repo

--- a/app/repository/verification_code_repository.py
+++ b/app/repository/verification_code_repository.py
@@ -1,0 +1,160 @@
+"""VerificationCodeRepository — verification_codes table CRUD.
+
+Stores 6-digit codes for email verification (bind email, password reset,
+2FA). Each code has a target (email), purpose, expiry, and used flag.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from sqlalchemy import select, func, update
+from sqlalchemy.ext.asyncio import AsyncSession
+from loguru import logger
+
+from app.models import VerificationCode
+
+
+class VerificationCodeRepository:
+    """Data access for the verification_codes table."""
+
+    async def create(
+        self,
+        db: AsyncSession,
+        *,
+        uid: int,
+        target: str,
+        purpose: str,
+        code: str,
+        ttl_seconds: int,
+    ) -> VerificationCode:
+        """Insert a new code, return the persisted row."""
+        now = datetime.now(timezone.utc)
+        vc = VerificationCode(
+            uid=uid,
+            target=target,
+            type="email",
+            purpose=purpose,
+            code=code,
+            expires_at=now + timedelta(seconds=ttl_seconds),
+            used=False,
+            created_at=now,
+        )
+        db.add(vc)
+        await db.flush()
+        logger.info(
+            "[VC_REPO] created uid=%s target=%s purpose=%s expires_in=%ss",
+            uid, target, purpose, ttl_seconds,
+        )
+        return vc
+
+    async def find_latest_unused(
+        self,
+        db: AsyncSession,
+        *,
+        target: str,
+        purpose: str,
+    ) -> Optional[VerificationCode]:
+        """Return the most recent unused, unexpired code for target+purpose."""
+        now = datetime.now(timezone.utc)
+        result = await db.execute(
+            select(VerificationCode)
+            .where(
+                VerificationCode.target == target,
+                VerificationCode.purpose == purpose,
+                VerificationCode.used.is_(False),
+                VerificationCode.expires_at > now,
+            )
+            .order_by(VerificationCode.created_at.desc())
+            .limit(1)
+        )
+        return result.scalar_one_or_none()
+
+    async def mark_used(self, db: AsyncSession, vc_id: int) -> None:
+        """Mark a code as used (single-use enforcement)."""
+        await db.execute(
+            update(VerificationCode)
+            .where(VerificationCode.id == vc_id)
+            .values(used=True)
+        )
+
+    async def increment_attempts(self, db: AsyncSession, vc_id: int) -> int:
+        """Increment wrong-code attempts, return new attempt count."""
+        result = await db.execute(
+            select(VerificationCode)
+            .where(VerificationCode.id == vc_id)
+        )
+        vc = result.scalar_one_or_none()
+        if vc is None:
+            return 0
+        vc.attempts = (vc.attempts or 0) + 1
+        return vc.attempts
+
+    async def count_recent_by_target(
+        self,
+        db: AsyncSession,
+        *,
+        target: str,
+        since: datetime,
+    ) -> int:
+        """Count codes sent to target since `since` (rate limiting)."""
+        result = await db.execute(
+            select(func.count(VerificationCode.id)).where(
+                VerificationCode.target == target,
+                VerificationCode.created_at >= since,
+            )
+        )
+        return int(result.scalar() or 0)
+
+    async def count_recent_by_uid(
+        self,
+        db: AsyncSession,
+        *,
+        uid: int,
+        since: datetime,
+    ) -> int:
+        """Count codes sent for uid since `since` (rate limiting)."""
+        result = await db.execute(
+            select(func.count(VerificationCode.id)).where(
+                VerificationCode.uid == uid,
+                VerificationCode.created_at >= since,
+            )
+        )
+        return int(result.scalar() or 0)
+
+    async def void_recent_unused(
+        self,
+        db: AsyncSession,
+        *,
+        target: str,
+        purpose: str,
+    ) -> None:
+        """Mark all unused codes for target+purpose as used.
+
+        Called when a new code is issued for the same target so that only
+        the latest code is valid.
+        """
+        now = datetime.now(timezone.utc)
+        await db.execute(
+            update(VerificationCode)
+            .where(
+                VerificationCode.target == target,
+                VerificationCode.purpose == purpose,
+                VerificationCode.used.is_(False),
+            )
+            .values(used=True)
+        )
+        logger.debug(
+            "[VC_REPO] voided unused codes target=%s purpose=%s at=%s",
+            target, purpose, now,
+        )
+
+
+_vc_repo: Optional[VerificationCodeRepository] = None
+
+
+def get_verification_code_repository() -> VerificationCodeRepository:
+    global _vc_repo
+    if _vc_repo is None:
+        _vc_repo = VerificationCodeRepository()
+    return _vc_repo

--- a/app/response/__init__.py
+++ b/app/response/__init__.py
@@ -17,6 +17,10 @@ from app.response.auth import (
     PasswordSetRequest,
     PasswordChangeRequest,
     EmailBindRequest,
+    EmailSendCodeRequest,
+    EmailVerifyRequest,
+    PasswordResetRequest,
+    PasswordResetConfirmRequest,
     PhoneBindRequest,
     SecurityOverviewResponse,
 )
@@ -144,6 +148,10 @@ __all__ = [
     "PasswordSetRequest",
     "PasswordChangeRequest",
     "EmailBindRequest",
+    "EmailSendCodeRequest",
+    "EmailVerifyRequest",
+    "PasswordResetRequest",
+    "PasswordResetConfirmRequest",
     "PhoneBindRequest",
     "SecurityOverviewResponse",
     # chat

--- a/app/response/auth.py
+++ b/app/response/auth.py
@@ -4,7 +4,7 @@ Pydantic schemas for auth API — request / response models.
 
 from datetime import datetime, date
 from typing import Optional
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, Field, field_validator
 
 
 def normalize_email(value: str) -> str:
@@ -109,14 +109,17 @@ class ProfileResponse(BaseModel):
 class PasswordSetRequest(BaseModel):
     """POST /auth/password/set request."""
 
-    password: str
+    password: str = Field(..., min_length=1, max_length=128)
 
 
 class PasswordChangeRequest(BaseModel):
     """PATCH /auth/password request."""
 
-    old_password: str
-    new_password: str
+    old_password: str = Field(..., min_length=1, max_length=128)
+    new_password: str = Field(..., min_length=1, max_length=128)
+    # Optional email verification code for 2FA on sensitive operations.
+    # Required when the user has email_verified=true; ignored otherwise.
+    email_code: Optional[str] = None
 
 
 class EmailBindRequest(BaseModel):
@@ -128,6 +131,68 @@ class EmailBindRequest(BaseModel):
     @classmethod
     def normalize_email_value(cls, value: str) -> str:
         return normalize_email(value)
+
+
+class EmailSendCodeRequest(BaseModel):
+    """POST /auth/email/send-code request."""
+
+    email: str
+    purpose: str = "bind_email"  # bind_email | twofa
+
+    @field_validator("email")
+    @classmethod
+    def normalize_email_value(cls, value: str) -> str:
+        return normalize_email(value)
+
+    @field_validator("purpose")
+    @classmethod
+    def validate_purpose(cls, v: str) -> str:
+        if v not in {"bind_email", "twofa"}:
+            raise ValueError("purpose must be bind_email or twofa")
+        return v
+
+
+class EmailVerifyRequest(BaseModel):
+    """POST /auth/email/verify request."""
+
+    email: str
+    code: str
+    purpose: str = "bind_email"
+
+    @field_validator("email")
+    @classmethod
+    def normalize_email_value(cls, value: str) -> str:
+        return normalize_email(value)
+
+    @field_validator("code")
+    @classmethod
+    def normalize_code(cls, v: str) -> str:
+        return v.strip()
+
+    @field_validator("purpose")
+    @classmethod
+    def validate_purpose(cls, v: str) -> str:
+        if v not in {"bind_email", "twofa"}:
+            raise ValueError("purpose must be bind_email or twofa")
+        return v
+
+
+class PasswordResetRequest(BaseModel):
+    """POST /auth/password/reset-request request (public)."""
+
+    email: str
+
+    @field_validator("email")
+    @classmethod
+    def normalize_email_value(cls, value: str) -> str:
+        return normalize_email(value)
+
+
+class PasswordResetConfirmRequest(BaseModel):
+    """POST /auth/password/reset request (public, uses reset token)."""
+
+    reset_token: str = Field(..., min_length=10)
+    new_password: str = Field(..., min_length=1, max_length=128)
 
 
 class PhoneBindRequest(BaseModel):

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -5,15 +5,19 @@ Login writes to new tables (users / user_oauth / user_profile /
 user_token / rbac_user_role). The legacy user_sessions table has been removed.
 """
 
-import hashlib
+from typing import Any, Optional
 
 from fastapi import APIRouter, HTTPException, Depends, Header, Query, Request
 from loguru import logger
 from sqlalchemy.ext.asyncio import AsyncSession
-from typing import Optional
 
 from app.database import get_db, get_db_context
 from app.infra.transaction import transactional_scope
+from app.utils.request_meta import (
+    get_client_ip as _get_client_ip,
+    get_device_id as _get_device_id,
+    extract_device_meta as _extract_device_meta,
+)
 from app.response import (
     LoginRequest,
     QRCodeResponse,
@@ -25,69 +29,26 @@ from app.response import (
     PasswordSetRequest,
     PasswordChangeRequest,
     EmailBindRequest,
+    EmailSendCodeRequest,
+    EmailVerifyRequest,
+    PasswordResetRequest,
+    PasswordResetConfirmRequest,
     PhoneBindRequest,
     SecurityOverviewResponse,
 )
 from app.services.bilibili import BilibiliService
 from app.services.auth import UserService, validate_token as _validate_token
 from app.services.auth.security import decrypt as _decrypt
-
-
-def _get_device_id(request: Request) -> str:
-    """Derive a stable anonymous device fingerprint from request headers."""
-    ua = request.headers.get("user-agent", "")
-    accept_lang = request.headers.get("accept-language", "")
-    raw = f"{ua}|{accept_lang}"
-    return hashlib.sha256(raw.encode()).hexdigest()[:16]
-
-
-def _is_trusted_proxy(host: str | None) -> bool:
-    """Return True iff `host` falls within the configured trusted_proxies CIDRs.
-
-    Used to decide whether to honour X-Forwarded-For / X-Real-IP. If the
-    direct peer is not a trusted proxy we ignore those headers entirely so
-    attackers cannot spoof client IP to bypass per-IP rate limits.
-    """
-    if not host:
-        return False
-    raw = ""
-    try:
-        from app.infra.config import config as _cfg
-        raw = str(getattr(_cfg.server, "trusted_proxies", "") or "")
-    except Exception:
-        return False
-    if not raw.strip():
-        return False
-    try:
-        import ipaddress
-        peer = ipaddress.ip_address(host)
-        for cidr in (c.strip() for c in raw.split(",") if c.strip()):
-            try:
-                if peer in ipaddress.ip_network(cidr, strict=False):
-                    return True
-            except ValueError:
-                continue
-    except ValueError:
-        return False
-    return False
-
-
-def _get_client_ip(request: Request) -> str:
-    """Extract real client IP, respecting reverse-proxy headers.
-
-    Only honours X-Forwarded-For / X-Real-IP when the direct peer is a
-    trusted proxy (see ``_is_trusted_proxy``). Otherwise falls back to the
-    raw socket peer, preventing spoofed-header IP bypass.
-    """
-    peer = request.client.host if request.client else None
-    if _is_trusted_proxy(peer):
-        forwarded = request.headers.get("x-forwarded-for")
-        if forwarded:
-            return forwarded.split(",")[0].strip()
-        real_ip = request.headers.get("x-real-ip")
-        if real_ip:
-            return real_ip.strip()
-    return peer or "unknown"
+from app.services.auth.verification_service import VerificationService
+from app.services.auth.rate_limit_deps import (
+    change_password_rate_limit_dep_inline as _change_pw_rl,
+    email_send_code_rate_limit_dep,
+    email_verify_rate_limit_dep,
+    login_rate_limit_dep,
+    password_reset_rate_limit_dep,
+    password_reset_request_rate_limit_dep,
+    send_code_uid_rate_limit,
+)
 
 
 router = APIRouter(prefix="/auth", tags=["认证"])
@@ -297,6 +258,7 @@ async def poll_qrcode_status(
                     device_id=_get_device_id(request),
                     ip=_get_client_ip(request),
                     user_agent=request.headers.get("user-agent"),
+                    device_meta=_extract_device_meta(request),
                 )
                 roles = await user_service.get_user_roles(uid)
                 response.session_id = user_token.session_token
@@ -347,6 +309,7 @@ async def poll_qrcode_status(
 async def login_with_password(
     req: LoginRequest,
     request: Request,
+    _rl: None = Depends(login_rate_limit_dep),
 ):
     """Login with email + password. Returns session token on success.
 
@@ -357,8 +320,6 @@ async def login_with_password(
     """
     from app.services.auth.login_throttle import (
         check_login_allowed,
-        record_failed_login,
-        record_successful_login,
     )
 
     # Per-email lockout check — must happen before the password check.
@@ -387,15 +348,51 @@ async def login_with_password(
             info = await user_service.get_user_by_uid(uid)
             roles = await user_service.get_user_roles(uid)
     except ValueError:
-        # Count the failed attempt so repeated wrong-password tries lock
-        # the account regardless of how many IPs the attacker spoofs.
-        await record_failed_login(req.email)
+        # Record failed attempt for cooldown / audit.
+        from app.services.auth.rate_limit_service import rate_limit_service
+        await rate_limit_service.record_login_attempt(
+            db,
+            uid=None,
+            email=req.email,
+            ip=ip,
+            device_id=device_id,
+            success=False,
+            failure_reason="invalid_credentials",
+        )
         raise HTTPException(status_code=401, detail="邮箱或密码不正确")
 
-    await record_successful_login(req.email)
+    # Record successful login for audit.
+    from app.services.auth.rate_limit_service import rate_limit_service
+    try:
+        await rate_limit_service.record_login_attempt(
+            db,
+            uid=uid,
+            email=req.email,
+            ip=ip,
+            device_id=device_id,
+            success=True,
+        )
+    except Exception:
+        logger.exception("[AUTH] record_login_attempt (success) failed uid={}", uid)
 
-    # Record device metadata after token commit (best-effort)
+    # Record device metadata after token commit (best-effort).
+    # Server-parsed UA metadata is the base; client-supplied req.device
+    # overrides per-field when present.
     from app.repository.user_device_repository import get_user_device_repository
+
+    server_meta = _extract_device_meta(request)
+    client_meta = req.device.model_dump() if req.device else {}
+    merged: dict[str, Any] = {
+        k: client_meta.get(k) or server_meta.get(k)
+        for k in (
+            "device_type",
+            "device_name",
+            "os",
+            "os_version",
+            "browser",
+            "browser_version",
+        )
+    }
 
     try:
         async with transactional_scope() as db:
@@ -403,12 +400,12 @@ async def login_with_password(
                 db,
                 uid=uid,
                 device_id=device_id,
-                device_type=req.device.device_type if req.device else None,
-                device_name=req.device.device_name if req.device else None,
-                os=req.device.os if req.device else None,
-                os_version=req.device.os_version if req.device else None,
-                browser=req.device.browser if req.device else None,
-                browser_version=req.device.browser_version if req.device else None,
+                device_type=merged["device_type"],
+                device_name=merged["device_name"],
+                os=merged["os"],
+                os_version=merged["os_version"],
+                browser=merged["browser"],
+                browser_version=merged["browser_version"],
                 commit=False,
             )
     except Exception:
@@ -544,6 +541,7 @@ async def set_password(
     try:
         await user_service.set_password(uid, body.password)
     except ValueError as e:
+        logger.warning("[AUTH] set_password failed uid={} reason={}", uid, e)
         raise HTTPException(status_code=400, detail=str(e))
     return {"message": "密码设置成功"}
 
@@ -554,25 +552,68 @@ async def change_password(
     uid: int = Depends(get_current_uid),
     db: AsyncSession = Depends(get_db),
 ):
-    """修改密码（需验证旧密码）"""
-    user_service = UserService(db, await _get_sf())
+    """修改密码（需验证旧密码 + 可选邮箱二次验证）。"""
+    # Per-uid rate limit (inline — dep would need get_current_uid → cycle).
+    await _change_pw_rl(uid, db)
+
+    vs = VerificationService()
     try:
-        await user_service.change_password(uid, body.old_password, body.new_password)
+        await vs.verify_and_change_password(
+            db,
+            uid=uid,
+            old_password=body.old_password,
+            new_password=body.new_password,
+            email_code=body.email_code,
+            sf=await _get_sf(),
+        )
     except ValueError as e:
+        logger.warning(
+            "[AUTH] change_password failed uid={} reason={}", uid, e,
+        )
         raise HTTPException(status_code=400, detail=str(e))
     return {"message": "密码修改成功"}
 
 
 @router.post("/password/reset-request")
-async def reset_password_request(uid: int = Depends(get_current_uid)):
-    """[预留] 请求密码重置邮件"""
-    raise HTTPException(status_code=501, detail="密码重置功能即将上线")
+async def reset_password_request(
+    body: PasswordResetRequest,
+    db: AsyncSession = Depends(get_db),
+    _rl: None = Depends(password_reset_request_rate_limit_dep),
+):
+    """公开接口：请求密码重置邮件。
+
+    即便邮箱未注册也返回相同成功信息（不泄漏账号是否存在）。
+    """
+    vs = VerificationService()
+    try:
+        await vs.send_reset_token(db, target=body.email)
+    except ValueError as e:
+        # "如果该邮箱已注册，您将收到重置邮件" 也走 200，避免账号枚举。
+        raise HTTPException(status_code=400, detail=str(e))
+    return {"message": "如果该邮箱已注册，您将收到重置邮件"}
 
 
 @router.post("/password/reset")
-async def reset_password(uid: int = Depends(get_current_uid)):
-    """[预留] 执行密码重置"""
-    raise HTTPException(status_code=501, detail="密码重置功能即将上线")
+async def reset_password(
+    body: PasswordResetConfirmRequest,
+    db: AsyncSession = Depends(get_db),
+    _rl: None = Depends(password_reset_rate_limit_dep),
+):
+    """公开接口：用 reset_token 设置新密码。"""
+    vs = VerificationService()
+    try:
+        await vs.consume_token_and_reset_password(
+            db,
+            token=body.reset_token,
+            new_password=body.new_password,
+            sf=await _get_sf(),
+        )
+    except ValueError as e:
+        logger.warning(
+            "[AUTH] reset_password failed reason={} err={}", type(e).__name__, e
+        )
+        raise HTTPException(status_code=400, detail=str(e))
+    return {"message": "密码已重置，请使用新密码登录"}
 
 
 # ── Email ────────────────────────────────────────────────────────
@@ -608,15 +649,55 @@ async def unbind_email(
 
 
 @router.post("/email/send-code")
-async def send_email_code(uid: int = Depends(get_current_uid)):
-    """[预留] 发送邮箱验证码"""
-    raise HTTPException(status_code=501, detail="邮箱验证功能即将上线")
+async def send_email_code(
+    body: EmailSendCodeRequest,
+    uid: int = Depends(get_current_uid),
+    db: AsyncSession = Depends(get_db),
+    _rl: None = Depends(email_send_code_rate_limit_dep),
+):
+    """发送邮箱验证码（登录态）。
+
+    用途：
+      - bind_email: 绑定/换邮箱前验证邮箱所有权
+      - twofa: 敏感操作（如改密码）二次验证
+    """
+    # Per-uid rate limit (inline — dep would need get_current_uid → cycle).
+    await send_code_uid_rate_limit(uid, db)
+
+    vs = VerificationService()
+    try:
+        await vs.send_code(
+            db, uid=uid, target=body.email, purpose=body.purpose,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    return {"message": "验证码已发送"}
 
 
 @router.post("/email/verify")
-async def verify_email(uid: int = Depends(get_current_uid)):
-    """[预留] 验证邮箱并绑定"""
-    raise HTTPException(status_code=501, detail="邮箱验证功能即将上线")
+async def verify_email(
+    body: EmailVerifyRequest,
+    uid: int = Depends(get_current_uid),
+    db: AsyncSession = Depends(get_db),
+    _rl: None = Depends(email_verify_rate_limit_dep),
+):
+    """验证邮箱验证码并完成绑定（purpose=bind_email 时）。
+
+    purpose=twofa 时仅校验，不绑定。
+    """
+    vs = VerificationService()
+    try:
+        await vs.verify_and_bind_email(
+            db,
+            uid=uid,
+            email=body.email,
+            code=body.code,
+            purpose=body.purpose,
+            sf=await _get_sf(),
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    return {"message": "验证成功", "email": body.email, "purpose": body.purpose}
 
 
 # ── Phone ────────────────────────────────────────────────────────

--- a/app/services/auth/rate_limit_deps.py
+++ b/app/services/auth/rate_limit_deps.py
@@ -1,0 +1,200 @@
+"""FastAPI dependency factories for rate-limiting auth endpoints.
+
+Uses the module-level singleton `rate_limit_service`. db is passed
+per-call so each request gets its own AsyncSession.
+
+Usage in router:
+
+    @router.post("/login")
+    async def login_with_password(
+        req: LoginRequest,
+        request: Request,
+        _rl: None = Depends(login_rate_limit_dep),
+    ):
+        ...
+"""
+from __future__ import annotations
+
+from fastapi import Depends, HTTPException, Request, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.database import get_db
+from app.utils.request_meta import get_client_ip
+from app.response import (
+    LoginRequest,
+    PasswordResetRequest,
+)
+from app.services.auth.rate_limit_service import (
+    LoginCooldown,
+    RateLimitExceeded,
+    rate_limit_service,
+)
+
+
+def _retry_after_header(retry_after: int) -> dict[str, str]:
+    return {"Retry-After": str(retry_after)}
+
+
+def _raise_429(retry_after: int, detail: str = "请求过于频繁，请稍后重试") -> None:
+    raise HTTPException(
+        status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+        detail=detail,
+        headers=_retry_after_header(retry_after),
+    )
+
+
+# ── /auth/login ────────────────────────────────────────────────────
+
+
+async def login_rate_limit_dep(
+    request: Request,
+    req: LoginRequest,
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    """Combined per-IP + per-email + DB cooldown check for /auth/login."""
+    ip = get_client_ip(request)
+    try:
+        await rate_limit_service.check_ip(
+            db,
+            endpoint="login",
+            ip=ip,
+            max_count=settings.rl_login_ip_max,
+            window_sec=settings.rl_login_ip_window,
+        )
+        await rate_limit_service.check_target(
+            db,
+            endpoint="login",
+            target=req.email,
+            max_count=settings.rl_login_email_max,
+            window_sec=settings.rl_login_email_window,
+        )
+        await rate_limit_service.check_login_cooldown(db, email=req.email)
+    except RateLimitExceeded as e:
+        _raise_429(e.retry_after)
+    except LoginCooldown as e:
+        _raise_429(e.retry_after, detail="账号已被临时锁定，请稍后重试")
+
+
+# ── /auth/password/reset-request ───────────────────────────────────
+
+
+async def password_reset_request_rate_limit_dep(
+    request: Request,
+    req: PasswordResetRequest,
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    ip = get_client_ip(request)
+    try:
+        await rate_limit_service.check_ip(
+            db,
+            endpoint="pw_reset_req",
+            ip=ip,
+            max_count=settings.rl_reset_request_ip_max,
+            window_sec=settings.rl_reset_request_ip_window,
+        )
+        await rate_limit_service.check_target(
+            db,
+            endpoint="pw_reset_req",
+            target=req.email,
+            max_count=settings.rl_reset_request_email_max,
+            window_sec=settings.rl_reset_request_email_window,
+        )
+    except RateLimitExceeded as e:
+        _raise_429(e.retry_after)
+
+
+# ── /auth/password/reset ───────────────────────────────────────────
+
+
+async def password_reset_rate_limit_dep(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    ip = get_client_ip(request)
+    try:
+        await rate_limit_service.check_ip(
+            db,
+            endpoint="pw_reset",
+            ip=ip,
+            max_count=settings.rl_reset_ip_max,
+            window_sec=settings.rl_reset_ip_window,
+        )
+    except RateLimitExceeded as e:
+        _raise_429(e.retry_after)
+
+
+# ── /auth/email/send-code ──────────────────────────────────────────
+
+
+async def email_send_code_rate_limit_dep(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    """Per-IP limiter for send-code. Per-uid is done by the router inline
+    via `send_code_uid_rate_limit()` (avoids circular import with auth.py)."""
+    ip = get_client_ip(request)
+    try:
+        await rate_limit_service.check_ip(
+            db,
+            endpoint="email_send",
+            ip=ip,
+            max_count=settings.rl_send_code_ip_max,
+            window_sec=settings.rl_send_code_ip_window,
+        )
+    except RateLimitExceeded as e:
+        _raise_429(e.retry_after)
+
+
+async def send_code_uid_rate_limit(uid: int, db: AsyncSession) -> None:
+    """Per-uid limiter for send-code. Called by router inline."""
+    try:
+        await rate_limit_service.check_uid(
+            db,
+            endpoint="email_send",
+            uid=uid,
+            max_count=settings.rl_send_code_uid_max,
+            window_sec=settings.rl_send_code_uid_window,
+        )
+    except RateLimitExceeded as e:
+        _raise_429(e.retry_after)
+
+
+# ── /auth/password (PATCH) ─────────────────────────────────────────
+
+
+async def change_password_rate_limit_dep_inline(uid: int, db: AsyncSession) -> None:
+    """Per-uid limiter for password change. Called by router inline.
+
+    Not a FastAPI Depends (would need get_current_uid → circular import).
+    """
+    try:
+        await rate_limit_service.check_uid(
+            db,
+            endpoint="pw_change",
+            uid=uid,
+            max_count=settings.rl_change_password_uid_max,
+            window_sec=settings.rl_change_password_uid_window,
+        )
+    except RateLimitExceeded as e:
+        _raise_429(e.retry_after)
+
+
+# ── /auth/email/verify ─────────────────────────────────────────────
+
+
+async def email_verify_rate_limit_dep(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    ip = get_client_ip(request)
+    try:
+        await rate_limit_service.check_ip(
+            db,
+            endpoint="email_verify",
+            ip=ip,
+            max_count=settings.rl_email_verify_ip_max,
+            window_sec=settings.rl_email_verify_ip_window,
+        )
+    except RateLimitExceeded as e:
+        _raise_429(e.retry_after)

--- a/app/services/auth/rate_limit_service.py
+++ b/app/services/auth/rate_limit_service.py
@@ -1,0 +1,177 @@
+"""RateLimitService — Redis-backed rate limiting + DB-backed login cooldown.
+
+Design: 模块级饿汉单例。db 按调用传入（每请求独立 session），
+配置在方法内读 settings（支持热更新），不持有任何 per-request 状态。
+
+Responsibilities:
+  - check_ip / check_target / check_uid: Redis 固定窗口限流（Lua INCR）
+  - check_login_cooldown: DB 查询失败计数，超阈值则冷却
+  - record_login_attempt: 持久化登录尝试（成功/失败）
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from loguru import logger
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.infra import redis as redis_mod
+from app.infra.transaction import transactional_scope
+from app.repository.login_attempt_repository import (
+    get_login_attempt_repository,
+)
+
+
+class RateLimitExceeded(Exception):
+    """Raised when a rate-limit budget is exhausted.
+
+    `retry_after` is in seconds (for the Retry-After HTTP header).
+    """
+
+    def __init__(self, *, retry_after: int) -> None:
+        self.retry_after = retry_after
+        super().__init__(f"rate limit exceeded (retry_after={retry_after}s)")
+
+
+class LoginCooldown(Exception):
+    """Raised when an email is in login-cooldown due to repeated failures."""
+
+    def __init__(self, *, email: str, retry_after: int) -> None:
+        self.email = email
+        self.retry_after = retry_after
+        super().__init__(f"login cooldown for {email}")
+
+
+class RateLimitService:
+    """Stateless singleton. db passed per-call, config read per-call."""
+
+    def __init__(self) -> None:
+        self.repo = get_login_attempt_repository()
+
+    # ── Redis fixed-window checks ─────────────────────────────────
+
+    async def _redis_check(
+        self,
+        *,
+        key: str,
+        max_count: int,
+        window_sec: int,
+    ) -> None:
+        """Run Redis INCR-based fixed-window check; raise if over budget."""
+        if not redis_mod.is_enabled():
+            # Fail open — nginx is the first line of defense.
+            logger.debug("[RATELIMIT] redis disabled, allowing key={}", key)
+            return
+        try:
+            allowed = await redis_mod.rate_limit(key, max_count, window_sec)
+        except Exception as e:
+            logger.warning("[RATELIMIT] redis error, fail-open key={} err={}", key, e)
+            return
+        if not allowed:
+            logger.warning(
+                "[RATELIMIT] blocked key={} max={} window={}s",
+                key, max_count, window_sec,
+            )
+            raise RateLimitExceeded(retry_after=window_sec)
+
+    async def check_ip(
+        self,
+        db: AsyncSession,
+        *,
+        endpoint: str,
+        ip: str,
+        max_count: int,
+        window_sec: int,
+    ) -> None:
+        key = f"rl:{endpoint}:ip:{ip}"
+        await self._redis_check(key=key, max_count=max_count, window_sec=window_sec)
+
+    async def check_target(
+        self,
+        db: AsyncSession,
+        *,
+        endpoint: str,
+        target: str,
+        max_count: int,
+        window_sec: int,
+    ) -> None:
+        key = f"rl:{endpoint}:target:{target}"
+        await self._redis_check(key=key, max_count=max_count, window_sec=window_sec)
+
+    async def check_uid(
+        self,
+        db: AsyncSession,
+        *,
+        endpoint: str,
+        uid: int,
+        max_count: int,
+        window_sec: int,
+    ) -> None:
+        key = f"rl:{endpoint}:uid:{uid}"
+        await self._redis_check(key=key, max_count=max_count, window_sec=window_sec)
+
+    # ── Login cooldown (DB-backed) ─────────────────────────────────
+
+    async def check_login_cooldown(
+        self,
+        db: AsyncSession,
+        *,
+        email: str,
+    ) -> None:
+        """Raise LoginCooldown if email has too many recent failures."""
+        cooldown_sec = settings.rl_login_cooldown_seconds
+        threshold = settings.rl_login_cooldown_threshold
+        since = datetime.now(timezone.utc) - timedelta(seconds=cooldown_sec)
+        failures = await self.repo.count_recent_failures_by_email(
+            db, email=email, since=since,
+        )
+        if failures >= threshold:
+            logger.warning(
+                "[RATELIMIT] login cooldown email={} failures={} threshold={}",
+                email, failures, threshold,
+            )
+            raise LoginCooldown(email=email, retry_after=cooldown_sec)
+
+    # ── Attempt recording ──────────────────────────────────────────
+
+    async def record_login_attempt(
+        self,
+        db: AsyncSession,
+        *,
+        uid: Optional[int],
+        email: Optional[str],
+        ip: str,
+        device_id: Optional[str],
+        success: bool,
+        failure_reason: Optional[str] = None,
+    ) -> None:
+        """Persist a login attempt row. Best-effort — errors are logged.
+
+        Owns its own transaction so callers don't need to wrap. The `db`
+        arg is accepted for API symmetry but a fresh tx session is used
+        internally to keep audit logging independent of the caller's tx.
+        """
+        _ = db  # caller session unused — audit writes use own tx
+        try:
+            async with transactional_scope() as tx_db:
+                await self.repo.create(
+                    tx_db,
+                    uid=uid,
+                    email=email,
+                    ip=ip,
+                    device_id=device_id,
+                    success=success,
+                    failure_reason=failure_reason,
+                )
+        except Exception as e:
+            logger.warning(
+                "[RATELIMIT] failed to record login attempt ip={} email={} err={}",
+                ip, email, e,
+            )
+
+
+# 模块级饿汉单例：__init__ 只持有另一个单例引用，无 IO，无运行时配置依赖。
+# db 在每个方法调用时传入，保证请求间 session 隔离。
+rate_limit_service = RateLimitService()

--- a/app/services/auth/user_service.py
+++ b/app/services/auth/user_service.py
@@ -6,6 +6,7 @@ Repository classes. No raw SQL or session.query() calls live here.
 """
 
 from typing import Optional
+import re
 
 from sqlalchemy.ext.asyncio import AsyncSession
 from loguru import logger
@@ -27,6 +28,34 @@ from app.repository.user_token_repository import get_user_token_repository
 from app.repository.rbac_repository import get_rbac_repository, DEFAULT_ROLE
 
 
+# Password strength policy — enforced on set and change.
+_PASSWORD_MIN_LEN = 8
+_PASSWORD_MAX_LEN = 128
+_PASSWORD_LETTER_RE = re.compile(r"[A-Za-z]")
+_PASSWORD_DIGIT_RE = re.compile(r"[0-9]")
+
+
+def _validate_password_strength(password: str) -> None:
+    """Raise ValueError if password fails strength policy.
+
+    Policy: 8-128 chars, must contain both a letter and a digit, no leading/
+    trailing whitespace. Intended to be called inside service methods that
+    already wrap ValueError → HTTPException(400) at the router layer.
+    """
+    if not isinstance(password, str) or not password:
+        raise ValueError("密码不能为空")
+    if password != password.strip():
+        raise ValueError("密码首尾不能包含空白字符")
+    if len(password) < _PASSWORD_MIN_LEN:
+        raise ValueError(f"密码至少 {_PASSWORD_MIN_LEN} 位")
+    if len(password) > _PASSWORD_MAX_LEN:
+        raise ValueError(f"密码不能超过 {_PASSWORD_MAX_LEN} 位")
+    if not _PASSWORD_LETTER_RE.search(password):
+        raise ValueError("密码必须同时包含字母和数字")
+    if not _PASSWORD_DIGIT_RE.search(password):
+        raise ValueError("密码必须同时包含字母和数字")
+
+
 class UserService:
     """User lifecycle service — stateless, repositories injected per-call."""
 
@@ -46,6 +75,7 @@ class UserService:
         device_id: str | None = None,
         ip: str | None = None,
         user_agent: str | None = None,
+        device_meta: dict | None = None,
     ) -> tuple[int, UserToken]:
         """Find or create a user via OAuth binding, then issue a session token.
 
@@ -121,7 +151,9 @@ class UserService:
         )
         # Record device info for device management
         if device_id:
-            await self._record_device(uid=uid, device_id=device_id)
+            await self._record_device(
+                uid=uid, device_id=device_id, device_meta=device_meta
+            )
         return uid, token
 
     # ── Queries ──────────────────────────────────────────────────
@@ -381,6 +413,7 @@ class UserService:
         """Set password for the first time (only if no password exists)."""
         from app.services.auth.security import hash_password as _hash
 
+        _validate_password_strength(password)
         user = await get_user_repository().get_by_uid(uid, self.db)
         if not user:
             raise ValueError("用户不存在")
@@ -403,6 +436,9 @@ class UserService:
             hash_password as _hash,
         )
 
+        _validate_password_strength(new_password)
+        if old_password == new_password:
+            raise ValueError("新密码不能与旧密码相同")
         user = await get_user_repository().get_by_uid(uid, self.db)
         if not user:
             raise ValueError("用户不存在")
@@ -410,6 +446,8 @@ class UserService:
             raise ValueError("未设置密码，请使用密码设置接口")
         if not _verify(old_password, user.password_hash):
             raise ValueError("旧密码不正确")
+        if _verify(new_password, user.password_hash):
+            raise ValueError("新密码不能与旧密码相同")
         await get_user_repository().update(
             uid,
             self.db,
@@ -417,6 +455,32 @@ class UserService:
         )
         await self._invalidate_user_cache(uid)
         logger.info(f"[USER] password changed for uid={uid}")
+
+    async def reset_password(self, uid: int, new_password: str) -> None:
+        """Reset password without old_password verification.
+
+        Caller MUST have verified the reset token before calling this.
+        Used by the forgot-password flow.
+        """
+        from app.services.auth.security import (
+            hash_password as _hash,
+            verify_password as _verify,
+        )
+
+        _validate_password_strength(new_password)
+        user = await get_user_repository().get_by_uid(uid, self.db)
+        if not user:
+            raise ValueError("用户不存在")
+        # If user had a password, refuse to reuse it.
+        if user.password_hash and _verify(new_password, user.password_hash):
+            raise ValueError("新密码不能与旧密码相同")
+        await get_user_repository().update(
+            uid,
+            self.db,
+            password_hash=_hash(new_password),
+        )
+        await self._invalidate_user_cache(uid)
+        logger.info(f"[USER] password reset for uid={uid}")
 
     # ── Email / Phone ─────────────────────────────────────────────
 
@@ -437,6 +501,29 @@ class UserService:
             raise ValueError("该邮箱已被其他账号绑定")
         await self._invalidate_user_cache(uid)
         logger.info(f"[USER] email bound for uid={uid}")
+
+    async def apply_verified_email(self, uid: int, email: str) -> None:
+        """Bind email AND mark email_verified=true.
+
+        Called by the verify-email flow after the user has proven control
+        of the inbox via verification code. Rejects emails already taken
+        by another account.
+        """
+        from sqlalchemy.exc import IntegrityError
+
+        try:
+            user = await get_user_repository().update(
+                uid,
+                self.db,
+                email=email,
+                email_verified=True,
+            )
+            if not user:
+                raise ValueError("用户不存在")
+        except IntegrityError:
+            raise ValueError("该邮箱已被其他账号绑定")
+        await self._invalidate_user_cache(uid)
+        logger.info(f"[USER] email verified for uid={uid}")
 
     async def bind_phone(self, uid: int, phone: str) -> None:
         """Directly bind/change phone (no verification)."""
@@ -581,7 +668,13 @@ class UserService:
 
     # ── Internal helpers ─────────────────────────────────────────
 
-    async def _record_device(self, *, uid: int, device_id: str) -> None:
+    async def _record_device(
+        self,
+        *,
+        uid: int,
+        device_id: str,
+        device_meta: dict | None = None,
+    ) -> None:
         """Ensure a user_device row exists for the given fingerprint.
         Best-effort — failures are logged but never block login.
         """
@@ -589,7 +682,19 @@ class UserService:
             from app.repository.user_device_repository import get_user_device_repository
 
             repo = get_user_device_repository()
-            await repo.upsert(self.db, uid=uid, device_id=device_id, commit=False)
+            meta = device_meta or {}
+            await repo.upsert(
+                self.db,
+                uid=uid,
+                device_id=device_id,
+                device_type=meta.get("device_type"),
+                device_name=meta.get("device_name"),
+                os=meta.get("os"),
+                os_version=meta.get("os_version"),
+                browser=meta.get("browser"),
+                browser_version=meta.get("browser_version"),
+                commit=False,
+            )
         except Exception:
             logger.exception("[USER] failed to record device uid={}", uid)
 

--- a/app/services/auth/verification_service.py
+++ b/app/services/auth/verification_service.py
@@ -1,0 +1,368 @@
+"""VerificationService — orchestrates verification code lifecycle.
+
+Responsibilities:
+  - Generate 6-digit codes (or reset tokens)
+  - Persist via VerificationCodeRepository
+  - Enforce rate limits (per-target cooldown + per-uid window)
+  - Send via EmailService
+  - Verify user-supplied codes (single-use, expiry, brute-force cap)
+  - Orchestrate multi-step auth flows (change password with 2FA, bind email,
+    reset password with token) — owns the transaction boundary for these.
+
+Valid purposes:
+  - bind_email     — bind/change email (requires login)
+  - reset_password — forgot password flow (public)
+  - twofa          — sensitive operation second factor (requires login)
+
+This service does NOT know about HTTP or sessions; it raises ValueError
+on business-rule violations and the router converts to HTTPException.
+
+Transaction boundary: standalone write methods (send_code, send_reset_token)
+own their transaction via transactional_scope(). Composable methods
+(verify_code, consume_code) accept a db and participate in the caller's
+transaction. Multi-service orchestration methods own the transaction and
+instantiate collaborating services (UserService) with the tx session.
+"""
+from __future__ import annotations
+
+import secrets
+import string
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional
+
+from loguru import logger
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.infra.transaction import transactional_scope
+from app.models import VerificationCode
+from app.repository.verification_code_repository import (
+    get_verification_code_repository,
+)
+from app.repository.user_repository import get_user_repository
+from app.services.auth.user_service import UserService
+from app.services.email_service import send_verification_code, EmailServiceError
+
+
+VALID_PURPOSES = {"bind_email", "reset_password", "twofa"}
+
+
+class VerificationService:
+    """Stateless orchestration of email verification codes.
+
+    Methods accept db per-call; no instance session state. Standalone
+    writes own their transaction; composable methods participate in the
+    caller's transaction.
+    """
+
+    def __init__(self) -> None:
+        self.repo = get_verification_code_repository()
+
+    # ── Send (standalone — owns tx) ────────────────────────────────
+
+    async def send_code(
+        self,
+        db: AsyncSession,
+        *,
+        uid: int,
+        target: str,
+        purpose: str,
+    ) -> None:
+        """Generate, persist, and email a verification code.
+
+        Rate limits:
+          - Same target: at most 1 send per `rate_limit_target_seconds` (default 60s)
+          - Same uid: at most `rate_limit_uid_max` sends in
+            `rate_limit_uid_minutes` window (default 5 / 10 min)
+
+        Raises ValueError on rate-limit or email failure.
+        """
+        if purpose not in VALID_PURPOSES:
+            raise ValueError(f"无效的验证用途: {purpose}")
+        if not target:
+            raise ValueError("邮箱不能为空")
+
+        code = _generate_numeric_code(settings.email_code_length)
+        async with transactional_scope() as tx_db:
+            await self._enforce_rate_limits(tx_db, uid, target)
+            # Void any prior unused codes for same target+purpose so only the
+            # latest one is valid.
+            await self.repo.void_recent_unused(
+                tx_db, target=target, purpose=purpose
+            )
+            await self.repo.create(
+                tx_db,
+                uid=uid,
+                target=target,
+                purpose=purpose,
+                code=code,
+                ttl_seconds=settings.email_code_ttl_seconds,
+            )
+
+        # Email send is outside tx — can't roll back, and a sent email with
+        # a persisted code is recoverable (user can retry, rate limit gates).
+        try:
+            await send_verification_code(target, code, purpose)
+        except EmailServiceError as e:
+            logger.warning(
+                "[VERIFY] email send failed uid=%s target=%s purpose=%s err=%s",
+                uid, target, purpose, e,
+            )
+            raise ValueError(str(e)) from e
+
+        logger.info(
+            "[VERIFY] code sent uid=%s target=%s purpose=%s",
+            uid, target, purpose,
+        )
+
+    async def send_reset_token(self, db: AsyncSession, *, target: str) -> None:
+        """Public entry: email a reset token to unverified user.
+
+        Looks up uid by email; raises ValueError if no user has that email.
+        Uses a 32-byte URL-safe token instead of a 6-digit code so it can
+        be embedded in a reset link.
+        """
+        user = await get_user_repository().find_by_email(target, db)
+        if not user:
+            # Don't leak whether the email is registered.
+            raise ValueError("如果该邮箱已注册，您将收到重置邮件")
+
+        token = secrets.token_urlsafe(32)
+        async with transactional_scope() as tx_db:
+            await self._enforce_rate_limits(tx_db, user.uid, target)
+            await self.repo.void_recent_unused(
+                tx_db, target=target, purpose="reset_password"
+            )
+            # Reset tokens live 10 minutes (longer than 6-digit codes).
+            await self.repo.create(
+                tx_db,
+                uid=user.uid,
+                target=target,
+                purpose="reset_password",
+                code=token,
+                ttl_seconds=600,
+            )
+
+        try:
+            await send_verification_code(target, token, "reset_password")
+        except EmailServiceError as e:
+            raise ValueError(str(e)) from e
+
+        logger.info(
+            "[VERIFY] reset token sent uid=%s target=%s",
+            user.uid, target,
+        )
+
+    # ── Verify (composable — participates in caller tx) ────────────
+
+    async def verify_code(
+        self,
+        db: AsyncSession,
+        *,
+        uid: int,
+        target: str,
+        purpose: str,
+        code: str,
+    ) -> int:
+        """Verify a user-supplied code WITHOUT consuming it.
+
+        Returns the verification_code.id on success. Caller MUST call
+        ``consume_code(db, vc_id)`` after the downstream business operation
+        (e.g. password change, email bind) succeeds, so that a failure in
+        the business step leaves the code reusable for retry.
+
+        Raises ValueError on:
+          - no matching code found (expired or never sent)
+          - wrong code (also increments attempt counter)
+          - brute-force cap reached (code auto-voided)
+        """
+        vc = await self.repo.find_latest_unused(
+            db, target=target, purpose=purpose
+        )
+        if vc is None:
+            raise ValueError("验证码已过期或未发送，请重新获取")
+        if vc.uid != uid:
+            # Code was issued to a different uid — treat as invalid.
+            raise ValueError("验证码无效")
+
+        if vc.attempts and vc.attempts >= settings.email_max_verify_attempts:
+            # Cap reached — void the code so it can't be retried.
+            await self.repo.mark_used(db, vc.id)
+            logger.warning(
+                "[VERIFY] brute-force cap reached target={} purpose={}",
+                target, purpose,
+            )
+            raise ValueError("验证码错误次数过多，请重新获取")
+
+        if vc.code != code:
+            attempts = await self.repo.increment_attempts(db, vc.id)
+            logger.info(
+                "[VERIFY] wrong code target={} purpose={} attempts={}",
+                target, purpose, attempts,
+            )
+            raise ValueError("验证码不正确")
+
+        logger.info(
+            "[VERIFY] ok (not yet consumed) uid={} target={} purpose={} vc_id={}",
+            uid, target, purpose, vc.id,
+        )
+        return vc.id
+
+    async def consume_code(self, db: AsyncSession, vc_id: int) -> None:
+        """Mark a verified code as used. Call this only AFTER the downstream
+        business operation (password change, email bind, etc.) succeeds."""
+        await self.repo.mark_used(db, vc_id)
+        logger.info("[VERIFY] consumed vc_id={}", vc_id)
+
+    async def verify_reset_token(
+        self, db: AsyncSession, *, token: str
+    ) -> int:
+        """Verify a reset token, return the uid it was issued to.
+
+        Public entry — caller is responsible for enforcing that the token
+        came from an email link (not user-supplied without proof).
+        """
+        now = datetime.now(timezone.utc)
+        result = await db.execute(
+            select(VerificationCode)
+            .where(
+                VerificationCode.purpose == "reset_password",
+                VerificationCode.code == token,
+                VerificationCode.used.is_(False),
+                VerificationCode.expires_at > now,
+            )
+            .order_by(VerificationCode.created_at.desc())
+            .limit(1)
+        )
+        vc = result.scalar_one_or_none()
+        if vc is None:
+            raise ValueError("重置链接无效或已过期")
+        return vc.uid
+
+    async def consume_reset_token(
+        self, db: AsyncSession, *, token: str
+    ) -> int:
+        """Verify + mark used. Returns uid for the caller to update password."""
+        uid = await self.verify_reset_token(db, token=token)
+        await db.execute(
+            update(VerificationCode)
+            .where(
+                VerificationCode.code == token,
+                VerificationCode.purpose == "reset_password",
+            )
+            .values(used=True)
+        )
+        return uid
+
+    # ── Multi-service orchestration (owns tx) ──────────────────────
+
+    async def verify_and_change_password(
+        self,
+        db: AsyncSession,
+        *,
+        uid: int,
+        old_password: str,
+        new_password: str,
+        email_code: Optional[str],
+        sf: Any,
+    ) -> None:
+        """Change password with optional 2FA verification.
+
+        If the user has a verified email, requires an email_code (2FA).
+        Verifies code → changes password → consumes code, atomically.
+        """
+        async with transactional_scope() as tx_db:
+            user = await get_user_repository().get_by_uid(uid, tx_db)
+            vc_id: Optional[int] = None
+            if user and user.email_verified and user.email:
+                if not email_code:
+                    raise ValueError("修改密码需要邮箱验证码")
+                vc_id = await self.verify_code(
+                    tx_db,
+                    uid=uid,
+                    target=user.email,
+                    purpose="twofa",
+                    code=email_code,
+                )
+            user_service = UserService(tx_db, sf)
+            await user_service.change_password(uid, old_password, new_password)
+            if vc_id is not None:
+                await self.consume_code(tx_db, vc_id)
+
+    async def verify_and_bind_email(
+        self,
+        db: AsyncSession,
+        *,
+        uid: int,
+        email: str,
+        code: str,
+        purpose: str,
+        sf: Any,
+    ) -> None:
+        """Verify email code and bind email (purpose=bind_email), or just
+        verify (purpose=twofa). Atomically verifies → binds → consumes."""
+        async with transactional_scope() as tx_db:
+            vc_id = await self.verify_code(
+                tx_db, uid=uid, target=email, purpose=purpose, code=code,
+            )
+            if purpose == "bind_email":
+                user_service = UserService(tx_db, sf)
+                await user_service.apply_verified_email(uid, email)
+            # Consume the code only after the downstream bind succeeds.
+            await self.consume_code(tx_db, vc_id)
+
+    async def consume_token_and_reset_password(
+        self,
+        db: AsyncSession,
+        *,
+        token: str,
+        new_password: str,
+        sf: Any,
+    ) -> None:
+        """Consume reset token and reset password, atomically."""
+        async with transactional_scope() as tx_db:
+            uid = await self.consume_reset_token(tx_db, token=token)
+            user_service = UserService(tx_db, sf)
+            await user_service.reset_password(uid, new_password)
+
+    # ── Rate limit enforcement ────────────────────────────────────
+
+    async def _enforce_rate_limits(
+        self, db: AsyncSession, uid: int, target: str
+    ) -> None:
+        """Raise ValueError if rate limits would be exceeded."""
+        now = datetime.now(timezone.utc)
+
+        # Per-target cooldown: latest code within N seconds blocks new sends.
+        recent_target_count = await self.repo.count_recent_by_target(
+            db,
+            target=target,
+            since=now - timedelta(seconds=settings.email_rate_limit_target_seconds),
+        )
+        if recent_target_count > 0:
+            raise ValueError(
+                f"请求过于频繁，请 {settings.email_rate_limit_target_seconds} 秒后重试"
+            )
+
+        # Per-uid window: at most N sends in M minutes.
+        recent_uid_count = await self.repo.count_recent_by_uid(
+            db,
+            uid=uid,
+            since=now - timedelta(minutes=settings.email_rate_limit_uid_minutes),
+        )
+        if recent_uid_count >= settings.email_rate_limit_uid_max:
+            raise ValueError(
+                "请求过于频繁，请稍后重试"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _generate_numeric_code(length: int) -> str:
+    """Cryptographically-random numeric code (avoids 0/O ambiguity not needed
+    because it's all digits)."""
+    alphabet = string.digits
+    return "".join(secrets.choice(alphabet) for _ in range(length))

--- a/app/services/email_service.py
+++ b/app/services/email_service.py
@@ -1,0 +1,138 @@
+"""Email service — sends verification codes and password-reset links via Resend.
+
+Resend docs: https://resend.com/docs/api-reference/emails/send-emails
+Free tier: 100 emails/day, 3000/month. For quick testing without domain
+verification, use the shared address "onboarding@resend.dev" as the From.
+
+This module is the only place that knows about Resend. Swap to another
+provider (SMTP, Aliyun DirectMail, etc.) by replacing this file.
+"""
+from __future__ import annotations
+
+import httpx
+from loguru import logger
+
+from app.config import settings
+
+
+RESEND_API_URL = "https://api.resend.com/emails"
+
+
+class EmailServiceError(Exception):
+    """Raised when the email provider rejects the request."""
+
+
+async def send_verification_code(
+    to_email: str, code: str, purpose: str
+) -> None:
+    """Send a 6-digit verification code to the given email.
+
+    Args:
+        to_email: Recipient address.
+        code: The 6-digit code (or reset token for purpose=reset_password).
+        purpose: One of: bind_email | reset_password | twofa.
+    """
+    if not settings.email_enabled:
+        logger.warning(
+            "[EMAIL] disabled (email.enabled=false); skipping send to=%s",
+            to_email,
+        )
+        return
+
+    api_key = settings.email_api_key
+    if not api_key:
+        raise EmailServiceError("邮件服务未配置 API Key")
+
+    subject, body = _render_template(code, purpose)
+
+    payload = {
+        "from": settings.email_from,
+        "to": [to_email],
+        "subject": subject,
+        "html": body,
+    }
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.post(RESEND_API_URL, json=payload, headers=headers)
+    except httpx.HTTPError as e:
+        logger.error("[EMAIL] transport error to=%s err=%s", to_email, e)
+        raise EmailServiceError("邮件发送失败，请稍后重试") from e
+
+    if resp.status_code >= 400:
+        logger.error(
+            "[EMAIL] resend rejected status=%s body=%s",
+            resp.status_code,
+            resp.text,
+        )
+        # Don't leak Resend error body to user; surface a safe message.
+        raise EmailServiceError("邮件发送失败，请稍后重试")
+
+    logger.info("[EMAIL] sent to=%s purpose=%s", to_email, purpose)
+
+
+# ---------------------------------------------------------------------------
+# Templates
+# ---------------------------------------------------------------------------
+
+_PURPOSE_LABEL = {
+    "bind_email": "绑定邮箱",
+    "reset_password": "重置密码",
+    "twofa": "二次验证",
+}
+
+
+def _render_template(code: str, purpose: str) -> tuple[str, str]:
+    """Return (subject, html_body) for the given purpose."""
+    label = _PURPOSE_LABEL.get(purpose, "验证")
+    subject = f"【MindBase】您的{label}验证码"
+
+    if purpose == "reset_password":
+        # `code` is actually a reset token; render a link.
+        link = f"{settings.email_frontend_url}/reset-password?token={code}"
+        body = f"""
+        <div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;
+                    max-width:480px;margin:0 auto;padding:24px;color:#202124;">
+          <h2 style="margin:0 0 16px 0;">重置您的 MindBase 密码</h2>
+          <p style="margin:0 0 12px 0;">点击下方按钮设置新密码，链接 10 分钟内有效：</p>
+          <p style="margin:24px 0;">
+            <a href="{link}"
+               style="display:inline-block;padding:12px 24px;
+                      background:#1a73e8;color:#fff;text-decoration:none;
+                      border-radius:6px;font-weight:500;">
+              重置密码
+            </a>
+          </p>
+          <p style="margin:0 0 8px 0;color:#5f6368;font-size:13px;">
+            如果按钮无法点击，请直接访问以下链接：
+          </p>
+          <p style="margin:0 0 24px 0;word-break:break-all;color:#1a73e8;font-size:13px;">
+            {link}
+          </p>
+          <p style="margin:0;color:#5f6368;font-size:13px;">
+            如果这不是您本人的操作，请忽略此邮件。
+          </p>
+        </div>
+        """
+        return subject, body
+
+    # Numeric verification code for bind_email / twofa
+    body = f"""
+    <div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;
+                max-width:480px;margin:0 auto;padding:24px;color:#202124;">
+      <h2 style="margin:0 0 16px 0;">MindBase {label}</h2>
+      <p style="margin:0 0 12px 0;">您正在进行{label}操作，验证码为：</p>
+      <p style="margin:24px 0;font-size:32px;font-weight:600;
+                letter-spacing:8px;color:#1a73e8;text-align:center;">
+        {code}
+      </p>
+      <p style="margin:0 0 24px 0;color:#5f6368;font-size:13px;">
+        验证码 5 分钟内有效。如非本人操作，请忽略此邮件。
+      </p>
+    </div>
+    """
+    return subject, body

--- a/app/test/security/README.md
+++ b/app/test/security/README.md
@@ -1,0 +1,83 @@
+# Security Tests
+
+Tests for the rate-limiting and login-attempt subsystem under `app/services/auth/`.
+
+## Scope
+
+Three layers are covered, mirroring the production code structure:
+
+| Layer | File | What it verifies |
+|-------|------|------------------|
+| Repository | `test_login_attempt_repository.py` | SQL aggregation: `count_recent_failures_by_ip/email/uid`, `has_recent_success_by_email`, singleton getter |
+| Service | `test_rate_limit_service.py` | Singleton stability, `check_ip/target/uid`, Redis fail-open policy, DB-backed login cooldown, best-effort `record_login_attempt` |
+| Deps (FastAPI integration) | `test_rate_limit_deps.py` | All 6 dep factories + 2 inline helpers translate `RateLimitExceeded` / `LoginCooldown` to HTTP 429 with correct `Retry-After` and detail message |
+
+## Running
+
+```bash
+# From project root
+PYTHONPATH=. python -m pytest app/test/security/ -v
+
+# Single file
+PYTHONPATH=. python -m pytest app/test/security/test_rate_limit_service.py -v
+
+# Single test
+PYTHONPATH=. python -m pytest app/test/security/test_rate_limit_service.py::test_login_cooldown_raises_when_failures_exceed_threshold -v
+```
+
+No external services required — Redis is mocked, SQLite runs in-memory.
+
+## Fixtures (`conftest.py`)
+
+### `security_db` (function-scoped, async)
+Fresh in-memory SQLite (`aiosqlite` + `StaticPool`) with all tables created via `Base.metadata.create_all`. Each test gets an isolated DB; no cross-test leakage.
+
+### Redis mocks
+All Redis-mocking fixtures **also** set `redis.is_enabled() → True`. Without this, the service fail-opens and tests that expect blocking silently pass.
+
+- `mock_redis_enabled` — swaps `redis.client` for an `AsyncMock`
+- `mock_rate_limit_allow` — `rate_limit()` always returns `True`
+- `mock_rate_limit_block` — `rate_limit()` always returns `False`
+- `mock_rate_limit_counting` — real counter dict; returns `True` until `count > max_count`, exposes the dict for key assertions
+
+### `cooldown_settings`
+Replaces the `settings` reference inside `rate_limit_service` module with a `SimpleNamespace` containing all 17 `rl_*` attributes.
+
+**Why swap the whole reference instead of monkeypatching attributes?**
+`_Settings` exposes config via `@property` accessors, which are read-only — `monkeypatch.setattr(settings, "rl_login_cooldown_threshold", 5)` raises `AttributeError: property has no setter`. Swapping the entire module-level `settings` binding is the cleanest workaround.
+
+## Mocking Strategy
+
+| Concern | Approach | Why |
+|--------|----------|-----|
+| Database | Real in-memory SQLite | Verify actual SQL aggregation, not just that the repo was called |
+| Redis | `monkeypatch` on `app.infra.redis` module | Redis is a network dependency; tests must not require it |
+| Settings | `SimpleNamespace` swap | `@property` accessors can't be monkeypatched attribute-by-attribute |
+| Singleton methods | `monkeypatch.setattr(rate_limit_deps.rate_limit_service, "check_ip", AsyncMock())` | Verify the dep layer translates exceptions correctly without coupling to service internals |
+
+## Key Behaviors Verified
+
+### Fail-open policy
+- `check_ip` passes silently when `redis.is_enabled() == False`
+- `check_ip` passes silently when `redis.rate_limit()` raises `ConnectionError`
+- Rationale: rate limiting is a defense layer, not a hard gate — Redis outage must not lock users out
+
+### Login cooldown
+- Triggered when recent failures (within `rl_login_cooldown_seconds`) ≥ `rl_login_cooldown_threshold`
+- Old failures excluded by `since` filter in SQL
+- Successful logins don't inflate the failure counter
+- `LoginCooldown` exception carries `email` + `retry_after`; deps translate to HTTP 429 with `"账号已被临时锁定"` detail
+
+### Best-effort persistence
+- `record_login_attempt` swallows repo errors — audit logging must never break the login flow
+
+### Singleton stability
+- `rate_limit_service is mod.rate_limit_service` holds across imports
+- `rate_limit_service.repo` is a `LoginAttemptRepository` instance
+- No per-request instantiation; `db` passed per-call for `AsyncSession` request isolation
+
+## Coverage Gaps (intentional)
+
+- **Real Redis**: not tested — would require a running instance. Covered by `diagnose_rag.py` smoke test indirectly.
+- **HTTP-level integration**: deps are tested in isolation, not via `TestClient`. FastAPI's `Depends` plumbing is trusted.
+- **Time-based edge cases**: `since` boundary is tested via backdated rows, but timezone arithmetic is assumed correct.

--- a/app/test/security/conftest.py
+++ b/app/test/security/conftest.py
@@ -1,0 +1,120 @@
+"""Local fixtures for security tests (rate limiting, login attempts)."""
+
+import pytest
+import pytest_asyncio
+from unittest.mock import AsyncMock
+
+from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession, async_sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.models import Base
+
+
+@pytest_asyncio.fixture(scope="function")
+async def security_db():
+    """Fresh in-memory SQLite DB for each test, with all tables created."""
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+        echo=False,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    session_factory = async_sessionmaker(
+        engine, class_=AsyncSession, expire_on_commit=False,
+    )
+    async with session_factory() as session:
+        yield session
+    await engine.dispose()
+
+
+@pytest.fixture
+def mock_redis_enabled(monkeypatch):
+    """Make app.infra.redis.is_enabled() return True and rate_limit callable."""
+    from app.infra import redis as redis_mod
+
+    fake_client = AsyncMock()
+    monkeypatch.setattr(redis_mod, "client", fake_client)
+    monkeypatch.setattr(redis_mod, "is_enabled", lambda: True)
+    return fake_client
+
+
+@pytest.fixture
+def mock_rate_limit_allow(monkeypatch):
+    """Patch redis.rate_limit to always allow (return True)."""
+    from app.infra import redis as redis_mod
+    monkeypatch.setattr(redis_mod, "is_enabled", lambda: True)
+
+    async def _allow(key, max_count, window_sec):
+        return True
+
+    monkeypatch.setattr(redis_mod, "rate_limit", _allow)
+
+
+@pytest.fixture
+def mock_rate_limit_block(monkeypatch):
+    """Patch redis.rate_limit to always block (return False)."""
+    from app.infra import redis as redis_mod
+    monkeypatch.setattr(redis_mod, "is_enabled", lambda: True)
+
+    async def _block(key, max_count, window_sec):
+        return False
+
+    monkeypatch.setattr(redis_mod, "rate_limit", _block)
+
+
+@pytest.fixture
+def mock_rate_limit_counting(monkeypatch):
+    """Patch redis.rate_limit with a real counter for testing thresholds.
+
+    Returns a dict tracking call counts per key so tests can simulate
+    "Nth request gets blocked" behavior.
+    """
+    from app.infra import redis as redis_mod
+    monkeypatch.setattr(redis_mod, "is_enabled", lambda: True)
+
+    counts: dict[str, int] = {}
+
+    async def _counting(key, max_count, window_sec):
+        counts[key] = counts.get(key, 0) + 1
+        return counts[key] <= max_count
+
+    monkeypatch.setattr(redis_mod, "rate_limit", _counting)
+    return counts
+
+
+@pytest.fixture
+def cooldown_settings(monkeypatch):
+    """Replace `settings` in rate_limit_service with a mutable namespace.
+
+    _Settings uses @property accessors, which can't be monkeypatched
+    attribute-by-attribute. Swap the whole reference instead.
+    """
+    from types import SimpleNamespace
+    from app.services.auth import rate_limit_service as mod
+
+    fake = SimpleNamespace(
+        rl_login_cooldown_threshold=5,
+        rl_login_cooldown_seconds=900,
+        rl_login_ip_max=10,
+        rl_login_ip_window=60,
+        rl_login_email_max=5,
+        rl_login_email_window=300,
+        rl_reset_request_ip_max=5,
+        rl_reset_request_ip_window=3600,
+        rl_reset_request_email_max=3,
+        rl_reset_request_email_window=3600,
+        rl_reset_ip_max=10,
+        rl_reset_ip_window=3600,
+        rl_send_code_ip_max=10,
+        rl_send_code_ip_window=60,
+        rl_send_code_uid_max=5,
+        rl_send_code_uid_window=600,
+        rl_change_password_uid_max=3,
+        rl_change_password_uid_window=3600,
+        rl_email_verify_ip_max=20,
+        rl_email_verify_ip_window=60,
+    )
+    monkeypatch.setattr(mod, "settings", fake)
+    return fake

--- a/app/test/security/test_login_attempt_repository.py
+++ b/app/test/security/test_login_attempt_repository.py
@@ -1,0 +1,147 @@
+"""Tests for LoginAttemptRepository — DB-backed failure counting + cooldown queries.
+
+Uses an in-memory SQLite DB (security_db fixture) for real SQL verification.
+No mocking — we want to verify the actual SQL queries return correct counts.
+"""
+
+import pytest
+from datetime import datetime, timedelta, timezone
+
+from app.repository.login_attempt_repository import (
+    LoginAttemptRepository,
+    get_login_attempt_repository,
+)
+
+
+@pytest.mark.asyncio
+async def test_create_persists_row(security_db):
+    """A created attempt should be queryable by its attributes."""
+    repo = LoginAttemptRepository()
+    await repo.create(
+        security_db,
+        uid=100,
+        email="alice@example.com",
+        ip="1.2.3.4",
+        device_id="dev-abc",
+        success=False,
+        failure_reason="invalid_credentials",
+    )
+
+    failures = await repo.count_recent_failures_by_email(
+        security_db,
+        email="alice@example.com",
+        since=datetime.now(timezone.utc) - timedelta(minutes=5),
+    )
+    assert failures == 1
+
+
+@pytest.mark.asyncio
+async def test_count_recent_failures_by_ip_includes_only_failures(security_db):
+    """Successful logins from the same IP must not inflate failure count."""
+    repo = LoginAttemptRepository()
+    now = datetime.now(timezone.utc)
+    since = now - timedelta(minutes=5)
+
+    # 2 failures + 1 success from same IP
+    await repo.create(security_db, uid=None, email="a@x.com", ip="1.2.3.4",
+                     device_id="d", success=False, failure_reason="x")
+    await repo.create(security_db, uid=None, email="b@x.com", ip="1.2.3.4",
+                     device_id="d", success=False, failure_reason="x")
+    await repo.create(security_db, uid=1, email="c@x.com", ip="1.2.3.4",
+                     device_id="d", success=True)
+
+    count = await repo.count_recent_failures_by_ip(security_db, ip="1.2.3.4", since=since)
+    assert count == 2
+
+
+@pytest.mark.asyncio
+async def test_count_recent_failures_by_email_excludes_old_records(security_db):
+    """Attempts older than `since` should be excluded from the count."""
+    repo = LoginAttemptRepository()
+    now = datetime.now(timezone.utc)
+
+    # Old failure (10 minutes ago)
+    old = await repo.create(
+        security_db, uid=None, email="a@x.com", ip="1.1.1.1",
+        device_id="d", success=False, failure_reason="x",
+    )
+    # Manually backdate the created_at
+    from app.models import LoginAttempt
+    from sqlalchemy import update
+    await security_db.execute(
+        update(LoginAttempt)
+        .where(LoginAttempt.id == old.id)
+        .values(created_at=now - timedelta(minutes=10))
+    )
+    await security_db.commit()
+
+    # Recent failure (just now)
+    await repo.create(security_db, uid=None, email="a@x.com", ip="1.1.1.1",
+                     device_id="d", success=False, failure_reason="x")
+
+    count = await repo.count_recent_failures_by_email(
+        security_db, email="a@x.com",
+        since=now - timedelta(minutes=5),
+    )
+    assert count == 1
+
+
+@pytest.mark.asyncio
+async def test_count_recent_failures_by_uid(security_db):
+    """Per-uid failure aggregation."""
+    repo = LoginAttemptRepository()
+    now = datetime.now(timezone.utc)
+    since = now - timedelta(minutes=5)
+
+    await repo.create(security_db, uid=42, email="a@x.com", ip="1.1.1.1",
+                     device_id="d", success=False)
+    await repo.create(security_db, uid=42, email="a@x.com", ip="2.2.2.2",
+                     device_id="d", success=False)
+    await repo.create(security_db, uid=42, email="a@x.com", ip="3.3.3.3",
+                     device_id="d", success=True)
+    await repo.create(security_db, uid=99, email="b@x.com", ip="4.4.4.4",
+                     device_id="d", success=False)
+
+    count = await repo.count_recent_failures_by_uid(security_db, uid=42, since=since)
+    assert count == 2  # 2 failures for uid=42, success excluded
+
+
+@pytest.mark.asyncio
+async def test_has_recent_success_by_email(security_db):
+    """Cooldown can be skipped for accounts that recently logged in successfully."""
+    repo = LoginAttemptRepository()
+    now = datetime.now(timezone.utc)
+    since = now - timedelta(minutes=30)
+
+    # No success yet
+    await repo.create(security_db, uid=1, email="a@x.com", ip="1.1.1.1",
+                     device_id="d", success=False)
+    assert await repo.has_recent_success_by_email(
+        security_db, email="a@x.com", since=since,
+    ) is False
+
+    # Add a success
+    await repo.create(security_db, uid=1, email="a@x.com", ip="1.1.1.1",
+                     device_id="d", success=True)
+    assert await repo.has_recent_success_by_email(
+        security_db, email="a@x.com", since=since,
+    ) is True
+
+
+@pytest.mark.asyncio
+async def test_singleton_get_repository_returns_same_instance():
+    """get_login_attempt_repository() must return the same instance each call."""
+    a = get_login_attempt_repository()
+    b = get_login_attempt_repository()
+    assert a is b
+
+
+@pytest.mark.asyncio
+async def test_count_returns_zero_for_empty_table(security_db):
+    """No attempts → zero failures (not None, not error)."""
+    repo = LoginAttemptRepository()
+    since = datetime.now(timezone.utc) - timedelta(minutes=5)
+
+    assert await repo.count_recent_failures_by_ip(security_db, ip="9.9.9.9", since=since) == 0
+    assert await repo.count_recent_failures_by_email(security_db, email="nobody@x.com", since=since) == 0
+    assert await repo.count_recent_failures_by_uid(security_db, uid=999, since=since) == 0

--- a/app/test/security/test_rate_limit_deps.py
+++ b/app/test/security/test_rate_limit_deps.py
@@ -1,0 +1,239 @@
+"""Tests for rate_limit_deps — FastAPI dependency factories.
+
+Each dep wraps rate_limit_service singleton calls and converts
+RateLimitExceeded / LoginCooldown to HTTPException(429) with Retry-After.
+
+We mock the singleton's methods directly to test the translation layer.
+The goal is to verify:
+  1. dep calls the right service method with right args
+  2. exceptions are translated to HTTP 429 with correct Retry-After header
+  3. 429 detail differs for LoginCooldown ("账号已被临时锁定")
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from fastapi import HTTPException
+
+from app.services.auth import rate_limit_deps
+from app.services.auth.rate_limit_service import (
+    LoginCooldown,
+    RateLimitExceeded,
+)
+
+
+def _make_request(ip: str = "1.2.3.4"):
+    """Build a mock Request with the given IP."""
+    req = MagicMock()
+    req.headers.get.return_value = ""
+    req.client = MagicMock(host=ip)
+    return req
+
+
+# ── login_rate_limit_dep ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_login_dep_passes_when_all_checks_pass(monkeypatch):
+    """No exception → dep returns None silently."""
+    monkeypatch.setattr(rate_limit_deps.rate_limit_service, "check_ip", AsyncMock())
+    monkeypatch.setattr(rate_limit_deps.rate_limit_service, "check_target", AsyncMock())
+    monkeypatch.setattr(rate_limit_deps.rate_limit_service, "check_login_cooldown", AsyncMock())
+
+    from app.response import LoginRequest
+    req = LoginRequest(email="alice@example.com", password="secret")
+    await rate_limit_deps.login_rate_limit_dep(_make_request(), req, db=MagicMock())
+
+
+@pytest.mark.asyncio
+async def test_login_dep_raises_429_on_ip_limit(monkeypatch):
+    """IP rate limit exceeded → HTTP 429 with Retry-After."""
+    async def _raise(*args, **kwargs):
+        raise RateLimitExceeded(retry_after=60)
+    monkeypatch.setattr(rate_limit_deps.rate_limit_service, "check_ip", _raise)
+    monkeypatch.setattr(rate_limit_deps.rate_limit_service, "check_target", AsyncMock())
+    monkeypatch.setattr(rate_limit_deps.rate_limit_service, "check_login_cooldown", AsyncMock())
+
+    from app.response import LoginRequest
+    req = LoginRequest(email="alice@example.com", password="secret")
+    with pytest.raises(HTTPException) as exc_info:
+        await rate_limit_deps.login_rate_limit_dep(_make_request(), req, db=MagicMock())
+    assert exc_info.value.status_code == 429
+    assert exc_info.value.headers["Retry-After"] == "60"
+
+
+@pytest.mark.asyncio
+async def test_login_dep_raises_429_on_cooldown(monkeypatch):
+    """LoginCooldown → HTTP 429 with account-locked detail message."""
+    async def _raise(*args, **kwargs):
+        raise LoginCooldown(email="alice@example.com", retry_after=900)
+    monkeypatch.setattr(rate_limit_deps.rate_limit_service, "check_ip", AsyncMock())
+    monkeypatch.setattr(rate_limit_deps.rate_limit_service, "check_target", AsyncMock())
+    monkeypatch.setattr(rate_limit_deps.rate_limit_service, "check_login_cooldown", _raise)
+
+    from app.response import LoginRequest
+    req = LoginRequest(email="alice@example.com", password="secret")
+    with pytest.raises(HTTPException) as exc_info:
+        await rate_limit_deps.login_rate_limit_dep(_make_request(), req, db=MagicMock())
+    assert exc_info.value.status_code == 429
+    assert "锁定" in exc_info.value.detail
+    assert exc_info.value.headers["Retry-After"] == "900"
+
+
+# ── password_reset_request_rate_limit_dep ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_reset_request_dep_passes(monkeypatch):
+    monkeypatch.setattr(rate_limit_deps.rate_limit_service, "check_ip", AsyncMock())
+    monkeypatch.setattr(rate_limit_deps.rate_limit_service, "check_target", AsyncMock())
+
+    from app.response import PasswordResetRequest
+    req = PasswordResetRequest(email="alice@example.com")
+    await rate_limit_deps.password_reset_request_rate_limit_dep(
+        _make_request(), req, db=MagicMock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_reset_request_dep_raises_429(monkeypatch):
+    async def _raise(*args, **kwargs):
+        raise RateLimitExceeded(retry_after=3600)
+    monkeypatch.setattr(rate_limit_deps.rate_limit_service, "check_ip", _raise)
+    monkeypatch.setattr(rate_limit_deps.rate_limit_service, "check_target", AsyncMock())
+
+    from app.response import PasswordResetRequest
+    req = PasswordResetRequest(email="alice@example.com")
+    with pytest.raises(HTTPException) as exc_info:
+        await rate_limit_deps.password_reset_request_rate_limit_dep(
+            _make_request(), req, db=MagicMock(),
+        )
+    assert exc_info.value.status_code == 429
+    assert exc_info.value.headers["Retry-After"] == "3600"
+
+
+# ── password_reset_rate_limit_dep ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_reset_dep_passes(monkeypatch):
+    monkeypatch.setattr(rate_limit_deps.rate_limit_service, "check_ip", AsyncMock())
+    await rate_limit_deps.password_reset_rate_limit_dep(_make_request(), db=MagicMock())
+
+
+@pytest.mark.asyncio
+async def test_reset_dep_raises_429(monkeypatch):
+    async def _raise(*args, **kwargs):
+        raise RateLimitExceeded(retry_after=3600)
+    monkeypatch.setattr(rate_limit_deps.rate_limit_service, "check_ip", _raise)
+    with pytest.raises(HTTPException) as exc_info:
+        await rate_limit_deps.password_reset_rate_limit_dep(_make_request(), db=MagicMock())
+    assert exc_info.value.status_code == 429
+
+
+# ── email_send_code_rate_limit_dep ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_send_code_dep_passes(monkeypatch):
+    monkeypatch.setattr(rate_limit_deps.rate_limit_service, "check_ip", AsyncMock())
+    await rate_limit_deps.email_send_code_rate_limit_dep(_make_request(), db=MagicMock())
+
+
+@pytest.mark.asyncio
+async def test_send_code_dep_raises_429(monkeypatch):
+    async def _raise(*args, **kwargs):
+        raise RateLimitExceeded(retry_after=60)
+    monkeypatch.setattr(rate_limit_deps.rate_limit_service, "check_ip", _raise)
+    with pytest.raises(HTTPException) as exc_info:
+        await rate_limit_deps.email_send_code_rate_limit_dep(_make_request(), db=MagicMock())
+    assert exc_info.value.status_code == 429
+    assert exc_info.value.headers["Retry-After"] == "60"
+
+
+@pytest.mark.asyncio
+async def test_send_code_uid_rate_limit_passes(monkeypatch):
+    monkeypatch.setattr(rate_limit_deps.rate_limit_service, "check_uid", AsyncMock())
+    await rate_limit_deps.send_code_uid_rate_limit(uid=42, db=MagicMock())
+
+
+@pytest.mark.asyncio
+async def test_send_code_uid_rate_limit_raises_429(monkeypatch):
+    async def _raise(*args, **kwargs):
+        raise RateLimitExceeded(retry_after=600)
+    monkeypatch.setattr(rate_limit_deps.rate_limit_service, "check_uid", _raise)
+    with pytest.raises(HTTPException) as exc_info:
+        await rate_limit_deps.send_code_uid_rate_limit(uid=42, db=MagicMock())
+    assert exc_info.value.status_code == 429
+    assert exc_info.value.headers["Retry-After"] == "600"
+
+
+# ── change_password_rate_limit_dep_inline ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_change_password_dep_passes(monkeypatch):
+    monkeypatch.setattr(rate_limit_deps.rate_limit_service, "check_uid", AsyncMock())
+    await rate_limit_deps.change_password_rate_limit_dep_inline(uid=42, db=MagicMock())
+
+
+@pytest.mark.asyncio
+async def test_change_password_dep_raises_429(monkeypatch):
+    async def _raise(*args, **kwargs):
+        raise RateLimitExceeded(retry_after=3600)
+    monkeypatch.setattr(rate_limit_deps.rate_limit_service, "check_uid", _raise)
+    with pytest.raises(HTTPException) as exc_info:
+        await rate_limit_deps.change_password_rate_limit_dep_inline(uid=42, db=MagicMock())
+    assert exc_info.value.status_code == 429
+    assert exc_info.value.headers["Retry-After"] == "3600"
+
+
+# ── email_verify_rate_limit_dep ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_verify_dep_passes(monkeypatch):
+    monkeypatch.setattr(rate_limit_deps.rate_limit_service, "check_ip", AsyncMock())
+    await rate_limit_deps.email_verify_rate_limit_dep(_make_request(), db=MagicMock())
+
+
+@pytest.mark.asyncio
+async def test_verify_dep_raises_429(monkeypatch):
+    async def _raise(*args, **kwargs):
+        raise RateLimitExceeded(retry_after=60)
+    monkeypatch.setattr(rate_limit_deps.rate_limit_service, "check_ip", _raise)
+    with pytest.raises(HTTPException) as exc_info:
+        await rate_limit_deps.email_verify_rate_limit_dep(_make_request(), db=MagicMock())
+    assert exc_info.value.status_code == 429
+    assert exc_info.value.headers["Retry-After"] == "60"
+
+
+# ── Detail message differs for cooldown vs plain rate limit ────────
+
+
+@pytest.mark.asyncio
+async def test_cooldown_detail_differs_from_rate_limit(monkeypatch):
+    """LoginCooldown detail should mention 临时锁定; plain RateLimitExceeded should not."""
+    # Plain rate limit
+    async def _raise_plain(*args, **kwargs):
+        raise RateLimitExceeded(retry_after=60)
+    monkeypatch.setattr(rate_limit_deps.rate_limit_service, "check_ip", _raise_plain)
+    monkeypatch.setattr(rate_limit_deps.rate_limit_service, "check_target", AsyncMock())
+    monkeypatch.setattr(rate_limit_deps.rate_limit_service, "check_login_cooldown", AsyncMock())
+
+    from app.response import LoginRequest
+    req = LoginRequest(email="a@x.com", password="x")
+    with pytest.raises(HTTPException) as exc_info:
+        await rate_limit_deps.login_rate_limit_dep(_make_request(), req, db=MagicMock())
+    plain_detail = exc_info.value.detail
+    assert "锁定" not in plain_detail
+
+    # Cooldown
+    async def _raise_cooldown(*args, **kwargs):
+        raise LoginCooldown(email="a@x.com", retry_after=900)
+    monkeypatch.setattr(rate_limit_deps.rate_limit_service, "check_ip", AsyncMock())
+    monkeypatch.setattr(rate_limit_deps.rate_limit_service, "check_login_cooldown", _raise_cooldown)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await rate_limit_deps.login_rate_limit_dep(_make_request(), req, db=MagicMock())
+    assert "锁定" in exc_info.value.detail

--- a/app/test/security/test_rate_limit_service.py
+++ b/app/test/security/test_rate_limit_service.py
@@ -1,0 +1,277 @@
+"""Tests for RateLimitService — Redis-backed limiting + DB-backed cooldown.
+
+The singleton service is stateless aside from its repo reference, so each
+test patches redis.rate_limit / redis.is_enabled to simulate states.
+
+We use a real in-memory SQLite DB (security_db) for cooldown checks to
+verify the SQL aggregation actually works end-to-end.
+"""
+
+import pytest
+from datetime import datetime, timedelta, timezone
+
+from app.services.auth.rate_limit_service import (
+    LoginCooldown,
+    RateLimitExceeded,
+    RateLimitService,
+    rate_limit_service,
+)
+
+
+# ── Singleton semantics ─────────────────────────────────────────────
+
+
+def test_module_level_singleton_is_stable():
+    """The module-level instance should be the same across imports."""
+    from app.services.auth import rate_limit_service as mod
+
+    assert rate_limit_service is mod.rate_limit_service
+    assert isinstance(rate_limit_service, RateLimitService)
+
+
+def test_singleton_holds_repository():
+    """The singleton should hold a LoginAttemptRepository instance."""
+    from app.repository.login_attempt_repository import LoginAttemptRepository
+
+    assert isinstance(rate_limit_service.repo, LoginAttemptRepository)
+
+
+# ── check_ip / check_target / check_uid ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_check_ip_allows_when_redis_permits(security_db, mock_rate_limit_allow):
+    """When redis.rate_limit returns True, check_ip should return None."""
+    await rate_limit_service.check_ip(
+        security_db, endpoint="login", ip="1.2.3.4",
+        max_count=10, window_sec=60,
+    )
+
+
+@pytest.mark.asyncio
+async def test_check_ip_raises_when_redis_blocks(security_db, mock_rate_limit_block):
+    """When redis.rate_limit returns False, check_ip should raise RateLimitExceeded."""
+    with pytest.raises(RateLimitExceeded) as exc_info:
+        await rate_limit_service.check_ip(
+            security_db, endpoint="login", ip="1.2.3.4",
+            max_count=10, window_sec=60,
+        )
+    assert exc_info.value.retry_after == 60
+
+
+@pytest.mark.asyncio
+async def test_check_ip_fail_open_when_redis_disabled(security_db, monkeypatch):
+    """When redis.is_enabled() returns False, check should pass silently."""
+    from app.infra import redis as redis_mod
+    monkeypatch.setattr(redis_mod, "is_enabled", lambda: False)
+    # redis_mod.rate_limit would raise if called — test that it's NOT called.
+    with pytest.raises(RuntimeError, match="not initialized"):
+        await redis_mod.rate_limit("k", 1, 1)
+
+    # But check_ip should NOT raise
+    await rate_limit_service.check_ip(
+        security_db, endpoint="login", ip="1.2.3.4",
+        max_count=10, window_sec=60,
+    )
+
+
+@pytest.mark.asyncio
+async def test_check_ip_fail_open_on_redis_exception(security_db, monkeypatch):
+    """When redis.rate_limit raises, check should pass (fail-open policy)."""
+    from app.infra import redis as redis_mod
+    monkeypatch.setattr(redis_mod, "is_enabled", lambda: True)
+
+    async def _boom(key, max_count, window_sec):
+        raise ConnectionError("redis down")
+
+    monkeypatch.setattr(redis_mod, "rate_limit", _boom)
+
+    # Should NOT raise — fail-open per design
+    await rate_limit_service.check_ip(
+        security_db, endpoint="login", ip="1.2.3.4",
+        max_count=10, window_sec=60,
+    )
+
+
+@pytest.mark.asyncio
+async def test_check_target_uses_target_in_key(security_db, mock_rate_limit_counting):
+    """Verify that check_target passes the target in the Redis key."""
+    counts = mock_rate_limit_counting
+    await rate_limit_service.check_target(
+        security_db, endpoint="login", target="alice@example.com",
+        max_count=5, window_sec=300,
+    )
+    assert "alice@example.com" in list(counts.keys())[0]
+    assert "target" in list(counts.keys())[0]
+
+
+@pytest.mark.asyncio
+async def test_check_uid_uses_uid_in_key(security_db, mock_rate_limit_counting):
+    """Verify that check_uid passes the uid in the Redis key."""
+    counts = mock_rate_limit_counting
+    await rate_limit_service.check_uid(
+        security_db, endpoint="email_send", uid=42,
+        max_count=5, window_sec=600,
+    )
+    key = list(counts.keys())[0]
+    assert "42" in key
+    assert "uid" in key
+
+
+# ── check_login_cooldown ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_login_cooldown_raises_when_failures_exceed_threshold(security_db, cooldown_settings):
+    """5 failures within cooldown window should trigger LoginCooldown."""
+    # Insert 5 failed attempts
+    from app.models import LoginAttempt
+    now = datetime.now(timezone.utc)
+    for _ in range(5):
+        security_db.add(LoginAttempt(
+            uid=None, email="alice@example.com", ip="1.2.3.4",
+            device_id="d", success=False, failure_reason="x", created_at=now,
+        ))
+    await security_db.commit()
+
+    with pytest.raises(LoginCooldown) as exc_info:
+        await rate_limit_service.check_login_cooldown(security_db, email="alice@example.com")
+    assert exc_info.value.email == "alice@example.com"
+    assert exc_info.value.retry_after == 900
+
+
+@pytest.mark.asyncio
+async def test_login_cooldown_passes_when_failures_below_threshold(security_db, cooldown_settings):
+    """4 failures (below threshold of 5) should not trigger cooldown."""
+    from app.models import LoginAttempt
+    now = datetime.now(timezone.utc)
+    for _ in range(4):
+        security_db.add(LoginAttempt(
+            uid=None, email="alice@example.com", ip="1.2.3.4",
+            device_id="d", success=False, failure_reason="x", created_at=now,
+        ))
+    await security_db.commit()
+
+    # Should NOT raise
+    await rate_limit_service.check_login_cooldown(security_db, email="alice@example.com")
+
+
+@pytest.mark.asyncio
+async def test_login_cooldown_ignores_old_failures(security_db, cooldown_settings):
+    """Failures older than cooldown_seconds should not count."""
+    cooldown_settings.rl_login_cooldown_threshold = 3
+    cooldown_settings.rl_login_cooldown_seconds = 300
+
+    from app.models import LoginAttempt
+    now = datetime.now(timezone.utc)
+    # 10 old failures (1 hour ago, outside 5-min window)
+    old_time = now - timedelta(hours=1)
+    for _ in range(10):
+        security_db.add(LoginAttempt(
+            uid=None, email="alice@example.com", ip="1.2.3.4",
+            device_id="d", success=False, failure_reason="x", created_at=old_time,
+        ))
+    await security_db.commit()
+
+    # Should NOT raise — old failures excluded
+    await rate_limit_service.check_login_cooldown(security_db, email="alice@example.com")
+
+
+@pytest.mark.asyncio
+async def test_login_cooldown_ignores_successful_attempts(security_db, cooldown_settings):
+    """Successful logins should not inflate the failure counter."""
+    cooldown_settings.rl_login_cooldown_threshold = 3
+
+    from app.models import LoginAttempt
+    now = datetime.now(timezone.utc)
+    # 2 failures + 5 successes
+    for _ in range(2):
+        security_db.add(LoginAttempt(
+            uid=1, email="alice@example.com", ip="1.2.3.4",
+            device_id="d", success=False, created_at=now,
+        ))
+    for _ in range(5):
+        security_db.add(LoginAttempt(
+            uid=1, email="alice@example.com", ip="1.2.3.4",
+            device_id="d", success=True, created_at=now,
+        ))
+    await security_db.commit()
+
+    # 2 failures < threshold 3 — should NOT raise
+    await rate_limit_service.check_login_cooldown(security_db, email="alice@example.com")
+
+
+# ── record_login_attempt ───────────────────────────────────────────
+#
+# record_login_attempt owns its tx via transactional_scope() (audit
+# independence — must persist even if caller's tx rolls back). Tests
+# monkeypatch transactional_scope to yield the in-memory security_db
+# so writes are visible to subsequent assertions on the same session.
+
+
+def _patch_scope_to_security_db(monkeypatch, security_db):
+    """Redirect transactional_scope in rate_limit_service to yield security_db."""
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager
+    async def _fake_scope(**kwargs):
+        yield security_db
+
+    monkeypatch.setattr(
+        "app.services.auth.rate_limit_service.transactional_scope", _fake_scope
+    )
+
+
+@pytest.mark.asyncio
+async def test_record_login_attempt_success_persists(security_db, monkeypatch):
+    """Successful login should be persisted with success=True."""
+    _patch_scope_to_security_db(monkeypatch, security_db)
+    await rate_limit_service.record_login_attempt(
+        security_db,
+        uid=42, email="alice@example.com", ip="1.2.3.4",
+        device_id="d", success=True,
+    )
+    # Verify via repo
+    from app.repository.login_attempt_repository import LoginAttemptRepository
+    repo = LoginAttemptRepository()
+    count = await repo.count_recent_failures_by_email(
+        security_db, email="alice@example.com",
+        since=datetime.now(timezone.utc) - timedelta(minutes=1),
+    )
+    assert count == 0  # success doesn't count as failure
+
+
+@pytest.mark.asyncio
+async def test_record_login_attempt_failure_with_reason(security_db, monkeypatch):
+    """Failed login with reason should be queryable as a failure."""
+    _patch_scope_to_security_db(monkeypatch, security_db)
+    await rate_limit_service.record_login_attempt(
+        security_db,
+        uid=None, email="alice@example.com", ip="1.2.3.4",
+        device_id="d", success=False, failure_reason="invalid_credentials",
+    )
+    from app.repository.login_attempt_repository import LoginAttemptRepository
+    repo = LoginAttemptRepository()
+    count = await repo.count_recent_failures_by_email(
+        security_db, email="alice@example.com",
+        since=datetime.now(timezone.utc) - timedelta(minutes=1),
+    )
+    assert count == 1
+
+
+@pytest.mark.asyncio
+async def test_record_login_attempt_swallows_repo_errors(security_db, monkeypatch):
+    """record_login_attempt should be best-effort: repo errors must not propagate."""
+    _patch_scope_to_security_db(monkeypatch, security_db)
+    # Force repo.create to raise
+    async def _boom(*args, **kwargs):
+        raise RuntimeError("DB down")
+
+    monkeypatch.setattr(rate_limit_service.repo, "create", _boom)
+
+    # Should NOT raise
+    await rate_limit_service.record_login_attempt(
+        security_db,
+        uid=1, email="x@x.com", ip="1.1.1.1",
+        device_id="d", success=True,
+    )

--- a/app/utils/request_meta.py
+++ b/app/utils/request_meta.py
@@ -1,0 +1,99 @@
+"""Request metadata helpers — shared between routers and middleware.
+
+Extracted from app/routers/auth.py to avoid circular imports between
+the router and rate-limit deps.
+"""
+from __future__ import annotations
+
+import hashlib
+from typing import Any, Optional
+
+from fastapi import Request
+from ua_parser import parse as _parse_ua
+
+
+def get_device_id(request: Request) -> str:
+    """Derive a stable anonymous device fingerprint from request headers."""
+    ua = request.headers.get("user-agent", "")
+    accept_lang = request.headers.get("accept-language", "")
+    raw = f"{ua}|{accept_lang}"
+    return hashlib.sha256(raw.encode()).hexdigest()[:16]
+
+
+_GENERIC_DEVICE_FAMILIES = {"Other", "Spider", "Desktop", ""}
+
+
+def extract_device_meta(request: Request) -> dict[str, Any]:
+    """Parse User-Agent into structured device metadata for user_device table."""
+    ua = request.headers.get("user-agent", "")
+    if not ua:
+        return {
+            "device_type": None,
+            "device_name": None,
+            "os": None,
+            "os_version": None,
+            "browser": None,
+            "browser_version": None,
+        }
+
+    parsed = _parse_ua(ua)
+    os_family = parsed.os.family if parsed.os else None
+    os_major = parsed.os.major if parsed.os else None
+    os_minor = parsed.os.minor if parsed.os else None
+    os_version = (
+        f"{os_major}.{os_minor}" if os_major and os_minor else os_major
+    )
+
+    ua_family = parsed.user_agent.family if parsed.user_agent else None
+    ua_major = parsed.user_agent.major if parsed.user_agent else None
+    ua_minor = parsed.user_agent.minor if parsed.user_agent else None
+    browser_version = (
+        f"{ua_major}.{ua_minor}" if ua_major and ua_minor else ua_major
+    )
+
+    device_family = parsed.device.family if parsed.device else None
+
+    device_type: Optional[str] = None
+    if device_family and "iPhone" in device_family:
+        device_type = "mobile"
+    elif device_family and "iPad" in device_family:
+        device_type = "tablet"
+    elif device_family and "Android" in device_family:
+        device_type = "mobile"
+    elif device_family and "Mobile" in device_family:
+        device_type = "mobile"
+    elif device_family and "Tablet" in device_family:
+        device_type = "tablet"
+
+    if device_type is None:
+        ua_lower = ua.lower()
+        if "mobile" in ua_lower or "android" in ua_lower:
+            device_type = "mobile"
+        elif "ipad" in ua_lower:
+            device_type = "tablet"
+        else:
+            device_type = "desktop"
+
+    device_name: Optional[str] = None
+    if device_family and device_family not in _GENERIC_DEVICE_FAMILIES:
+        device_name = device_family
+
+    return {
+        "device_type": device_type,
+        "device_name": device_name,
+        "os": os_family,
+        "os_version": os_version,
+        "browser": ua_family,
+        "browser_version": browser_version,
+    }
+
+
+def get_client_ip(request: Request) -> str:
+    """Extract real client IP, respecting reverse-proxy headers."""
+    forwarded = request.headers.get("x-forwarded-for")
+    if forwarded:
+        return forwarded.split(",")[0].strip()
+    real_ip = request.headers.get("x-real-ip")
+    if real_ip:
+        return real_ip.strip()
+    return request.client.host if request.client else "unknown"

--- a/frontend/app/forgot-password/page.tsx
+++ b/frontend/app/forgot-password/page.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useState } from "react";
+import { userApi } from "@/lib/api";
+
+export default function ForgotPasswordPage() {
+  const [email, setEmail] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [done, setDone] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!email.trim()) {
+      setError("请输入邮箱");
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      await userApi.requestPasswordReset({ email: email.trim() });
+      setDone(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "请求失败，请稍后重试");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-[#f8fafd] flex items-center justify-center px-4">
+      <div className="w-full max-w-md bg-white rounded-[20px] shadow-[0_12px_36px_rgba(60,64,67,0.18)] p-8">
+        <div className="mb-6 flex items-center gap-3">
+          <div className="h-11 w-11 rounded-full bg-[#e8f0fe] text-[#1a73e8] flex items-center justify-center font-medium text-lg">
+            M
+          </div>
+          <div>
+            <p className="text-xs font-medium tracking-[0.16em] text-[#1a73e8]">MINDBASE</p>
+            <h1 className="text-[22px] font-normal text-[#202124]">重置密码</h1>
+          </div>
+        </div>
+
+        {done ? (
+          <div className="space-y-4">
+            <p className="text-[14px] leading-6 text-[#3c4043]">
+              如果该邮箱已注册，您将收到一封包含重置链接的邮件。请在 10 分钟内完成重置。
+            </p>
+            <p className="text-[13px] text-[#5f6368]">
+              没收到？请检查垃圾邮件箱，或{" "}
+              <button
+                onClick={() => setDone(false)}
+                className="text-[#1a73e8] hover:underline font-medium"
+              >
+                重新输入邮箱
+              </button>
+            </p>
+            <button
+              onClick={() => (window.location.href = "/")}
+              className="w-full h-11 rounded-full bg-[#1a73e8] text-white font-medium text-[14px] hover:bg-[#1765cc] transition-colors"
+            >
+              返回首页
+            </button>
+          </div>
+        ) : (
+          <form onSubmit={onSubmit} className="space-y-4">
+            <p className="text-[14px] leading-6 text-[#3c4043]">
+              输入您的账号邮箱，我们会向您发送一封密码重置邮件。
+            </p>
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="your@email.com"
+              required
+              className="w-full h-[48px] rounded border border-[#dadce0] bg-white px-4 text-base text-[#202124] outline-none focus:border-2 focus:border-[#1a73e8] transition-colors"
+            />
+            {error && (
+              <div className="text-[13px] text-[#d93025] bg-[#fce8e6] rounded px-3 py-2">
+                {error}
+              </div>
+            )}
+            <button
+              type="submit"
+              disabled={submitting}
+              className="w-full h-11 rounded-full bg-[#1a73e8] text-white font-medium text-[14px] hover:bg-[#1765cc] transition-colors disabled:opacity-60"
+            >
+              {submitting ? "发送中…" : "发送重置邮件"}
+            </button>
+            <button
+              type="button"
+              onClick={() => (window.location.href = "/")}
+              className="w-full text-[13px] text-[#5f6368] hover:underline"
+            >
+              返回首页
+            </button>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/reset-password/page.tsx
+++ b/frontend/app/reset-password/page.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useState, useEffect, Suspense } from "react";
+import { useSearchParams } from "next/navigation";
+import { userApi } from "@/lib/api";
+
+function ResetPasswordInner() {
+  const searchParams = useSearchParams();
+  const token = searchParams.get("token") ?? "";
+
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [showPw, setShowPw] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [done, setDone] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!token) setError("重置链接无效：缺少 token");
+  }, [token]);
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    if (!token) {
+      setError("重置链接无效");
+      return;
+    }
+    if (newPassword.length < 8) {
+      setError("密码至少 8 位");
+      return;
+    }
+    if (!/[A-Za-z]/.test(newPassword) || !/[0-9]/.test(newPassword)) {
+      setError("密码必须同时包含字母和数字");
+      return;
+    }
+    if (newPassword !== confirmPassword) {
+      setError("两次输入的密码不一致");
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      await userApi.confirmPasswordReset({
+        reset_token: token,
+        new_password: newPassword,
+      });
+      setDone(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "重置失败，请重新申请");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-[#f8fafd] flex items-center justify-center px-4">
+      <div className="w-full max-w-md bg-white rounded-[20px] shadow-[0_12px_36px_rgba(60,64,67,0.18)] p-8">
+        <div className="mb-6 flex items-center gap-3">
+          <div className="h-11 w-11 rounded-full bg-[#e8f0fe] text-[#1a73e8] flex items-center justify-center font-medium text-lg">
+            M
+          </div>
+          <div>
+            <p className="text-xs font-medium tracking-[0.16em] text-[#1a73e8]">MINDBASE</p>
+            <h1 className="text-[22px] font-normal text-[#202124]">设置新密码</h1>
+          </div>
+        </div>
+
+        {done ? (
+          <div className="space-y-4">
+            <p className="text-[14px] leading-6 text-[#3c4043]">
+              密码已重置成功，请使用新密码登录。
+            </p>
+            <button
+              onClick={() => (window.location.href = "/")}
+              className="w-full h-11 rounded-full bg-[#1a73e8] text-white font-medium text-[14px] hover:bg-[#1765cc] transition-colors"
+            >
+              返回首页登录
+            </button>
+          </div>
+        ) : (
+          <form onSubmit={onSubmit} className="space-y-4">
+            <p className="text-[13px] text-[#5f6368]">
+              请输入新密码（8 位以上，同时包含字母和数字）。
+            </p>
+            <input
+              type={showPw ? "text" : "password"}
+              value={newPassword}
+              onChange={(e) => setNewPassword(e.target.value)}
+              placeholder="新密码"
+              required
+              className="w-full h-[48px] rounded border border-[#dadce0] bg-white px-4 text-base text-[#202124] outline-none focus:border-2 focus:border-[#1a73e8] transition-colors"
+            />
+            <input
+              type={showPw ? "text" : "password"}
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              placeholder="再次输入新密码"
+              required
+              className="w-full h-[48px] rounded border border-[#dadce0] bg-white px-4 text-base text-[#202124] outline-none focus:border-2 focus:border-[#1a73e8] transition-colors"
+            />
+            <label className="flex items-center gap-2 text-[13px] text-[#3c4043] cursor-pointer">
+              <input
+                type="checkbox"
+                checked={showPw}
+                onChange={(e) => setShowPw(e.target.checked)}
+              />
+              显示密码
+            </label>
+            {error && (
+              <div className="text-[13px] text-[#d93025] bg-[#fce8e6] rounded px-3 py-2">
+                {error}
+              </div>
+            )}
+            <button
+              type="submit"
+              disabled={submitting || !token}
+              className="w-full h-11 rounded-full bg-[#1a73e8] text-white font-medium text-[14px] hover:bg-[#1765cc] transition-colors disabled:opacity-60"
+            >
+              {submitting ? "提交中…" : "重置密码"}
+            </button>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function ResetPasswordPage() {
+  return (
+    <Suspense fallback={<div className="min-h-screen bg-[#f8fafd]" />}>
+      <ResetPasswordInner />
+    </Suspense>
+  );
+}

--- a/frontend/components/PasswordLoginModal.tsx
+++ b/frontend/components/PasswordLoginModal.tsx
@@ -204,6 +204,19 @@ export default function PasswordLoginModal({ isOpen, onClose, onSuccess, onSwitc
                 还没有密码？请先使用 B 站扫码登录，在账户安全中绑定邮箱并设置密码。
               </p>
 
+              <div className="flex justify-end">
+                <button
+                  type="button"
+                  onClick={() => {
+                    onClose();
+                    window.location.href = "/forgot-password";
+                  }}
+                  className="text-[13px] font-medium text-[#1a73e8] hover:underline"
+                >
+                  忘记密码？
+                </button>
+              </div>
+
               <div className="flex flex-col-reverse items-stretch gap-3 pt-8 sm:flex-row sm:items-center sm:justify-between sm:gap-6">
                 <Button
                   type="button"

--- a/frontend/components/dock-modules/account.tsx
+++ b/frontend/components/dock-modules/account.tsx
@@ -47,14 +47,24 @@ export default function AccountPanel({ isOpen }: DockPanelProps) {
   const [editPhone, setEditPhone] = useState(false);
   const [editPassword, setEditPassword] = useState(false);
   const [emailVal, setEmailVal] = useState("");
+  const [emailCode, setEmailCode] = useState("");
+  const [emailSending, setEmailSending] = useState(false);
+  const [emailCooldown, setEmailCooldown] = useState(0);
   const [phoneVal, setPhoneVal] = useState("");
   const [oldPw, setOldPw] = useState("");
   const [newPw, setNewPw] = useState("");
+  const [pwEmailCode, setPwEmailCode] = useState("");
+  const [pwEmailSending, setPwEmailSending] = useState(false);
+  const [pwEmailCooldown, setPwEmailCooldown] = useState(0);
   const [showPw, setShowPw] = useState(false);
+  const [pwError, setPwError] = useState<string | null>(null);
+  const [emailError, setEmailError] = useState<string | null>(null);
 
   const flash = (message: string, type: "success" | "error") => {
     setToast({ message, type });
-    setTimeout(() => setToast(null), 3200);
+    // Errors need more time to read; success is fleeting.
+    const duration = type === "error" ? 6000 : 3200;
+    setTimeout(() => setToast(null), duration);
   };
 
   const load = useCallback(async () => {
@@ -67,6 +77,47 @@ export default function AccountPanel({ isOpen }: DockPanelProps) {
   }, []);
 
   useEffect(() => { if (isOpen) load(); }, [isOpen, load]);
+
+  // Cooldown tick for "resend code" buttons (1s resolution).
+  useEffect(() => {
+    if (emailCooldown <= 0 && pwEmailCooldown <= 0) return;
+    const t = setInterval(() => {
+      setEmailCooldown(v => Math.max(0, v - 1));
+      setPwEmailCooldown(v => Math.max(0, v - 1));
+    }, 1000);
+    return () => clearInterval(t);
+  }, [emailCooldown, pwEmailCooldown]);
+
+  // ── email verification (bind/ change) ──
+
+  const sendEmailCode = async () => {
+    if (!emailVal.trim() || emailCooldown > 0) return;
+    setEmailSending(true);
+    try {
+      await userApi.sendEmailCode({ email: emailVal.trim(), purpose: "bind_email" });
+      setEmailCooldown(60);
+      flash("验证码已发送，请查收邮件", "success");
+    } catch (e) {
+      flash(e instanceof Error ? e.message : "发送失败", "error");
+    } finally {
+      setEmailSending(false);
+    }
+  };
+
+  const sendPwEmailCode = async () => {
+    if (!profile?.email || pwEmailCooldown > 0) return;
+    setPwEmailSending(true);
+    try {
+      await userApi.sendEmailCode({ email: profile.email, purpose: "twofa" });
+      setPwEmailCooldown(60);
+      flash("验证码已发送至邮箱", "success");
+    } catch (e) {
+      console.error("[Account] sendPwEmailCode failed:", e);
+      flash(e instanceof Error ? e.message : "发送失败", "error");
+    } finally {
+      setPwEmailSending(false);
+    }
+  };
 
   // ── profile ──
 
@@ -98,9 +149,28 @@ export default function AccountPanel({ isOpen }: DockPanelProps) {
   // ── email ──
 
   const saveEmail = async () => {
-    if (!emailVal.trim()) return;
-    try { await userApi.bindEmail({ email: emailVal.trim() }); setEditEmail(false); flash("邮箱已绑定", "success"); load(); }
-    catch (e) { flash(e instanceof Error ? e.message : "绑定失败", "error"); }
+    if (!emailVal.trim() || !emailCode.trim()) {
+      setEmailError("请填写邮箱和验证码");
+      return;
+    }
+    setEmailError(null);
+    try {
+      await userApi.verifyEmail({
+        email: emailVal.trim(),
+        code: emailCode.trim(),
+        purpose: "bind_email",
+      });
+      setEditEmail(false);
+      setEmailCode("");
+      setEmailCooldown(0);
+      flash("邮箱已验证并绑定", "success");
+      load();
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : "验证失败";
+      console.error("[Account] saveEmail failed:", e);
+      setEmailError(msg);
+      flash(msg, "error");
+    }
   };
 
   const unbindEmail = async () => {
@@ -130,18 +200,40 @@ export default function AccountPanel({ isOpen }: DockPanelProps) {
   };
 
   const savePassword = async () => {
+    setPwError(null);
     try {
       if (security?.has_password) {
-        if (!oldPw || !newPw) return;
-        await userApi.changePassword({ old_password: oldPw, new_password: newPw });
+        if (!oldPw || !newPw) {
+          setPwError("请填写当前密码和新密码");
+          return;
+        }
+        // If email is verified, 2FA code is required by backend.
+        const needs2FA = !!profile?.email_verified && !!profile?.email;
+        if (needs2FA && !pwEmailCode.trim()) {
+          setPwError("请先获取并输入邮箱验证码");
+          return;
+        }
+        await userApi.changePassword({
+          old_password: oldPw,
+          new_password: newPw,
+          email_code: needs2FA ? pwEmailCode.trim() : undefined,
+        });
       } else {
-        if (!newPw) return;
+        if (!newPw) {
+          setPwError("请输入新密码");
+          return;
+        }
         await userApi.setPassword({ password: newPw });
       }
-      setEditPassword(false); setOldPw(""); setNewPw("");
+      setEditPassword(false); setOldPw(""); setNewPw(""); setPwEmailCode(""); setPwEmailCooldown(0); setPwError(null);
       flash(security?.has_password ? "密码已修改" : "密码已设置", "success");
       load();
-    } catch (e) { flash(e instanceof Error ? e.message : "操作失败", "error"); }
+    } catch (e) {
+      console.error("[Account] savePassword failed:", e);
+      const msg = e instanceof Error ? e.message : "操作失败";
+      setPwError(msg);
+      flash(msg, "error");
+    }
   };
 
   if (!isOpen) return null;
@@ -276,10 +368,24 @@ export default function AccountPanel({ isOpen }: DockPanelProps) {
           </div>
           {editEmail ? (
             <div className="ac-edit-area">
-              <InlineField value={emailVal} onChange={setEmailVal} placeholder="your@email.com" />
+              <InlineField value={emailVal} onChange={(v) => { setEmailVal(v); setEmailError(null); }} placeholder="your@email.com" />
+              <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+                <InlineField value={emailCode} onChange={setEmailCode} placeholder="6 位验证码" />
+                <button
+                  className="ac-ghost-btn"
+                  onClick={sendEmailCode}
+                  disabled={emailSending || emailCooldown > 0 || !emailVal.trim()}
+                  style={{ whiteSpace: "nowrap" }}
+                >
+                  {emailCooldown > 0 ? `${emailCooldown}s` : emailSending ? "发送中…" : "发送验证码"}
+                </button>
+              </div>
+              {emailError && (
+                <div style={{ color: "#dc2626", fontSize: 12, marginTop: 4 }}>{emailError}</div>
+              )}
               <div className="ac-edit-actions">
-                <button className="ac-btn secondary" onClick={() => setEditEmail(false)}>取消</button>
-                <button className="ac-btn primary" onClick={saveEmail}><Check size={14} /> 保存</button>
+                <button className="ac-btn secondary" onClick={() => { setEditEmail(false); setEmailCode(""); setEmailCooldown(0); setEmailError(null); }}>取消</button>
+                <button className="ac-btn primary" onClick={saveEmail}><Check size={14} /> 验证并绑定</button>
               </div>
             </div>
           ) : (
@@ -339,15 +445,38 @@ export default function AccountPanel({ isOpen }: DockPanelProps) {
           {editPassword ? (
             <div className="ac-edit-area">
               {security.has_password && (
-                <InlineField value={oldPw} onChange={setOldPw} placeholder="当前密码" type={showPw ? "text" : "password"} />
+                <InlineField value={oldPw} onChange={(v) => { setOldPw(v); setPwError(null); }} placeholder="当前密码" type={showPw ? "text" : "password"} />
               )}
-              <InlineField value={newPw} onChange={setNewPw} placeholder="新密码" type={showPw ? "text" : "password"} />
+              <InlineField value={newPw} onChange={(v) => { setNewPw(v); setPwError(null); }} placeholder="新密码（8 位以上，含字母和数字）" type={showPw ? "text" : "password"} />
+              {security.has_password && profile?.email_verified && profile?.email && (
+                <>
+                  <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+                    <InlineField value={pwEmailCode} onChange={(v) => { setPwEmailCode(v); setPwError(null); }} placeholder="邮箱验证码（二次验证）" />
+                    <button
+                      className="ac-ghost-btn"
+                      onClick={sendPwEmailCode}
+                      disabled={pwEmailSending || pwEmailCooldown > 0}
+                      style={{ whiteSpace: "nowrap" }}
+                    >
+                      {pwEmailCooldown > 0 ? `${pwEmailCooldown}s` : pwEmailSending ? "发送中…" : "发送验证码"}
+                    </button>
+                  </div>
+                  <div style={{ fontSize: 12, color: "#5f6368" }}>
+                    验证码将发送至 {profile.email}
+                  </div>
+                </>
+              )}
+              {pwError && (
+                <div style={{ color: "#dc2626", fontSize: 12, marginTop: 4, padding: "6px 10px", background: "rgba(220,38,38,0.06)", borderRadius: 6, border: "1px solid rgba(220,38,38,0.12)" }}>
+                  {pwError}
+                </div>
+              )}
               <div className="ac-edit-actions">
                 <button className="ac-ghost-btn" onClick={() => setShowPw(p => !p)}>
                   {showPw ? <EyeOff size={14} /> : <Eye size={14} />} {showPw ? "隐藏" : "显示"}
                 </button>
                 <div style={{ flex: 1 }} />
-                <button className="ac-btn secondary" onClick={() => setEditPassword(false)}>取消</button>
+                <button className="ac-btn secondary" onClick={() => { setEditPassword(false); setOldPw(""); setNewPw(""); setPwEmailCode(""); setPwEmailCooldown(0); setPwError(null); }}>取消</button>
                 <button className="ac-btn primary" onClick={savePassword}><Check size={14} /> 保存</button>
               </div>
             </div>

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1071,6 +1071,7 @@ export interface QuizSetData {
     quiz_uuid: string;
     title: string;
     status: string;
+    error_message?: string | null;
     question_count: number;
     type_distribution?: Record<string, number>;
     difficulty: string;
@@ -1109,6 +1110,7 @@ export interface QuizHistoryItem {
     quiz_uuid: string;
     title: string;
     status?: string;
+    error_message?: string | null;
     question_count?: number;
     difficulty?: string;
     source_type?: string;
@@ -1207,7 +1209,7 @@ export const quizApi = {
         const body = params.pages?.length ? JSON.stringify(params.pages) : undefined;
         return request<QuizGenerateResponse>(`/quiz/generate?${sp.toString()}`, {
             method: "POST",
-            headers: { ...getAuthHeaders(), ...(body ? { "Content-Type": "application/json" } : {}) as Record<string,string> },
+            headers: { ...getAuthHeaders(), ...(body ? { "Content-Type": "application/json" } : {}) },
             ...(body ? { body } : {}),
         });
     },
@@ -1341,10 +1343,31 @@ export interface PasswordSetParams {
 export interface PasswordChangeParams {
     old_password: string;
     new_password: string;
+    email_code?: string;
 }
 
 export interface EmailBindParams {
     email: string;
+}
+
+export interface EmailSendCodeParams {
+    email: string;
+    purpose: "bind_email" | "twofa";
+}
+
+export interface EmailVerifyParams {
+    email: string;
+    code: string;
+    purpose: "bind_email" | "twofa";
+}
+
+export interface PasswordResetRequestParams {
+    email: string;
+}
+
+export interface PasswordResetConfirmParams {
+    reset_token: string;
+    new_password: string;
 }
 
 export interface PhoneBindParams {
@@ -1380,6 +1403,32 @@ export const userApi = {
         request<{ message: string; email: string }>("/auth/email", {
             method: "PUT",
             headers: getAuthHeaders(),
+            body: JSON.stringify(data),
+        }),
+
+    sendEmailCode: (data: EmailSendCodeParams) =>
+        request<{ message: string }>("/auth/email/send-code", {
+            method: "POST",
+            headers: getAuthHeaders(),
+            body: JSON.stringify(data),
+        }),
+
+    verifyEmail: (data: EmailVerifyParams) =>
+        request<{ message: string; email: string; purpose: string }>("/auth/email/verify", {
+            method: "POST",
+            headers: getAuthHeaders(),
+            body: JSON.stringify(data),
+        }),
+
+    requestPasswordReset: (data: PasswordResetRequestParams) =>
+        request<{ message: string }>("/auth/password/reset-request", {
+            method: "POST",
+            body: JSON.stringify(data),
+        }),
+
+    confirmPasswordReset: (data: PasswordResetConfirmParams) =>
+        request<{ message: string }>("/auth/password/reset", {
+            method: "POST",
             body: JSON.stringify(data),
         }),
 

--- a/frontend/lib/error-utils.ts
+++ b/frontend/lib/error-utils.ts
@@ -3,6 +3,10 @@
  *
  * NEVER expose raw backend error messages to the user — they may contain
  * stack traces, SQL queries, file paths, or other internal details.
+ *
+ * Exception: short, business-level detail strings (e.g. "密码至少 8 位")
+ * raised via ValueError at the router layer are intended for end users and
+ * are passed through after a safety check.
  */
 
 const STATUS_MESSAGES: Record<number, string> = {
@@ -32,6 +36,32 @@ const NETWORK_PATTERNS = [
   "net::ERR_",
 ];
 
+// Tech markers that indicate a raw backend leak (stack trace, SQL, etc.).
+// If any of these appear in detail, treat as unsafe and fall back to status message.
+const UNSAFE_DETAIL_MARKERS = [
+  "traceback",
+  "Error:",
+  "Exception",
+  "sqlalchemy",
+  "SQL",
+  "psycopg",
+  "asyncpg",
+  "IntegrityError",
+  "KeyError",
+  "AttributeError",
+  "TypeError",
+  "ValueError:",  // raw ValueError repr, not our user-facing message
+  "File \"",
+  "line ",
+  ".py:",
+  "\\",
+  "/",
+  "<",
+  ">",
+];
+
+const SAFE_DETAIL_MAX_LEN = 80;
+
 function isNetworkError(message: string): boolean {
   return NETWORK_PATTERNS.some((p) => message.includes(p));
 }
@@ -46,6 +76,18 @@ function isTimeoutError(message: string): boolean {
   );
 }
 
+/**
+ * A detail string is safe to show only if it is short and contains no
+ * technical markers. Our router-layer ValueError messages (e.g.
+ * "密码至少 8 位", "新密码不能与旧密码相同") pass; raw exception reprs,
+ * SQL fragments, or file paths do not.
+ */
+function isSafeDetail(detail: string): boolean {
+  if (!detail || detail.length > SAFE_DETAIL_MAX_LEN) return false;
+  const lower = detail.toLowerCase();
+  return !UNSAFE_DETAIL_MARKERS.some((m) => lower.includes(m.toLowerCase()));
+}
+
 export function sanitizeError(err: unknown): string {
   if (!err) return "操作失败，请重试";
 
@@ -58,9 +100,10 @@ export function sanitizeError(err: unknown): string {
     return err;
   }
 
-  // Extract status and message from error-like objects
+  // Extract status, message, and detail from error-like objects
   let status: number | undefined;
   let message = "";
+  let detail = "";
 
   if (err instanceof Error) {
     message = err.message;
@@ -71,7 +114,14 @@ export function sanitizeError(err: unknown): string {
     const obj = err as Record<string, unknown>;
     if (typeof obj.status === "number") status = obj.status;
     if (typeof obj.message === "string") message = obj.message;
-    if (typeof obj.detail === "string") message = obj.detail;
+    if (typeof obj.detail === "string") detail = obj.detail;
+  }
+
+  // Prefer explicit detail when it is a safe business-level message.
+  // This must run BEFORE the status-code fallback so that "密码至少 8 位"
+  // is shown instead of the generic "请求参数有误".
+  if (detail && isSafeDetail(detail)) {
+    return detail;
   }
 
   // 4xx with a backend-provided detail: trust it — these are user-facing

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,6 +47,9 @@ loguru==0.7.2
 # Password hashing
 bcrypt>=4.0
 
+# User-Agent parsing — device fingerprint metadata extraction
+ua-parser>=1.0
+
 # System dependency (install separately or via apt)
 # ffmpeg — installed in Dockerfile
 


### PR DESCRIPTION
- routers/auth.py: password login flow with device fingerprinting, email verification (send-code/verify), password reset (request + confirm), change password; removed dead inline _get_device_id/ _get_client_ip/_is_trusted_proxy (now imported from request_meta)
- services/auth/verification_service.py: 6-digit code generation, TTL, per-target/uid rate limiting, max verify attempts
- services/auth/rate_limit_service.py + rate_limit_deps.py: per-IP and per-uid sliding window limits via Redis (fail-open on outage), login cooldown after N failures
- services/email_service.py: Resend integration for verification + password reset emails
- repository/login_attempt_repository.py + verification_code_repository.py: audit + brute-force tracking
- models.py / database.py: LoginAttempt table, VerificationCode widened (code VARCHAR(64), attempts INTEGER), migration for MODIFY COLUMN + ADD COLUMN
- config/default.yaml + settings.py: security.rate_limit + email sections; per-endpoint windows (login / reset / send_code / verify)
- middleware/rate_limit.py: shared limiter wiring
- utils/request_meta.py: get_client_ip / get_device_id / extract_device_meta (ua-parser based) — extracted to avoid circular imports between router and rate-limit deps
- frontend: forgot-password + reset-password pages, PasswordLoginModal extensions, account dock with email bind/change-password flows, api.ts + error-utils.ts helpers
- requirements.txt: ua-parser for device fingerprint metadata
- tests: 38 security tests covering rate-limit service/deps and login_attempt repository