### PR TITLE
feat(auth): per-email rate limit fix + frontend AuthProvider

### DIFF
--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -46,6 +46,7 @@ from app.services.auth.rate_limit_deps import (
     email_verify_rate_limit_dep,
     login_rate_limit_dep,
     password_reset_rate_limit_dep,
+    password_reset_request_email_rate_limit,
     password_reset_request_rate_limit_dep,
     send_code_uid_rate_limit,
 )
@@ -584,6 +585,7 @@ async def reset_password_request(
 
     即便邮箱未注册也返回相同成功信息（不泄漏账号是否存在）。
     """
+    await password_reset_request_email_rate_limit(body.email, db)
     vs = VerificationService()
     try:
         await vs.send_reset_token(db, target=body.email)

--- a/app/services/auth/rate_limit_deps.py
+++ b/app/services/auth/rate_limit_deps.py
@@ -23,7 +23,6 @@ from app.database import get_db
 from app.utils.request_meta import get_client_ip
 from app.response import (
     LoginRequest,
-    PasswordResetRequest,
 )
 from app.services.auth.rate_limit_service import (
     LoginCooldown,
@@ -81,9 +80,16 @@ async def login_rate_limit_dep(
 
 async def password_reset_request_rate_limit_dep(
     request: Request,
-    req: PasswordResetRequest,
     db: AsyncSession = Depends(get_db),
 ) -> None:
+    """Per-IP limiter for reset-request. Per-email is done by the router
+    inline via ``password_reset_request_email_rate_limit()``.
+
+    Do NOT declare the request body (e.g. ``req: PasswordResetRequest``)
+    here: a bare Pydantic-model param is treated as a second body field,
+    colliding with the route's ``body`` and making FastAPI wrap the body
+    into ``{req, body}`` (HTTP 422 for callers sending ``{email}``).
+    """
     ip = get_client_ip(request)
     try:
         await rate_limit_service.check_ip(
@@ -93,10 +99,21 @@ async def password_reset_request_rate_limit_dep(
             max_count=settings.rl_reset_request_ip_max,
             window_sec=settings.rl_reset_request_ip_window,
         )
+    except RateLimitExceeded as e:
+        _raise_429(e.retry_after)
+
+
+async def password_reset_request_email_rate_limit(
+    email: str, db: AsyncSession
+) -> None:
+    """Per-email limiter for reset-request. Called by the router inline
+    (mirrors ``send_code_uid_rate_limit`` / ``change_password_rate_limit_dep_inline``).
+    """
+    try:
         await rate_limit_service.check_target(
             db,
             endpoint="pw_reset_req",
-            target=req.email,
+            target=email,
             max_count=settings.rl_reset_request_email_max,
             window_sec=settings.rl_reset_request_email_window,
         )

--- a/frontend/app/forgot-password/page.tsx
+++ b/frontend/app/forgot-password/page.tsx
@@ -1,9 +1,15 @@
 "use client";
 
-import { useState } from "react";
+import { useId, useState } from "react";
+import Link from "next/link";
+import { motion } from "framer-motion";
 import { userApi } from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import { GoogleInput } from "@/components/ui/google-input";
+import { AuthLayout, itemVariants, Spinner, AlertIcon, SuccessCard } from "@/components/auth/auth-ui";
 
 export default function ForgotPasswordPage() {
+  const emailId = useId();
   const [email, setEmail] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [done, setDone] = useState(false);
@@ -11,14 +17,19 @@ export default function ForgotPasswordPage() {
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!email.trim()) {
-      setError("请输入邮箱");
+    setError(null);
+    const trimmed = email.trim();
+    if (!trimmed) {
+      setError("请输入邮箱地址");
+      return;
+    }
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmed)) {
+      setError("请输入有效的邮箱地址");
       return;
     }
     setSubmitting(true);
-    setError(null);
     try {
-      await userApi.requestPasswordReset({ email: email.trim() });
+      await userApi.requestPasswordReset({ email: trimmed });
       setDone(true);
     } catch (err) {
       setError(err instanceof Error ? err.message : "请求失败，请稍后重试");
@@ -28,74 +39,111 @@ export default function ForgotPasswordPage() {
   };
 
   return (
-    <div className="min-h-screen bg-[#f8fafd] flex items-center justify-center px-4">
-      <div className="w-full max-w-md bg-white rounded-[20px] shadow-[0_12px_36px_rgba(60,64,67,0.18)] p-8">
-        <div className="mb-6 flex items-center gap-3">
-          <div className="h-11 w-11 rounded-full bg-[#e8f0fe] text-[#1a73e8] flex items-center justify-center font-medium text-lg">
-            M
-          </div>
-          <div>
-            <p className="text-xs font-medium tracking-[0.16em] text-[#1a73e8]">MINDBASE</p>
-            <h1 className="text-[22px] font-normal text-[#202124]">重置密码</h1>
-          </div>
-        </div>
+    <AuthLayout
+      brand={
+        <>
+          <motion.div variants={itemVariants} className="relative z-10 flex items-center gap-3">
+            <div className="flex h-11 w-11 items-center justify-center rounded-full bg-[var(--gemini-user-bubble)] text-[var(--gemini-primary)] shadow-[inset_0_0_0_1px_color-mix(in_srgb,var(--gemini-primary)_12%,transparent)]">
+              <span className="text-lg font-medium">M</span>
+            </div>
+            <p className="text-xs font-medium tracking-[0.18em] text-[var(--gemini-primary)]">MINDBASE</p>
+          </motion.div>
 
-        {done ? (
-          <div className="space-y-4">
-            <p className="text-[14px] leading-6 text-[#3c4043]">
-              如果该邮箱已注册，您将收到一封包含重置链接的邮件。请在 10 分钟内完成重置。
+          <motion.div variants={itemVariants} className="relative z-10 my-10 md:my-0">
+            <h1 className="max-w-[320px] text-[28px] font-normal leading-[1.18] tracking-[-0.5px] text-[var(--gemini-text-primary)] md:text-[34px]">
+              找回你的账号访问
+            </h1>
+            <p className="mt-4 max-w-[360px] text-[14px] leading-[1.65] text-[var(--gemini-text-secondary)]">
+              输入注册邮箱，我们会发送一封密码重置邮件。链接在 10 分钟内有效，请尽快完成重置。
             </p>
-            <p className="text-[13px] text-[#5f6368]">
-              没收到？请检查垃圾邮件箱，或{" "}
-              <button
-                onClick={() => setDone(false)}
-                className="text-[#1a73e8] hover:underline font-medium"
-              >
-                重新输入邮箱
-              </button>
-            </p>
-            <button
-              onClick={() => (window.location.href = "/")}
-              className="w-full h-11 rounded-full bg-[#1a73e8] text-white font-medium text-[14px] hover:bg-[#1765cc] transition-colors"
-            >
-              返回首页
+          </motion.div>
+
+          <motion.p variants={itemVariants} className="relative z-10 hidden text-[13px] text-[var(--gemini-text-tertiary)] md:block">
+            还没有账号？先扫码登录，再在账户安全中绑定邮箱并设置密码。
+          </motion.p>
+        </>
+      }
+    >
+      {done ? (
+        <SuccessCard
+          title="检查你的邮箱"
+          desc={
+            <>
+              如果 <span className="font-medium text-[var(--gemini-text-primary)]">{email}</span> 已注册，你将收到一封包含重置链接的邮件。
+            </>
+          }
+        >
+          <p className="mt-2 text-[13px] text-[var(--gemini-text-tertiary)]">
+            没收到？检查垃圾邮件箱，或
+            <button type="button" onClick={() => setDone(false)} className="ml-1 font-medium text-[var(--gemini-primary)] hover:underline">
+              重新输入邮箱
             </button>
-          </div>
-        ) : (
-          <form onSubmit={onSubmit} className="space-y-4">
-            <p className="text-[14px] leading-6 text-[#3c4043]">
-              输入您的账号邮箱，我们会向您发送一封密码重置邮件。
-            </p>
-            <input
+          </p>
+          <Link
+            href="/"
+            className="mt-6 flex h-11 items-center justify-center rounded-full bg-[var(--gemini-primary)] font-medium text-white transition-colors hover:bg-[var(--gemini-primary-hover)]"
+          >
+            返回登录
+          </Link>
+        </SuccessCard>
+      ) : (
+        <form onSubmit={onSubmit} noValidate>
+          <motion.div variants={itemVariants} className="mb-2">
+            <p className="text-xs font-medium tracking-[0.16em] text-[var(--gemini-primary)]">MINDBASE</p>
+            <h2 className="mt-1 text-[24px] font-normal tracking-[-0.3px] text-[var(--gemini-text-primary)]">重置密码</h2>
+          </motion.div>
+          <motion.p variants={itemVariants} className="mb-6 text-[14px] leading-[1.6] text-[var(--gemini-text-secondary)]">
+            输入账号邮箱，我们会向你发送一封密码重置邮件。
+          </motion.p>
+
+          <motion.div variants={itemVariants}>
+            <GoogleInput
+              id={emailId}
+              label="电子邮件地址"
               type="email"
               value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              placeholder="your@email.com"
+              onChange={(v) => {
+                setEmail(v);
+                setError(null);
+              }}
+              autoComplete="email"
+              autoFocus
               required
-              className="w-full h-[48px] rounded border border-[#dadce0] bg-white px-4 text-base text-[#202124] outline-none focus:border-2 focus:border-[#1a73e8] transition-colors"
             />
+          </motion.div>
+
+          <motion.div variants={itemVariants} className="min-h-[40px] pt-3">
             {error && (
-              <div className="text-[13px] text-[#d93025] bg-[#fce8e6] rounded px-3 py-2">
-                {error}
+              <div role="alert" className="flex items-start gap-2 rounded-[8px] bg-[#fce8e6] px-3 py-2 text-[13px] leading-5 text-[#d93025] dark:bg-[#2a1a1a] dark:text-[#f28b82]">
+                <AlertIcon />
+                <span>{error}</span>
               </div>
             )}
-            <button
+          </motion.div>
+
+          <motion.div variants={itemVariants}>
+            <Button
               type="submit"
               disabled={submitting}
-              className="w-full h-11 rounded-full bg-[#1a73e8] text-white font-medium text-[14px] hover:bg-[#1765cc] transition-colors disabled:opacity-60"
+              className="h-11 w-full rounded-full bg-[var(--gemini-primary)] text-white transition-colors hover:bg-[var(--gemini-primary-hover)] disabled:opacity-60"
             >
-              {submitting ? "发送中…" : "发送重置邮件"}
-            </button>
-            <button
-              type="button"
-              onClick={() => (window.location.href = "/")}
-              className="w-full text-[13px] text-[#5f6368] hover:underline"
-            >
-              返回首页
-            </button>
-          </form>
-        )}
-      </div>
-    </div>
+              {submitting ? (
+                <span className="flex items-center justify-center gap-2">
+                  <Spinner /> 发送中
+                </span>
+              ) : (
+                "发送重置邮件"
+              )}
+            </Button>
+          </motion.div>
+
+          <motion.div variants={itemVariants} className="mt-5 text-center">
+            <Link href="/" className="text-[13px] font-medium text-[var(--gemini-text-secondary)] transition-colors hover:text-[var(--gemini-primary)] hover:underline">
+              ← 返回登录
+            </Link>
+          </motion.div>
+        </form>
+      )}
+    </AuthLayout>
   );
 }

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -3,6 +3,8 @@ import { ZCOOL_XiaoWei, Noto_Sans_SC, Geist, Roboto } from "next/font/google";
 import "./globals.css";
 import { cn } from "@/lib/utils";
 import { ThemeProvider } from "@/components/ThemeProvider";
+import { AuthProvider } from "@/lib/auth";
+import { RouteGuard } from "@/components/RouteGuard";
 
 const geist = Geist({subsets:['latin'],variable:'--font-sans'});
 
@@ -43,7 +45,9 @@ export default function RootLayout({
     <html lang="zh-CN" className={cn("font-sans", "dark", geist.variable, roboto.variable)}>
       <body className={`${display.variable} ${body.variable} ${roboto.variable} antialiased`}>
         <ThemeProvider>
-          {children}
+          <AuthProvider>
+            <RouteGuard>{children}</RouteGuard>
+          </AuthProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -9,7 +9,8 @@ import DockPanelWrapper from "@/components/DockPanelWrapper";
 import ASRViewerModal from "@/components/ASRViewerModal";
 import { DockContext } from "@/lib/dock-context";
 import { dockModules } from "@/components/dock-modules";
-import { UserInfo, authApi, chatApi, VectorPageStatusResponse, WorkspacePage } from "@/lib/api";
+import { UserInfo, chatApi, VectorPageStatusResponse, WorkspacePage } from "@/lib/api";
+import { useAuth } from "@/lib/auth";
 import { ChatSidebarRenameDialog } from "@/components/chat-sidebar/ChatSidebarRenameDialog";
 import { ChatSidebarDeleteDialog } from "@/components/chat-sidebar/ChatSidebarDeleteDialog";
 import { useAppStore } from "@/stores/app-store";
@@ -17,8 +18,7 @@ import ThreeJSScene from "@/components/three/ThreeJSScene";
 import ThemeToggle from "@/components/ThemeToggle";
 
 export default function Home() {
-  const [session, setSession] = useState<string | null>(null);
-  const [user, setUser] = useState<string | null>(null);
+  const { user, sessionToken: session, login, logout } = useAuth();
   const [showQRLogin, setShowQRLogin] = useState(false);
   const [showPasswordLogin, setShowPasswordLogin] = useState(false);
   const [showDemo, setShowDemo] = useState(false);
@@ -51,15 +51,6 @@ export default function Home() {
   const [renameDialog, setRenameDialog] = useState<{ sessionId: string; title: string } | null>(null);
   const [deleteDialog, setDeleteDialog] = useState<{ sessionId: string; title: string } | null>(null);
   const [sessionRefreshKey, setSessionRefreshKey] = useState(0);
-
-  useEffect(() => {
-    const s = localStorage.getItem("bili_session");
-    const u = localStorage.getItem("bili_user");
-    if (s) {
-      setSession(s);
-      setUser(u || "用户");
-    }
-  }, []);
 
   // 初始化/恢复聊天会话
   useEffect(() => {
@@ -100,27 +91,18 @@ export default function Home() {
   };
 
   const onLogin = (sid: string, info: UserInfo) => {
-    const displayName = info.uname || info.nickname || "用户";
-    setSession(sid);
-    setUser(displayName);
+    login(sid, info);
     setShowQRLogin(false);
     setShowPasswordLogin(false);
-    localStorage.setItem("bili_session", sid);
-    localStorage.setItem("bili_user", displayName);
   };
 
-  const onLogout = useCallback(() => {
-    if (session) authApi.logoutCurrent(session).catch(() => { });
-    setSession(null);
-    setUser(null);
+  const onLogout = useCallback(async () => {
+    await logout();
     setActiveChatSessionId(null);
     setActivePanelId(null);
     setSelectedFolderIds([]);
     setWorkspacePages([]);
-    localStorage.removeItem("bili_session");
-    localStorage.removeItem("bili_user");
-    localStorage.removeItem("bili_chat_session");
-  }, [session]);
+  }, [logout]);
 
   const onOpenASR = useCallback((bvid: string, cid: number, pageTitle: string, pageIndex: number = 0) => {
     setAsrModal({ isOpen: true, bvid, cid, pageIndex, pageTitle });

--- a/frontend/app/reset-password/page.tsx
+++ b/frontend/app/reset-password/page.tsx
@@ -1,23 +1,76 @@
 "use client";
 
-import { useState, useEffect, Suspense } from "react";
+import { useId, useState, Suspense } from "react";
 import { useSearchParams } from "next/navigation";
+import Link from "next/link";
+import { motion } from "framer-motion";
 import { userApi } from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import { GoogleInput, EyeIcon } from "@/components/ui/google-input";
+import { cn } from "@/lib/utils";
+import { AuthLayout, itemVariants, Spinner, AlertIcon, CheckSmall, SuccessCard, ErrorCard } from "@/components/auth/auth-ui";
+
+function PasswordChecks({ pw, confirm }: { pw: string; confirm: string }) {
+  const checks = [
+    { label: "至少 8 个字符", pass: pw.length >= 8 },
+    { label: "包含字母", pass: /[A-Za-z]/.test(pw) },
+    { label: "包含数字", pass: /[0-9]/.test(pw) },
+  ];
+  const matched = confirm.length > 0 && pw === confirm;
+  const mismatched = confirm.length > 0 && pw !== confirm;
+
+  return (
+    <ul className="mt-3 space-y-1.5">
+      {checks.map((c) => (
+        <li key={c.label} className="flex items-center gap-2 text-[13px]">
+          <span
+            className={cn(
+              "flex h-4 w-4 items-center justify-center rounded-full border transition-all duration-200",
+              c.pass
+                ? "border-[#1e8e3e] bg-[#1e8e3e] text-white dark:border-[#81c995] dark:bg-[#81c995] dark:text-[#1e2920]"
+                : "border-[var(--gemini-border)] text-transparent"
+            )}
+          >
+            <CheckSmall />
+          </span>
+          <span className={c.pass ? "text-[var(--gemini-text-secondary)]" : "text-[var(--gemini-text-tertiary)]"}>
+            {c.label}
+          </span>
+        </li>
+      ))}
+      {confirm.length > 0 && (
+        <li className="flex items-center gap-2 text-[13px]">
+          <span
+            className={cn(
+              "flex h-4 w-4 items-center justify-center rounded-full border transition-all duration-200",
+              mismatched
+                ? "border-[#d93025] text-transparent dark:border-[#f28b82]"
+                : "border-[#1e8e3e] bg-[#1e8e3e] text-white dark:border-[#81c995] dark:bg-[#81c995] dark:text-[#1e2920]"
+            )}
+          >
+            <CheckSmall />
+          </span>
+          <span className={matched ? "text-[var(--gemini-text-secondary)]" : "text-[#d93025] dark:text-[#f28b82]"}>
+            两次输入一致
+          </span>
+        </li>
+      )}
+    </ul>
+  );
+}
 
 function ResetPasswordInner() {
   const searchParams = useSearchParams();
   const token = searchParams.get("token") ?? "";
 
+  const pwId = useId();
+  const confirmId = useId();
   const [newPassword, setNewPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
   const [showPw, setShowPw] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [done, setDone] = useState(false);
   const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (!token) setError("重置链接无效：缺少 token");
-  }, [token]);
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -42,10 +95,7 @@ function ResetPasswordInner() {
 
     setSubmitting(true);
     try {
-      await userApi.confirmPasswordReset({
-        reset_token: token,
-        new_password: newPassword,
-      });
+      await userApi.confirmPasswordReset({ reset_token: token, new_password: newPassword });
       setDone(true);
     } catch (err) {
       setError(err instanceof Error ? err.message : "重置失败，请重新申请");
@@ -54,82 +104,146 @@ function ResetPasswordInner() {
     }
   };
 
-  return (
-    <div className="min-h-screen bg-[#f8fafd] flex items-center justify-center px-4">
-      <div className="w-full max-w-md bg-white rounded-[20px] shadow-[0_12px_36px_rgba(60,64,67,0.18)] p-8">
-        <div className="mb-6 flex items-center gap-3">
-          <div className="h-11 w-11 rounded-full bg-[#e8f0fe] text-[#1a73e8] flex items-center justify-center font-medium text-lg">
-            M
-          </div>
-          <div>
-            <p className="text-xs font-medium tracking-[0.16em] text-[#1a73e8]">MINDBASE</p>
-            <h1 className="text-[22px] font-normal text-[#202124]">设置新密码</h1>
-          </div>
-        </div>
+  const renderEye = () => (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon-lg"
+      onClick={() => setShowPw((o) => !o)}
+      aria-label={showPw ? "隐藏密码" : "显示密码"}
+      className="h-9 w-9 rounded-full text-[var(--gemini-text-secondary)] hover:bg-[var(--gemini-border-subtle)] hover:text-[var(--gemini-text-primary)]"
+    >
+      <EyeIcon open={showPw} />
+    </Button>
+  );
 
-        {done ? (
-          <div className="space-y-4">
-            <p className="text-[14px] leading-6 text-[#3c4043]">
-              密码已重置成功，请使用新密码登录。
+  return (
+    <AuthLayout
+      brand={
+        <>
+          <motion.div variants={itemVariants} className="relative z-10 flex items-center gap-3">
+            <div className="flex h-11 w-11 items-center justify-center rounded-full bg-[var(--gemini-user-bubble)] text-[var(--gemini-primary)] shadow-[inset_0_0_0_1px_color-mix(in_srgb,var(--gemini-primary)_12%,transparent)]">
+              <span className="text-lg font-medium">M</span>
+            </div>
+            <p className="text-xs font-medium tracking-[0.18em] text-[var(--gemini-primary)]">MINDBASE</p>
+          </motion.div>
+
+          <motion.div variants={itemVariants} className="relative z-10 my-10 md:my-0">
+            <h1 className="max-w-[320px] text-[28px] font-normal leading-[1.18] tracking-[-0.5px] text-[var(--gemini-text-primary)] md:text-[34px]">
+              设置一个新密码
+            </h1>
+            <p className="mt-4 max-w-[360px] text-[14px] leading-[1.65] text-[var(--gemini-text-secondary)]">
+              为你的账号设置新密码后即可重新登录。建议 8 位以上，同时包含字母和数字。
             </p>
-            <button
-              onClick={() => (window.location.href = "/")}
-              className="w-full h-11 rounded-full bg-[#1a73e8] text-white font-medium text-[14px] hover:bg-[#1765cc] transition-colors"
-            >
-              返回首页登录
-            </button>
-          </div>
-        ) : (
-          <form onSubmit={onSubmit} className="space-y-4">
-            <p className="text-[13px] text-[#5f6368]">
-              请输入新密码（8 位以上，同时包含字母和数字）。
-            </p>
-            <input
+          </motion.div>
+
+          <motion.p variants={itemVariants} className="relative z-10 hidden text-[13px] text-[var(--gemini-text-tertiary)] md:block">
+            设置完成后，旧密码将立即失效。
+          </motion.p>
+        </>
+      }
+    >
+      {!token ? (
+        <ErrorCard
+          title="重置链接无效"
+          desc="链接缺少必要的凭证，可能已损坏或被截断。请重新申请一封密码重置邮件。"
+        >
+          <Link
+            href="/forgot-password"
+            className="mt-6 flex h-11 items-center justify-center rounded-full bg-[var(--gemini-primary)] font-medium text-white transition-colors hover:bg-[var(--gemini-primary-hover)]"
+          >
+            重新申请重置邮件
+          </Link>
+        </ErrorCard>
+      ) : done ? (
+        <SuccessCard title="密码已重置" desc="你现在可以使用新密码登录了。">
+          <Link
+            href="/"
+            className="mt-6 flex h-11 items-center justify-center rounded-full bg-[var(--gemini-primary)] font-medium text-white transition-colors hover:bg-[var(--gemini-primary-hover)]"
+          >
+            返回登录
+          </Link>
+        </SuccessCard>
+      ) : (
+        <form onSubmit={onSubmit} noValidate>
+          <motion.div variants={itemVariants} className="mb-2">
+            <p className="text-xs font-medium tracking-[0.16em] text-[var(--gemini-primary)]">MINDBASE</p>
+            <h2 className="mt-1 text-[24px] font-normal tracking-[-0.3px] text-[var(--gemini-text-primary)]">设置新密码</h2>
+          </motion.div>
+          <motion.p variants={itemVariants} className="mb-6 text-[14px] leading-[1.6] text-[var(--gemini-text-secondary)]">
+            请输入新密码，并通过下方的强度要求检查。
+          </motion.p>
+
+          <motion.div variants={itemVariants} className="grid gap-4">
+            <GoogleInput
+              id={pwId}
+              label="新密码"
               type={showPw ? "text" : "password"}
               value={newPassword}
-              onChange={(e) => setNewPassword(e.target.value)}
-              placeholder="新密码"
-              required
-              className="w-full h-[48px] rounded border border-[#dadce0] bg-white px-4 text-base text-[#202124] outline-none focus:border-2 focus:border-[#1a73e8] transition-colors"
+              onChange={(v) => {
+                setNewPassword(v);
+                setError(null);
+              }}
+              autoComplete="new-password"
+              trailing={renderEye()}
             />
-            <input
+            <GoogleInput
+              id={confirmId}
+              label="确认新密码"
               type={showPw ? "text" : "password"}
               value={confirmPassword}
-              onChange={(e) => setConfirmPassword(e.target.value)}
-              placeholder="再次输入新密码"
-              required
-              className="w-full h-[48px] rounded border border-[#dadce0] bg-white px-4 text-base text-[#202124] outline-none focus:border-2 focus:border-[#1a73e8] transition-colors"
+              onChange={(v) => {
+                setConfirmPassword(v);
+                setError(null);
+              }}
+              autoComplete="new-password"
+              trailing={renderEye()}
             />
-            <label className="flex items-center gap-2 text-[13px] text-[#3c4043] cursor-pointer">
-              <input
-                type="checkbox"
-                checked={showPw}
-                onChange={(e) => setShowPw(e.target.checked)}
-              />
-              显示密码
-            </label>
+          </motion.div>
+
+          <motion.div variants={itemVariants}>
+            <PasswordChecks pw={newPassword} confirm={confirmPassword} />
+          </motion.div>
+
+          <motion.div variants={itemVariants} className="min-h-[40px] pt-3">
             {error && (
-              <div className="text-[13px] text-[#d93025] bg-[#fce8e6] rounded px-3 py-2">
-                {error}
+              <div role="alert" className="flex items-start gap-2 rounded-[8px] bg-[#fce8e6] px-3 py-2 text-[13px] leading-5 text-[#d93025] dark:bg-[#2a1a1a] dark:text-[#f28b82]">
+                <AlertIcon />
+                <span>{error}</span>
               </div>
             )}
-            <button
+          </motion.div>
+
+          <motion.div variants={itemVariants}>
+            <Button
               type="submit"
-              disabled={submitting || !token}
-              className="w-full h-11 rounded-full bg-[#1a73e8] text-white font-medium text-[14px] hover:bg-[#1765cc] transition-colors disabled:opacity-60"
+              disabled={submitting}
+              className="h-11 w-full rounded-full bg-[var(--gemini-primary)] text-white transition-colors hover:bg-[var(--gemini-primary-hover)] disabled:opacity-60"
             >
-              {submitting ? "提交中…" : "重置密码"}
-            </button>
-          </form>
-        )}
-      </div>
-    </div>
+              {submitting ? (
+                <span className="flex items-center justify-center gap-2">
+                  <Spinner /> 提交中
+                </span>
+              ) : (
+                "重置密码"
+              )}
+            </Button>
+          </motion.div>
+
+          <motion.div variants={itemVariants} className="mt-5 text-center">
+            <Link href="/" className="text-[13px] font-medium text-[var(--gemini-text-secondary)] transition-colors hover:text-[var(--gemini-primary)] hover:underline">
+              ← 返回登录
+            </Link>
+          </motion.div>
+        </form>
+      )}
+    </AuthLayout>
   );
 }
 
 export default function ResetPasswordPage() {
   return (
-    <Suspense fallback={<div className="min-h-screen bg-[#f8fafd]" />}>
+    <Suspense fallback={<div className="min-h-screen bg-[var(--gemini-surface)]" />}>
       <ResetPasswordInner />
     </Suspense>
   );

--- a/frontend/components/RouteGuard.tsx
+++ b/frontend/components/RouteGuard.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useEffect, type ReactNode } from "react";
+import { usePathname, useRouter } from "next/navigation";
+import { useAuth } from "@/lib/auth";
+
+/**
+ * Public routes that do NOT require authentication.
+ *
+ * Everything else is treated as protected (fail-closed): any new route is
+ * guarded by default until explicitly added here. The home page "/" is public
+ * because it doubles as the login entry (it renders its own hero/login UI when
+ * unauthenticated, and the app shell when authenticated).
+ */
+const PUBLIC_EXACT = ["/"];
+const PUBLIC_PREFIXES = [
+  "/forgot-password",
+  "/reset-password",
+  "/notes/shared",
+  "/quiz/share-view",
+];
+
+function isPublicPath(pathname: string): boolean {
+  if (PUBLIC_EXACT.includes(pathname)) return true;
+  return PUBLIC_PREFIXES.some((p) => pathname === p || pathname.startsWith(`${p}/`));
+}
+
+/**
+ * Global route guard. Renders a placeholder (never the protected content) while
+ * auth state is loading or during the redirect to "/", so protected UI never
+ * flashes for unauthenticated users. Public routes pass through untouched.
+ */
+export function RouteGuard({ children }: { children: ReactNode }) {
+  const { status } = useAuth();
+  const pathname = usePathname();
+  const router = useRouter();
+  const isPublic = isPublicPath(pathname ?? "/");
+
+  useEffect(() => {
+    if (status === "unauthenticated" && !isPublic) {
+      router.replace("/");
+    }
+  }, [status, isPublic, router]);
+
+  if (!isPublic && status !== "authenticated") {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-[var(--gemini-surface)]">
+        <span className="text-sm opacity-60">加载中…</span>
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/frontend/components/auth/auth-ui.tsx
+++ b/frontend/components/auth/auth-ui.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { motion } from "framer-motion";
+
+export const containerVariants = {
+  hidden: {},
+  show: { transition: { staggerChildren: 0.07, delayChildren: 0.04 } },
+};
+
+export const itemVariants = {
+  hidden: { opacity: 0, y: 14 },
+  show: { opacity: 1, y: 0, transition: { duration: 0.5, ease: [0.22, 1, 0.36, 1] as [number, number, number, number] } },
+};
+
+/**
+ * Two-column auth shell: a tinted brand panel (left on desktop, top on mobile)
+ * and a centered form panel. Both columns run staggered enter animations.
+ */
+export function AuthLayout({ brand, children }: { brand: ReactNode; children: ReactNode }) {
+  return (
+    <div className="flex min-h-screen flex-col bg-[var(--gemini-surface)] text-[var(--gemini-text-primary)] md:flex-row">
+      <motion.aside
+        variants={containerVariants}
+        initial="hidden"
+        animate="show"
+        className="relative flex flex-col justify-between overflow-hidden bg-[var(--gemini-surface-variant)] p-8 md:w-[44%] md:min-h-screen md:p-14"
+      >
+        <div aria-hidden className="pointer-events-none absolute -right-20 -top-20 h-64 w-64 rounded-full bg-[var(--gemini-primary)] opacity-[0.07] blur-2xl" />
+        <div aria-hidden className="pointer-events-none absolute -bottom-28 -left-12 h-80 w-80 rounded-full bg-[var(--gemini-primary)] opacity-[0.05] blur-3xl" />
+        {brand}
+      </motion.aside>
+      <main className="flex flex-1 items-center justify-center p-6 md:p-10">
+        <motion.div variants={containerVariants} initial="hidden" animate="show" className="w-full max-w-[420px]">
+          {children}
+        </motion.div>
+      </main>
+    </div>
+  );
+}
+
+export function Spinner({ className }: { className?: string }) {
+  return <span className={`h-4 w-4 rounded-full border-2 border-white/40 border-t-white animate-spin ${className ?? ""}`} />;
+}
+
+export function CheckIcon({ className = "h-6 w-6" }: { className?: string }) {
+  return (
+    <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+    </svg>
+  );
+}
+
+export function AlertIcon({ className = "h-4 w-4" }: { className?: string }) {
+  return (
+    <svg className={className} fill="currentColor" viewBox="0 0 20 20">
+      <path fillRule="evenodd" d="M18 10A8 8 0 112 10a8 8 0 0116 0zM9 5a1 1 0 112 0v6a1 1 0 11-2 0V5zm1 10a1.25 1.25 0 100-2.5A1.25 1.25 0 0010 15z" clipRule="evenodd" />
+    </svg>
+  );
+}
+
+export function CheckSmall() {
+  return (
+    <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M5 13l4 4L19 7" />
+    </svg>
+  );
+}
+
+export function SuccessCard({ title, desc, children }: { title: string; desc?: ReactNode; children?: ReactNode }) {
+  return (
+    <motion.div
+      variants={itemVariants}
+      className="rounded-[var(--gemini-radius-sm)] border border-[var(--gemini-border-subtle)] bg-[var(--gemini-surface)] p-8 shadow-[var(--gemini-shadow-md)]"
+    >
+      <motion.div
+        initial={{ scale: 0, opacity: 0 }}
+        animate={{ scale: 1, opacity: 1 }}
+        transition={{ delay: 0.12, type: "spring", stiffness: 220, damping: 16 }}
+        className="mb-5 flex h-14 w-14 items-center justify-center rounded-full bg-[#e6f4ea] text-[#1e8e3e] dark:bg-[#1e2920] dark:text-[#81c995]"
+      >
+        <CheckIcon />
+      </motion.div>
+      <h2 className="text-[22px] font-normal text-[var(--gemini-text-primary)]">{title}</h2>
+      {desc && <div className="mt-3 text-[14px] leading-[1.6] text-[var(--gemini-text-secondary)]">{desc}</div>}
+      {children}
+    </motion.div>
+  );
+}
+
+export function ErrorCard({ title, desc, children }: { title: string; desc?: ReactNode; children?: ReactNode }) {
+  return (
+    <motion.div
+      variants={itemVariants}
+      className="rounded-[var(--gemini-radius-sm)] border border-[var(--gemini-border-subtle)] bg-[var(--gemini-surface)] p-8 shadow-[var(--gemini-shadow-md)]"
+    >
+      <div className="mb-5 flex h-14 w-14 items-center justify-center rounded-full bg-[#fce8e6] text-[#d93025] dark:bg-[#2a1a1a] dark:text-[#f28b82]">
+        <AlertIcon className="h-6 w-6" />
+      </div>
+      <h2 className="text-[22px] font-normal text-[var(--gemini-text-primary)]">{title}</h2>
+      {desc && <div className="mt-3 text-[14px] leading-[1.6] text-[var(--gemini-text-secondary)]">{desc}</div>}
+      {children}
+    </motion.div>
+  );
+}

--- a/frontend/components/ui/google-input.tsx
+++ b/frontend/components/ui/google-input.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+interface GoogleInputProps {
+  id: string;
+  label: string;
+  type: string;
+  value: string;
+  onChange: (value: string) => void;
+  autoComplete?: string;
+  autoFocus?: boolean;
+  trailing?: ReactNode;
+  required?: boolean;
+  name?: string;
+}
+
+/**
+ * Material-style outlined text field with a floating label.
+ * Uses --gemini-* CSS variables so it adapts to light/dark themes.
+ */
+export function GoogleInput({
+  id,
+  label,
+  type,
+  value,
+  onChange,
+  autoComplete,
+  autoFocus,
+  trailing,
+  required,
+  name,
+}: GoogleInputProps) {
+  return (
+    <div className="relative w-full">
+      <input
+        id={id}
+        name={name}
+        type={type}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder=" "
+        autoComplete={autoComplete}
+        autoFocus={autoFocus}
+        required={required}
+        className="peer h-[58px] w-full rounded border border-[var(--gemini-border)] bg-[var(--gemini-surface)] text-base text-[var(--gemini-text-primary)] outline-none transition-colors hover:border-[var(--gemini-text-secondary)] focus:border-2 focus:border-[var(--gemini-primary)] disabled:bg-[var(--gemini-surface-variant)]"
+        style={{ padding: trailing ? "12px 56px 0 16px" : "12px 16px 0" }}
+      />
+      <label
+        htmlFor={id}
+        className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 bg-[var(--gemini-surface)] text-base text-[var(--gemini-text-secondary)] transition-all duration-150 peer-focus:left-3 peer-focus:top-0 peer-focus:text-xs peer-focus:font-medium peer-focus:text-[var(--gemini-primary)] peer-[:not(:placeholder-shown)]:left-3 peer-[:not(:placeholder-shown)]:top-0 peer-[:not(:placeholder-shown)]:text-xs"
+        style={{ padding: "0 4px" }}
+      >
+        {label}
+      </label>
+      {trailing && <div className="absolute right-2 top-1/2 -translate-y-1/2">{trailing}</div>}
+    </div>
+  );
+}
+
+export function EyeIcon({ open }: { open: boolean }) {
+  return open ? (
+    <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z" />
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+    </svg>
+  ) : (
+    <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M3.98 8.223A10.477 10.477 0 001.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.45 10.45 0 0112 4.5c4.756 0 8.773 3.162 10.065 7.498a10.523 10.523 0 01-4.293 5.774M6.228 6.228L3 3m3.228 3.228l3.65 3.65m7.894 7.894L21 21m-3.228-3.228l-3.65-3.65m0 0a3 3 0 10-4.243-4.243m4.242 4.242L9.88 9.88" />
+    </svg>
+  );
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -45,6 +45,7 @@ async function request<T>(
             if (token) {
                 localStorage.removeItem("bili_session");
                 localStorage.removeItem("bili_user");
+                window.dispatchEvent(new Event("auth:unauthorized"));
                 throw new Error(sanitizeError({ status: 401 }));
             }
         }
@@ -584,12 +585,12 @@ export const chatApi = {
             body: JSON.stringify(payload),
         });
 
-        // 会话失效时自动清除登录状态并刷新页面（与 request() 保持一致）
+        // 会话失效：清本地登录态并通知 AuthProvider 统一跳转（替代硬刷新）
         if (res.status === 401) {
             if (typeof window !== "undefined") {
                 localStorage.removeItem("bili_session");
                 localStorage.removeItem("bili_user");
-                window.location.href = "/";
+                window.dispatchEvent(new Event("auth:unauthorized"));
             }
             throw new Error("会话已过期，请重新登录");
         }
@@ -2003,6 +2004,7 @@ async function fetchNotesList(
             if (token) {
                 localStorage.removeItem("bili_session");
                 localStorage.removeItem("bili_user");
+                window.dispatchEvent(new Event("auth:unauthorized"));
                 throw new Error(sanitizeError({ status: 401 }));
             }
         }

--- a/frontend/lib/auth.tsx
+++ b/frontend/lib/auth.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from "react";
+import { useRouter } from "next/navigation";
+import { authApi, type UserInfo } from "@/lib/api";
+
+export type AuthStatus = "loading" | "authenticated" | "unauthenticated";
+
+interface AuthContextValue {
+  status: AuthStatus;
+  sessionToken: string | null;
+  user: string | null;
+  login: (token: string, user: UserInfo) => void;
+  logout: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+const SESSION_KEY = "bili_session";
+const USER_KEY = "bili_user";
+const CHAT_SESSION_KEY = "bili_chat_session";
+
+function resolveDisplayName(user: UserInfo): string {
+  return user.uname || user.nickname || "用户";
+}
+
+/**
+ * Single source of truth for client-side auth state.
+ *
+ * Token stays in localStorage (Bearer token, injected by api.ts getAuthHeaders).
+ * This provider only mirrors it into React state so guarded routes and the home
+ * page can react to login/logout/401 uniformly.
+ */
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const router = useRouter();
+  const [status, setStatus] = useState<AuthStatus>("loading");
+  const [sessionToken, setSessionToken] = useState<string | null>(null);
+  const [user, setUser] = useState<string | null>(null);
+
+  // Initialize from localStorage on mount. Client-only to avoid hydration mismatch;
+  // initial render is "loading" so protected content never flashes.
+  useEffect(() => {
+    const token = localStorage.getItem(SESSION_KEY);
+    if (token) {
+      setSessionToken(token);
+      setUser(localStorage.getItem(USER_KEY) || "用户");
+      setStatus("authenticated");
+    } else {
+      setStatus("unauthenticated");
+    }
+  }, []);
+
+  // React to 401 dispatched by api.ts: drop local auth and return to home
+  // (home hero is the login entry). Keeps every API surface consistent.
+  useEffect(() => {
+    const onUnauthorized = () => {
+      setSessionToken(null);
+      setUser(null);
+      setStatus("unauthenticated");
+      router.replace("/");
+    };
+    window.addEventListener("auth:unauthorized", onUnauthorized);
+    return () => window.removeEventListener("auth:unauthorized", onUnauthorized);
+  }, [router]);
+
+  const login = useCallback((token: string, userInfo: UserInfo) => {
+    const name = resolveDisplayName(userInfo);
+    localStorage.setItem(SESSION_KEY, token);
+    localStorage.setItem(USER_KEY, name);
+    setSessionToken(token);
+    setUser(name);
+    setStatus("authenticated");
+  }, []);
+
+  const logout = useCallback(async () => {
+    if (sessionToken) {
+      try {
+        await authApi.logoutCurrent(sessionToken);
+      } catch {
+        // Best-effort: network may be gone; still clear locally.
+      }
+    }
+    localStorage.removeItem(SESSION_KEY);
+    localStorage.removeItem(USER_KEY);
+    localStorage.removeItem(CHAT_SESSION_KEY);
+    setSessionToken(null);
+    setUser(null);
+    setStatus("unauthenticated");
+  }, [sessionToken]);
+
+  return (
+    <AuthContext.Provider value={{ status, sessionToken, user, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth(): AuthContextValue {
+  const ctx = useContext(AuthContext);
+  if (!ctx) {
+    throw new Error("useAuth must be used within AuthProvider");
+  }
+  return ctx;
+}


### PR DESCRIPTION
## 背景

1. 密码重置请求接口缺 per-email 限流，且 `password_reset_request_rate_limit_dep` 误把 Pydantic body 参数声明为依赖，导致 FastAPI 把 body 包成 `{req, body}`，调用方发 `{email}` 时 422。
2. 前端 session/user 状态散落在 `page.tsx` 的 localStorage，401 时硬 `window.location.reload`，无统一 auth 状态管理；登录 UI 需对齐 Material 风格（见用户偏好）。

## 改动

**后端（`fix(auth): per-email reset-request rate limit + 422 body collision`）**
- `rate_limit_deps.py`：拆分为 per-IP dep + per-email inline 限流器（`password_reset_request_email_rate_limit`），对齐 `send_code_uid` / `change_password` 的 inline 模式
- 移除 dep 上的 `req: PasswordResetRequest` 参数（裸 model 参数被当第二个 body 字段，与 route body 冲突 → 422）
- `auth.py`：发送重置 token 前调用 per-email 限流

**前端（`feat(auth): frontend AuthProvider + RouteGuard + Material auth UI`）**
- `lib/auth.tsx`：`AuthProvider` + `useAuth()` hook，集中管理 session/user 状态
- `components/RouteGuard.tsx`：路由保护
- `components/auth/auth-ui.tsx` + `components/ui/google-input.tsx`：Material 风格 auth UI
- `layout.tsx`：用 `AuthProvider` + `RouteGuard` 包裹
- `page.tsx`：本地 session/user 状态替换为 `useAuth()`
- `forgot-password` / `reset-password`：Material 风格重设计
- `lib/api.ts`：401 时改派发 `auth:unauthorized` 事件（AuthProvider 统一跳转），替代硬刷新

## Test plan

- [x] 后端 `ruff` 通过（CI Backend ✅）
- [x] 前端 `tsc --noEmit` + `next build` 通过（CI Frontend ✅）
- [ ] 手动：密码重置请求 per-email 限流生效，`{email}` body 不再 422
- [ ] 手动：登录/登出/会话过期跳转走 AuthProvider 统一逻辑