### PR TITLE
fix(nginx): make proxy_cache actually work

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -132,8 +132,10 @@ http {
 
         proxy_connect_timeout   75s;
         proxy_read_timeout      300s;  # SSE / streaming
-        proxy_buffering         off;   # disable buffering for SSE
-        proxy_cache             off;
+        # proxy_buffering / proxy_cache are NOT set at server level —
+        # each location sets its own. Cacheable locations enable
+        # proxy_buffering on; streaming locations (/chat, /minio-proxy/)
+        # set proxy_buffering off explicitly.
 
         client_max_body_size    50m;
 
@@ -162,21 +164,21 @@ http {
         # Favorites — read-heavy, short cache to avoid repeated B站 API calls
         location /favorites {
             limit_req zone=api burst=5 nodelay;
+            proxy_buffering on;
             proxy_cache api_cache;
-            proxy_cache_key "$scheme$request_method$host$request_uri$cookie_bili_session";
+            proxy_cache_key "$scheme$request_method$host$request_uri";
             proxy_cache_valid 200 30s;
-            proxy_cache_valid 404 1s;
-            proxy_cache_bypass $http_cache_control;
+            proxy_cache_valid 404 10s;
             add_header X-Cache-Status $upstream_cache_status;
             proxy_pass http://backend;
         }
 
         # Knowledge — read-heavy folder/video status
         location /knowledge {
+            proxy_buffering on;
             proxy_cache api_cache;
-            proxy_cache_key "$scheme$request_method$host$request_uri$cookie_bili_session";
+            proxy_cache_key "$scheme$request_method$host$request_uri";
             proxy_cache_valid 200 10s;
-            proxy_cache_bypass $http_cache_control;
             add_header X-Cache-Status $upstream_cache_status;
             proxy_pass http://backend;
         }
@@ -199,10 +201,10 @@ http {
 
         # Billing — read-only, medium cache
         location /billing {
+            proxy_buffering on;
             proxy_cache api_cache;
-            proxy_cache_key "$scheme$request_method$host$request_uri$cookie_bili_session";
+            proxy_cache_key "$scheme$request_method$host$request_uri";
             proxy_cache_valid 200 60s;
-            proxy_cache_bypass $http_cache_control;
             add_header X-Cache-Status $upstream_cache_status;
             proxy_pass http://backend;
         }
@@ -212,6 +214,7 @@ http {
         # would otherwise hit the /quiz block (which has no cache).
         location /quiz/shared/ {
             limit_req zone=api burst=5 nodelay;
+            proxy_buffering on;
             proxy_cache api_cache;
             proxy_cache_key "$host$request_uri";
             proxy_cache_valid 200 60s;
@@ -228,6 +231,7 @@ http {
 
         # Health / docs / OpenAPI — cacheable
         location /health {
+            proxy_buffering on;
             proxy_cache api_cache;
             proxy_cache_key "$host$request_uri";
             proxy_cache_valid 200 5s;
@@ -236,6 +240,7 @@ http {
         }
         location /docs        { proxy_pass http://backend; }
         location /openapi.json {
+            proxy_buffering on;
             proxy_cache api_cache;
             proxy_cache_key "$host$request_uri";
             proxy_cache_valid 200 1h;
@@ -297,11 +302,12 @@ http {
             # Bypass cache for write methods
             set $ws_bypass 0;
             if ($request_method != GET) { set $ws_bypass 1; }
+            proxy_buffering on;
             proxy_cache api_cache;
-            proxy_cache_key "$scheme$request_method$host$request_uri$cookie_bili_session";
+            proxy_cache_key "$scheme$request_method$host$request_uri";
             proxy_cache_valid 200 15s;
-            proxy_cache_valid 404 1s;
-            proxy_cache_bypass $http_cache_control $ws_bypass;
+            proxy_cache_valid 404 10s;
+            proxy_cache_bypass $ws_bypass;
             proxy_no_cache $ws_bypass;
             add_header X-Cache-Status $upstream_cache_status;
             proxy_pass http://backend;
@@ -333,13 +339,13 @@ http {
             proxy_pass          http://frontend;
             proxy_set_header    Upgrade           $http_upgrade;
             proxy_set_header    Connection        "upgrade";
+            proxy_buffering     on;
             proxy_cache         pages_cache;
             proxy_cache_key     "$host$request_uri";
             proxy_cache_valid   200 5m;
             proxy_cache_valid   404 1m;
-            # Bypass cache for authenticated users (pages differ by login state)
-            proxy_cache_bypass   $cookie_bili_session;
-            proxy_no_cache       $cookie_bili_session;
+            # Auth state lives in localStorage (client-side), so SSR HTML
+            # is login-agnostic and safe to cache uniformly.
             # Don't cache WebSocket upgrade
             proxy_cache_bypass   $http_upgrade;
             add_header           X-Cache-Status $upstream_cache_status;


### PR DESCRIPTION
Root cause: server-level `proxy_buffering off` (set for SSE) was inherited by all cacheable locations. nginx requires proxy_buffering on to write responses to cache files, so /favorites /knowledge /billing /quiz/shared/ /workspaces /health /openapi.json X-Cache-Status was always MISS.

- remove server-level proxy_buffering off / proxy_cache off
- add explicit `proxy_buffering on` to 7 API cache locations + / (frontend SSR); /chat and /minio-proxy/ keep proxy_buffering off
- drop $cookie_bili_session from cache keys — this cookie does not exist (frontend uses localStorage, backend uses session_id query param already in $request_uri), so it was dead noise
- drop proxy_cache_bypass $http_cache_control — clients could send Cache-Control: no-cache to punch through the cache and hammer the backend; /workspaces now bypasses only on non-GET ($ws_bypass)
- /favorites /workspaces 404 TTL 1s -> 10s (1s was pointless)
- location /: drop dead $cookie_bili_session bypass/no_cache, add proxy_buffering on, document that SSR HTML is login-agnostic