### PR TITLE
fix(docker): switch ffmpeg source to BtbN GitHub releases (GH Actions 415)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,16 +13,21 @@ RUN sed -i 's/deb.debian.org/mirrors.aliyun.com/g' /etc/apt/sources.list.d/debia
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-# Static ffmpeg + ffprobe (~160MB, self-contained codecs) replace apt ffmpeg
-# (~451MB layer). johnvansickle static build bundles all codecs — compatible
-# with Bilibili aac/m4s audio used in the ASR pipeline (asr.py, content_fetcher.py).
-RUN curl -fsSL --retry 5 --retry-delay 3 --connect-timeout 30 \
-        https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz \
+# Static ffmpeg + ffprobe (~126MB, self-contained codecs) replace apt ffmpeg
+# (~451MB layer). GPL build bundles all codecs — compatible with Bilibili
+# aac/m4s audio used in the ASR pipeline (asr.py, content_fetcher.py).
+#
+# Source: BtbN/FFmpeg-Builds GitHub releases (GPL, linux64 = amd64). Hosted on
+# GitHub's own CDN so it is reliable in GitHub Actions. The previous
+# johnvansickle.com host started returning HTTP 415 to GH Actions datacenter
+# IPs; curl --retry does not retry 4xx, so --retry-all-errors is added.
+RUN curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 --connect-timeout 30 \
+        https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-gpl.tar.xz \
         -o /tmp/ffmpeg.tar.xz \
     && tar -xf /tmp/ffmpeg.tar.xz -C /tmp/ \
-    && cp /tmp/ffmpeg-*-amd64-static/ffmpeg /tmp/ffmpeg-*-amd64-static/ffprobe /usr/local/bin/ \
+    && cp /tmp/ffmpeg-*/bin/ffmpeg /tmp/ffmpeg-*/bin/ffprobe /usr/local/bin/ \
     && chmod +x /usr/local/bin/ffmpeg /usr/local/bin/ffprobe \
-    && rm -rf /tmp/ffmpeg.tar.xz /tmp/ffmpeg-*-amd64-static \
+    && rm -rf /tmp/ffmpeg.tar.xz /tmp/ffmpeg-* \
     && ffmpeg -version | head -1
 
 WORKDIR /app


### PR DESCRIPTION
## Problem

GitHub Actions Docker build failed at the ffmpeg download step:

```
#9 [3/9] RUN curl ... https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz ...
#9 0.341 curl: (22) The requested URL returned error: 415
ERROR: ... exit code: 22
```

## Root cause

`johnvansickle.com` (Apache) started returning **HTTP 415** to GitHub Actions datacenter IPs. Verified the URL itself is healthy - it returns 200 to residential IPs, so the 415 is IP-based blocking, not a dead URL or header issue.

Worse, `curl --retry 5` **does not retry 4xx** by default (only timeouts / 5xx / 429), so the 5 retries never helped.

## Fix

Switch the static-ffmpeg source to **BtbN/FFmpeg-Builds** (GPL, linux64), hosted on GitHub's own CDN (`github.com/.../releases/download/...` -> `release-assets.githubusercontent.com`). Same network as GitHub Actions, so no datacenter-IP blocking.

Also add `--retry-all-errors` for transient-error robustness.

### Why BtbN
- GitHub-hosted = reliable in GitHub Actions
- GPL build bundles all codecs (aac/m4s for the Bilibili ASR pipeline preserved)
- Well-maintained, current ffmpeg
- ~126MB static binaries (still much smaller than apt ffmpeg's ~451MB)

## Changes

```diff
- https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz
+ https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-gpl.tar.xz
```
- Added `--retry-all-errors` to the curl flags
- Updated copy glob: `ffmpeg-*-amd64-static/ffmpeg` -> `ffmpeg-*/bin/ffmpeg` (BtbN archive layout)
- Updated `rm` glob accordingly

## Verification

- [x] BtbN URL returns 200 (HEAD, via GitHub release-assets CDN)
- [x] Archive structure confirmed: `ffmpeg-master-latest-linux64-gpl/bin/{ffmpeg,ffprobe}`
- [x] glob `ffmpeg-*/bin/ffmpeg` matches the extracted path
- [x] `rm -rf /tmp/ffmpeg.tar.xz /tmp/ffmpeg-*` removes both tarball and extracted dir (glob `ffmpeg-*` does not match `ffmpeg.tar.xz`)
- [ ] CI build passes (this PR)

## Notes

- `linux64` = amd64 only (matches the previous johnvansickle amd64-static; not a regression)
- `latest` tag is mutable (same as johnvansickle's `release` pointer); can pin to a specific `n7.1` build later if reproducibility is needed
