### PR TITLE
[cloud,frontend] fix: 向量状态读时对账 + 云盘刷新视觉反馈

### DIFF
--- a/app/routers/cloud.py
+++ b/app/routers/cloud.py
@@ -324,6 +324,48 @@ async def list_videos(
             sort=sort,
             order=order,
         )
+        # Read-time reconcile: batch-check done files against Milvus, flip
+        # to failed those whose vectors are gone. Concurrent to bound latency;
+        # only done rows checked (processing may be mid-write). Skip when
+        # Milvus is not configured to avoid false positives.
+        done_files = [f for f in files if f.vector_status == "done"]
+        if done_files and config.milvus.enabled:
+            try:
+                import asyncio
+                from concurrent.futures import ThreadPoolExecutor
+
+                from app.services.rag import get_rag_service
+
+                rag = get_rag_service()
+                if rag.cloud_backend is not None:
+                    loop = asyncio.get_running_loop()
+                    uuids = [f.upload_uuid for f in done_files]
+                    with ThreadPoolExecutor(
+                        max_workers=min(len(uuids), 10)
+                    ) as pool:
+                        counts = await asyncio.gather(
+                            *[
+                                loop.run_in_executor(
+                                    pool, rag.count_cloud_chunks, u
+                                )
+                                for u in uuids
+                            ]
+                        )
+                    flipped = 0
+                    for f, c in zip(done_files, counts):
+                        if c == 0:
+                            f.vector_status = "failed"
+                            flipped += 1
+                    if flipped:
+                        logger.warning(
+                            "[CLOUD] list: flipped {} done file(s) -> failed "
+                            "(Milvus vectors lost)",
+                            flipped,
+                        )
+                        await db.commit()
+            except Exception:
+                logger.exception("[CLOUD] list: read-time reconcile failed")
+
         videos = [VideoItem.model_validate(f) for f in files]
         return VideoListResponse(
             videos=videos,
@@ -348,6 +390,29 @@ async def get_video_detail(
         file = await file_repo.get_by_uuid(upload_uuid, uid, db)
         if file is None:
             raise HTTPException(status_code=404, detail="File not found")
+
+        # Read-time reconcile: flip done -> failed if Milvus vectors gone.
+        if file.vector_status == "done" and config.milvus.enabled:
+            try:
+                from app.services.rag import get_rag_service
+
+                rag = get_rag_service()
+                if (
+                    rag.cloud_backend is not None
+                    and rag.count_cloud_chunks(upload_uuid) == 0
+                ):
+                    file.vector_status = "failed"
+                    logger.warning(
+                        "[CLOUD] detail: file {} flipped done->failed "
+                        "(Milvus vectors lost)",
+                        upload_uuid,
+                    )
+                    await db.commit()
+            except Exception:
+                logger.exception(
+                    "[CLOUD] detail: read-time reconcile failed upload_uuid={}",
+                    upload_uuid,
+                )
 
         # Build base response from ORM model
         result = VideoDetailResponse.model_validate(file)
@@ -520,16 +585,36 @@ async def get_video_status(
         if file is None:
             raise HTTPException(status_code=404, detail="File not found")
 
-        # Check Milvus for actual chunk count (authoritative)
+        # Read-time reconcile: DB may say "done" while Milvus has lost the
+        # vectors (collection rebuilt after embedding model change, data
+        # corruption, manual reset, etc.). Verify done rows against Milvus
+        # and flip to failed if vectors are gone, so the user sees the
+        # truth and can reprocess. Only check done rows (processing may be
+        # mid-write); skip when Milvus is not configured (cloud_backend
+        # is None) to avoid false positives.
         milvus_chunk_count = file.vector_chunk_count or 0
-        if config.milvus.enabled and milvus_chunk_count == 0:
+        if file.vector_status == "done" and config.milvus.enabled:
             try:
                 from app.services.rag import get_rag_service
 
                 rag = get_rag_service()
-                milvus_chunk_count = rag.count_cloud_chunks(upload_uuid)
+                if rag.cloud_backend is not None:
+                    actual = rag.count_cloud_chunks(upload_uuid)
+                    milvus_chunk_count = actual
+                    if actual == 0:
+                        file.vector_status = "failed"
+                        logger.warning(
+                            "[CLOUD] file {} flipped done->failed: "
+                            "Milvus vectors lost (collection rebuilt "
+                            "or data missing)",
+                            upload_uuid,
+                        )
+                        await db.commit()
             except Exception:
-                pass
+                logger.exception(
+                    "[CLOUD] read-time reconcile failed upload_uuid={}",
+                    upload_uuid,
+                )
 
         return VideoStatusResponse(
             asrStatus=file.asr_status,

--- a/app/test/test_cloud_status_reconcile.py
+++ b/app/test/test_cloud_status_reconcile.py
@@ -1,0 +1,255 @@
+# app/test/test_cloud_status_reconcile.py
+# 读时对账：状态/详情/列表接口在 DB 标 done 但 Milvus 无向量时 flip failed
+# 直接调用路由函数（绕过 HTTP/Depends），聚焦校验+flip 逻辑本身。
+
+import pytest
+import pytest_asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import StaticPool
+
+from app.models import Base, CloudFile
+from app.routers.cloud import get_video_detail, get_video_status, list_videos
+
+
+# ==================== Fixtures ====================
+
+
+@pytest_asyncio.fixture(scope="function")
+async def test_db():
+    """In-memory SQLite session per test."""
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+        echo=False,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    async_session = async_sessionmaker(
+        engine, class_=AsyncSession, expire_on_commit=False
+    )
+    async with async_session() as session:
+        yield session
+    await engine.dispose()
+
+
+async def _make_file(
+    test_db, vector_status="done", vector_chunk_count=5, uuid="uuid-test"
+):
+    """Insert a CloudFile row scoped to uid=123."""
+    f = CloudFile(
+        upload_uuid=uuid,
+        uid=123,
+        original_name="x.pdf",
+        file_size=100,
+        mime_type="application/pdf",
+        bucket="b",
+        object_key="k",
+        asr_status="done",
+        vector_status=vector_status,
+        vector_chunk_count=vector_chunk_count,
+    )
+    test_db.add(f)
+    await test_db.commit()
+    return f
+
+
+async def _fetch_file(test_db, uuid="uuid-test"):
+    return (
+        await test_db.execute(
+            select(CloudFile).where(CloudFile.upload_uuid == uuid)
+        )
+    ).scalar_one()
+
+
+def _mock_rag(count, backend_present=True):
+    rag = MagicMock()
+    rag.cloud_backend = MagicMock() if backend_present else None
+    rag.count_cloud_chunks.return_value = count
+    return rag
+
+
+# ==================== /video/{uuid}/status ====================
+
+
+class TestGetVideoStatusReconcile:
+    @pytest.mark.asyncio
+    async def test_done_with_vectors_stays_done(self, test_db):
+        await _make_file(test_db, "done", 5)
+        rag = _mock_rag(count=5, backend_present=True)
+        with patch("app.services.rag.get_rag_service", return_value=rag), patch(
+            "app.routers.cloud.config"
+        ) as cfg:
+            cfg.milvus.enabled = True
+            resp = await get_video_status("uuid-test", uid=123, db=test_db)
+
+        assert resp.vectorStatus == "done"
+        assert resp.vectorChunkCount == 5
+        f = await _fetch_file(test_db)
+        assert f.vector_status == "done"
+
+    @pytest.mark.asyncio
+    async def test_done_with_zero_flips_failed(self, test_db):
+        await _make_file(test_db, "done", 5)
+        rag = _mock_rag(count=0, backend_present=True)
+        with patch("app.services.rag.get_rag_service", return_value=rag), patch(
+            "app.routers.cloud.config"
+        ) as cfg:
+            cfg.milvus.enabled = True
+            resp = await get_video_status("uuid-test", uid=123, db=test_db)
+
+        assert resp.vectorStatus == "failed"
+        f = await _fetch_file(test_db)
+        assert f.vector_status == "failed"
+
+    @pytest.mark.asyncio
+    async def test_done_milvus_not_configured_no_flip(self, test_db):
+        await _make_file(test_db, "done", 5)
+        rag = _mock_rag(count=0, backend_present=False)
+        with patch("app.services.rag.get_rag_service", return_value=rag), patch(
+            "app.routers.cloud.config"
+        ) as cfg:
+            cfg.milvus.enabled = True
+            resp = await get_video_status("uuid-test", uid=123, db=test_db)
+
+        assert resp.vectorStatus == "done"
+        rag.count_cloud_chunks.assert_not_called()
+        f = await _fetch_file(test_db)
+        assert f.vector_status == "done"
+
+    @pytest.mark.asyncio
+    async def test_milvus_disabled_no_check(self, test_db):
+        await _make_file(test_db, "done", 5)
+        rag = _mock_rag(count=0, backend_present=True)
+        with patch("app.services.rag.get_rag_service", return_value=rag), patch(
+            "app.routers.cloud.config"
+        ) as cfg:
+            cfg.milvus.enabled = False
+            resp = await get_video_status("uuid-test", uid=123, db=test_db)
+
+        assert resp.vectorStatus == "done"
+        rag.count_cloud_chunks.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_processing_not_checked(self, test_db):
+        await _make_file(test_db, "processing", 0)
+        rag = _mock_rag(count=0, backend_present=True)
+        with patch("app.services.rag.get_rag_service", return_value=rag), patch(
+            "app.routers.cloud.config"
+        ) as cfg:
+            cfg.milvus.enabled = True
+            resp = await get_video_status("uuid-test", uid=123, db=test_db)
+
+        assert resp.vectorStatus == "processing"
+        rag.count_cloud_chunks.assert_not_called()
+        f = await _fetch_file(test_db)
+        assert f.vector_status == "processing"
+
+
+# ==================== /video/{uuid} (detail) ====================
+
+
+class TestGetVideoDetailReconcile:
+    @pytest.mark.asyncio
+    async def test_detail_done_with_zero_flips_failed(self, test_db):
+        await _make_file(test_db, "done", 5)
+        rag = _mock_rag(count=0, backend_present=True)
+        with patch("app.services.rag.get_rag_service", return_value=rag), patch(
+            "app.routers.cloud.config"
+        ) as cfg:
+            cfg.milvus.enabled = True
+            resp = await get_video_detail("uuid-test", uid=123, db=test_db)
+
+        assert resp.vectorStatus == "failed"
+        f = await _fetch_file(test_db)
+        assert f.vector_status == "failed"
+
+    @pytest.mark.asyncio
+    async def test_detail_done_with_vectors_stays_done(self, test_db):
+        await _make_file(test_db, "done", 5)
+        rag = _mock_rag(count=5, backend_present=True)
+        with patch("app.services.rag.get_rag_service", return_value=rag), patch(
+            "app.routers.cloud.config"
+        ) as cfg:
+            cfg.milvus.enabled = True
+            resp = await get_video_detail("uuid-test", uid=123, db=test_db)
+
+        assert resp.vectorStatus == "done"
+        f = await _fetch_file(test_db)
+        assert f.vector_status == "done"
+
+
+# ==================== /videos (list, batch) ====================
+
+
+class TestListVideosReconcile:
+    @pytest.mark.asyncio
+    async def test_list_batch_flips_done_with_zero_vectors(self, test_db):
+        """done(有向量) + done(无向量) + processing -> 仅无向量的 flip。"""
+        f1 = await _make_file(test_db, "done", 5, uuid="u1")
+        f2 = await _make_file(test_db, "done", 5, uuid="u2")
+        f3 = await _make_file(test_db, "processing", 0, uuid="u3")
+
+        rag = MagicMock()
+        rag.cloud_backend = MagicMock()
+        # u1 -> 5 (有), u2 -> 0 (无); u3 processing 不查
+        rag.count_cloud_chunks.side_effect = [5, 0]
+
+        file_repo = MagicMock()
+        file_repo.list_by_folder = AsyncMock(return_value=([f1, f2, f3], 3))
+
+        with patch(
+            "app.routers.cloud._get_file_repo", return_value=file_repo
+        ), patch(
+            "app.services.rag.get_rag_service", return_value=rag
+        ), patch("app.routers.cloud.config") as cfg:
+            cfg.milvus.enabled = True
+            resp = await list_videos(
+                folderId=None,
+                page=1,
+                pageSize=50,
+                sort="created_at",
+                order="desc",
+                uid=123,
+                db=test_db,
+            )
+
+        statuses = {v.uploadUuid: v.vectorStatus for v in resp.videos}
+        assert statuses["u1"] == "done"
+        assert statuses["u2"] == "failed"
+        assert statuses["u3"] == "processing"
+        # DB 持久化
+        assert (await _fetch_file(test_db, "u1")).vector_status == "done"
+        assert (await _fetch_file(test_db, "u2")).vector_status == "failed"
+        assert (await _fetch_file(test_db, "u3")).vector_status == "processing"
+
+    @pytest.mark.asyncio
+    async def test_list_milvus_not_configured_no_flip(self, test_db):
+        f1 = await _make_file(test_db, "done", 5, uuid="u1")
+        rag = _mock_rag(count=0, backend_present=False)
+        file_repo = MagicMock()
+        file_repo.list_by_folder = AsyncMock(return_value=([f1], 1))
+        with patch(
+            "app.routers.cloud._get_file_repo", return_value=file_repo
+        ), patch(
+            "app.services.rag.get_rag_service", return_value=rag
+        ), patch("app.routers.cloud.config") as cfg:
+            cfg.milvus.enabled = True
+            resp = await list_videos(
+                folderId=None,
+                page=1,
+                pageSize=50,
+                sort="created_at",
+                order="desc",
+                uid=123,
+                db=test_db,
+            )
+
+        assert resp.videos[0].vectorStatus == "done"
+        rag.count_cloud_chunks.assert_not_called()

--- a/frontend/components/dock-modules/cloud-drive/index.tsx
+++ b/frontend/components/dock-modules/cloud-drive/index.tsx
@@ -59,6 +59,7 @@ export default function CloudDrivePanel({ isOpen }: DockPanelProps) {
   // Video list
   const [videos, setVideos] = useState<CloudVideoItem[]>([]);
   const [videosLoading, setVideosLoading] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
   const [videoPage, setVideoPage] = useState(1);
   const [videoHasMore, setVideoHasMore] = useState(false);
 
@@ -223,6 +224,10 @@ export default function CloudDrivePanel({ isOpen }: DockPanelProps) {
   }, []);
 
   const loadVideos = useCallback(async (folderId: number | null, page: number) => {
+    // page === 1 = refresh / first load; track separately so the overlay
+    // doesn't fire on "load more" (page > 1), which would blank the list
+    // the user is currently scrolling.
+    if (page === 1) setRefreshing(true);
     setVideosLoading(true);
     try {
       const res = await cloudApi.listVideos(folderId, page);
@@ -237,6 +242,7 @@ export default function CloudDrivePanel({ isOpen }: DockPanelProps) {
       if (!e.message?.includes("503")) setError(e);
     } finally {
       setVideosLoading(false);
+      setRefreshing(false);
     }
   }, []);
 
@@ -546,7 +552,29 @@ export default function CloudDrivePanel({ isOpen }: DockPanelProps) {
         </aside>
 
         {/* Right — file list */}
-        <section className="cd-file-list">
+        <section className="cd-file-list" style={{ position: "relative" }}>
+          {/* Refresh overlay: only when refreshing with existing data,
+              so first load (length 0) keeps its own spinner and "load
+              more" (page > 1) doesn't blank the list. */}
+          {refreshing && videos.length > 0 && (
+            <div
+              style={{
+                position: "absolute",
+                inset: 0,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                gap: 8,
+                background: "rgba(255, 255, 255, 0.7)",
+                zIndex: 20,
+                color: "#666",
+                fontSize: 14,
+              }}
+            >
+              <Loader2 size={20} className="animate-spin" />
+              <span>刷新中…</span>
+            </div>
+          )}
           {/* Breadcrumb */}
           <nav className="cd-breadcrumb" aria-label="位置">
             <button


### PR DESCRIPTION
## 背景

`cloud_files.vector_status='done'` 但 Milvus `cloud_drive` 实际无向量的"假 done"--collection 重建（换 embedding 模型/dim 不匹配）或数据丢失后，关系库状态仍 done，检索静默搜不到，状态页却显示已向量化。现有 `_reset_cloud_vector_statuses` 仅覆盖启动时 dim-mismatch 重建一种场景，运行期其他丢失（admin reset、数据损坏、单文件误删）不处理。

## 后端改动 (app/routers/cloud.py)

状态/详情/列表三端点读时校验，done + Milvus 0 向量 -> flip `failed`：
- `GET /cloud/video/{uuid}/status`、`GET /cloud/video/{uuid}`：单文件校验
- `GET /cloud/videos`：当前页 done 文件并发批量校验 (ThreadPoolExecutor, max_workers=10)，0 的批量 flip、一次 commit
- `cloud_backend None`（Milvus 未配置）跳过；`processing`/disabled 不校验
- 不改 RAG 层，复用现有 `count_cloud_chunks`
- 恢复方式：用户手动 reprocess（不自动重跑，避免惊群）

## 前端改动 (cloud-drive/index.tsx)

文件列表刷新视觉反馈：原转圈仅在空列表时显示，有数据刷新无反馈（用户误以为只刷文件夹树）。新增 `refreshing` state 区分刷新 (page=1) 与加载更多 (page>1)，有数据刷新时显示半透明遮罩 + 转圈，加载更多行为不变。

## 测试

- 后端 9 passed（5 status + 2 detail + 2 list）：`app/test/test_cloud_status_reconcile.py`
- 前端 `tsc --noEmit` 通过

## 未覆盖（后续 issue）

- bilibili 链路 fail-open（`vector_page_service` 的 `get_page_vector_count` 异常返回 0 会误 flip）
- `quiz_generator` / `sync_service` 直接 `is_vectorized=='done'` 不校验 Milvus
- `startup_checks` 从 warning 升级为自动 repair
- `count_by_upload_uuid` 的 10000 截断 bug（影响数量精确比对，不影响存在性判断）

## 验证

1. 后端：重建/重启 Docker 容器加载新代码
2. 前端：`npm run dev`
3. 刷新云盘：假 done 文件应变 `failed`；文件列表显示刷新遮罩

🤖 Generated with [Claude Code](https://claude.com/claude-code)