### PR TITLE
[notes] feat: 笔记模块 UI 重品牌与自动保存修复

### DIFF
--- a/app/services/notes/service.py
+++ b/app/services/notes/service.py
@@ -80,7 +80,7 @@ class NoteService:
         content_hash = mongo_note.content_hash(clean_md)
 
         try:
-            note = await self._repo.create_note(
+            await self._repo.create_note(
                 db,
                 uuid=note_uuid,
                 uid=uid,
@@ -99,7 +99,7 @@ class NoteService:
             await mongo_note.delete_content(note_uuid)
             raise
 
-        return self._meta_to_dict(note)
+        return await self.get_note(db, note_uuid, uid=uid)
 
     # ── Read ───────────────────────────────────────────────────────
 
@@ -185,6 +185,11 @@ class NoteService:
         if if_match is not None and if_match != note.updated_at:
             raise NoteConflictError(note_uuid, note.updated_at)
 
+        # Reject no-op updates so silent field-mapping regressions surface
+        # as 400 instead of a misleading 200.
+        if title is None and content_md is None and is_pinned is None:
+            raise ValueError("empty update: at least one field required")
+
         new_title: Optional[str] = title
         new_pinned: Optional[bool] = is_pinned
         new_length: Optional[int] = None
@@ -230,7 +235,11 @@ class NoteService:
                 bump_revision=bump_revision,
             )
 
-        return self._meta_to_dict(note)
+        # Return full detail (meta + content_md + anchors + share) so the
+        # NoteDetailResponse validation passes - returning _meta_to_dict alone
+        # omits content_md and triggers a 500 that breaks the auto-save loop
+        # (serverUpdatedAtRef never advances -> next save 409s).
+        return await self.get_note(db, note_uuid, uid=uid)
 
     @staticmethod
     async def _should_snapshot(

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { ZCOOL_XiaoWei, Noto_Sans_SC, Geist, Roboto } from "next/font/google";
+import { ZCOOL_XiaoWei, Noto_Sans_SC, Geist, Roboto, Fraunces, Hanken_Grotesk } from "next/font/google";
 import "./globals.css";
 import { cn } from "@/lib/utils";
 import { ThemeProvider } from "@/components/ThemeProvider";
@@ -26,6 +26,22 @@ const roboto = Roboto({
   variable: "--font-roboto",
 });
 
+// Editorial Atelier type pairing for the notes module (scoped via
+// --font-fraunces / --font-hanken in notes.css). Latin-only; CJK falls
+// back to Noto Sans SC (--font-body) / system serif.
+const fraunces = Fraunces({
+  subsets: ["latin"],
+  weight: ["400", "500", "600"],
+  style: ["normal", "italic"],
+  variable: "--font-fraunces",
+});
+
+const hanken = Hanken_Grotesk({
+  subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
+  variable: "--font-hanken",
+});
+
 export const metadata: Metadata = {
   title: "MindBase - 知识库系统",
   description: "将你的 B站收藏夹变成可对话的知识库",
@@ -43,7 +59,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="zh-CN" className={cn("font-sans", "dark", geist.variable, roboto.variable)}>
-      <body className={`${display.variable} ${body.variable} ${roboto.variable} antialiased`}>
+      <body className={`${display.variable} ${body.variable} ${roboto.variable} ${fraunces.variable} ${hanken.variable} antialiased`}>
         <ThemeProvider>
           <AuthProvider>
             <RouteGuard>{children}</RouteGuard>

--- a/frontend/app/notes/shared/[token]/page.tsx
+++ b/frontend/app/notes/shared/[token]/page.tsx
@@ -28,30 +28,10 @@ export default function SharedNotePage() {
 
     if (loading) {
         return (
-            <div
-                className="min-h-screen flex items-center justify-center"
-                style={{
-                    background: "#faf8f3",
-                    color: "#a8a39b",
-                    fontFamily: '"Hanken Grotesk", sans-serif',
-                    fontStyle: "italic",
-                }}
-            >
+            <div className="notes-reading notes-reading-center">
                 <div className="flex flex-col items-center gap-3">
-                    <div
-                        style={{
-                            fontFamily: '"Fraunces", Georgia, serif',
-                            fontStyle: "italic",
-                            fontSize: 40,
-                            color: "#c4b89f",
-                            opacity: 0.6,
-                        }}
-                    >
-                        ❦
-                    </div>
-                    <span style={{ fontSize: 12, letterSpacing: "0.14em", textTransform: "uppercase", fontWeight: 600 }}>
-                        Loading
-                    </span>
+                    <div className="note-fleuron-lg">❦</div>
+                    <span className="note-eyebrow">Loading</span>
                 </div>
             </div>
         );
@@ -59,46 +39,17 @@ export default function SharedNotePage() {
 
     if (error || !note) {
         return (
-            <div
-                className="min-h-screen flex flex-col items-center justify-center gap-4"
-                style={{
-                    background: "#faf8f3",
-                    color: "#54545a",
-                    fontFamily: '"Hanken Grotesk", sans-serif',
-                }}
-            >
-                <div
-                    style={{
-                        fontFamily: '"Fraunces", Georgia, serif',
-                        fontSize: 88,
-                        fontStyle: "italic",
-                        color: "#c4b89f",
-                        opacity: 0.55,
-                        lineHeight: 1,
-                        fontVariationSettings: '"opsz" 144',
-                    }}
-                >
-                    404
-                </div>
-                <div
-                    style={{
-                        fontSize: 10,
-                        letterSpacing: "0.18em",
-                        textTransform: "uppercase",
-                        fontWeight: 600,
-                        color: "#a8a39b",
-                    }}
-                >
-                    Not Found
-                </div>
-                <div style={{ fontSize: 14, fontFamily: '"Fraunces", Georgia, serif', fontStyle: "italic" }}>
-                    {error || "分享不存在或已失效"}
+            <div className="notes-reading notes-reading-center">
+                <div className="flex flex-col items-center gap-4">
+                    <div className="note-404">404</div>
+                    <div className="note-eyebrow">Not Found</div>
+                    <div className="note-404-msg">分享不存在或已失效</div>
                 </div>
             </div>
         );
     }
 
-    // Reading stats for the colophon — strip markdown noise + whitespace.
+    // Reading stats for the colophon - strip markdown noise + whitespace.
     const stripped = note.contentMd
         ? note.contentMd
               .replace(/```[\s\S]*?```/g, "")
@@ -117,55 +68,13 @@ export default function SharedNotePage() {
                     style={{ animationDuration: "480ms" }}
                 >
                     <header className="mb-10">
-                        <div
-                            style={{
-                                fontFamily: "var(--note-sans)",
-                                fontSize: 10,
-                                fontWeight: 600,
-                                letterSpacing: "0.2em",
-                                textTransform: "uppercase",
-                                color: "var(--note-folio)",
-                                marginBottom: 18,
-                            }}
-                        >
-                            <span style={{ fontStyle: "italic", fontFamily: "var(--note-serif)", textTransform: "none", letterSpacing: 0, fontSize: 14, marginRight: 8, color: "var(--note-accent)" }}>
-                                ❦
-                            </span>
+                        <div className="note-eyebrow note-eyebrow-lg">
+                            <span className="note-fleuron">❦</span>
                             A Note from MindBase
                         </div>
-                        <h1
-                            style={{
-                                fontFamily: "var(--note-serif)",
-                                fontSize: 44,
-                                fontWeight: 500,
-                                letterSpacing: "-0.022em",
-                                lineHeight: 1.12,
-                                color: "var(--note-ink)",
-                                fontVariationSettings: '"opsz" 144',
-                            }}
-                        >
-                            {note.title || "无标题"}
-                        </h1>
-                        <div
-                            style={{
-                                width: 56,
-                                height: 1,
-                                background: "var(--note-ink)",
-                                opacity: 0.65,
-                                marginTop: 22,
-                            }}
-                        />
-                        <div
-                            className="flex flex-wrap items-center gap-3 mt-5"
-                            style={{
-                                color: "var(--note-ink-faint)",
-                                fontFamily: "var(--note-sans)",
-                                fontSize: 11,
-                                fontWeight: 600,
-                                letterSpacing: "0.14em",
-                                textTransform: "uppercase",
-                            }}
-                        >
+                        <h1 className="note-article-title">{note.title || "无标题"}</h1>
+                        <div className="note-title-rule" />
+                        <div className="note-article-meta">
                             <span>
                                 {new Date(note.sharedAt).toLocaleDateString("zh-CN", {
                                     year: "numeric",
@@ -173,36 +82,18 @@ export default function SharedNotePage() {
                                     day: "numeric",
                                 })}
                             </span>
-                            <span style={{ fontFamily: "var(--note-serif)", fontStyle: "italic", textTransform: "none", letterSpacing: 0, fontSize: 11, color: "var(--note-folio)" }}>
-                                ❧
-                            </span>
+                            <span className="note-meta-sep">❧</span>
                             <span>{note.viewCount} 次浏览</span>
                         </div>
                     </header>
 
-                    <div
-                        className="note-preview note-article-body"
-                        style={{
-                            fontFamily: "var(--note-sans)",
-                            fontSize: 16.5,
-                            lineHeight: 1.85,
-                            color: "var(--note-ink)",
-                        }}
-                    >
+                    <div className="note-preview note-article-body">
                         {note.contentMd ? (
                             <ReactMarkdown remarkPlugins={[remarkGfm]}>
                                 {note.contentMd}
                             </ReactMarkdown>
                         ) : (
-                            <p
-                                style={{
-                                    color: "var(--note-ink-faint)",
-                                    fontStyle: "italic",
-                                    fontFamily: "var(--note-serif)",
-                                }}
-                            >
-                                （空笔记）
-                            </p>
+                            <p className="note-empty-body">（空笔记）</p>
                         )}
                     </div>
 

--- a/frontend/components/dock-modules/index.ts
+++ b/frontend/components/dock-modules/index.ts
@@ -38,7 +38,7 @@ export const dockModules: DockModule[] = [
     icon: NotebookPen,
     title: "笔记",
     panel: NotesPanel,
-    defaultSize: { width: 1100, height: 680 },
+    defaultSize: { width: 1200, height: 680 },
   },
   {
     id: "favorites",

--- a/frontend/components/dock-modules/notes/editor.tsx
+++ b/frontend/components/dock-modules/notes/editor.tsx
@@ -5,11 +5,16 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { notesApi, type NoteDetail } from "@/lib/api";
 import { saveDraft, getDraft, clearDraft } from "./draft-store";
+import { Share2, Trash2 } from "lucide-react";
+// TypeScript may not have a module declaration for CSS imports in this project.
+// @ts-ignore: allow importing CSS in TSX
 import "./notes.css";
 
 interface NoteEditorProps {
     note: NoteDetail;
     onChanged: () => void;
+    onShare: () => void;
+    onDelete: () => void;
 }
 
 type SaveStatus = "idle" | "saving" | "saved" | "error" | "conflict";
@@ -25,7 +30,7 @@ const STATUS_LABEL: Record<SaveStatus, string> = {
     conflict: "冲突 · 该笔记已在别处修改",
 };
 
-export default function NoteEditor({ note, onChanged }: NoteEditorProps) {
+export default function NoteEditor({ note, onChanged, onShare, onDelete }: NoteEditorProps) {
     const [title, setTitle] = useState(note.title);
     const [content, setContent] = useState(note.contentMd);
     const [status, setStatus] = useState<SaveStatus>("idle");
@@ -35,7 +40,12 @@ export default function NoteEditor({ note, onChanged }: NoteEditorProps) {
     const serverUpdatedAtRef = useRef<string | null>(note.updatedAt);
     const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-    // Reset internal state when switching notes.
+    // Reset internal state ONLY when switching to a different note. We
+    // deliberately do NOT depend on note.contentMd / note.updatedAt here:
+    // re-running on every auto-save round-trip would clobber in-flight
+    // edits - the server returns the pre-debounce content, which would
+    // overwrite keystrokes the user typed during the await. Server-version
+    // sync is handled by the separate effect below.
     useEffect(() => {
         setTitle(note.title);
         setContent(note.contentMd);
@@ -49,7 +59,16 @@ export default function NoteEditor({ note, onChanged }: NoteEditorProps) {
                 setDraftPrompt(true);
             }
         });
-    }, [note.uuid, note.title, note.contentMd, note.updatedAt]);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [note.uuid]);
+
+    // Keep serverUpdatedAtRef in sync when the server advances updated_at
+    // (after our own auto-save, or an external edit). Crucially, do NOT
+    // touch local title/content here - that would overwrite unsaved
+    // keystrokes typed during the save round-trip.
+    useEffect(() => {
+        serverUpdatedAtRef.current = note.updatedAt;
+    }, [note.uuid, note.updatedAt]);
 
     const isClean = title === note.title && content === note.contentMd;
 
@@ -156,79 +175,104 @@ export default function NoteEditor({ note, onChanged }: NoteEditorProps) {
         [wordCount],
     );
 
+    // Defensive: backend may send invalid date / missing revision count.
+    const updatedAtMs = new Date(note.updatedAt).getTime();
+    const dateText = Number.isFinite(updatedAtMs)
+        ? new Date(note.updatedAt).toLocaleDateString("zh-CN", {
+              year: "numeric",
+              month: "long",
+              day: "numeric",
+          })
+        : "暂无日期";
+    const revisionText = `${note.revisionCount ?? 0} 次修订`;
+
     return (
         <div className="notes-scope flex flex-col h-full note-fade-in">
             {/* Title + status */}
             <div
-                className="flex items-start gap-3 px-8 pt-6 pb-4"
+                className="px-28 pt-9 pb-6 grid grid-cols-[1fr_2fr_1fr] items-start gap-3"
                 style={{ borderBottom: "1px solid var(--note-line-soft)" }}
             >
-                <div className="flex-1 min-w-0">
+                <span />
+                <div className="min-w-0 flex flex-col items-center">
                     <input
                         type="text"
                         value={title}
                         onChange={(e) => setTitle(e.target.value)}
                         placeholder="无标题"
                         className="note-title-input"
+                        style={{ textAlign: "center" }}
                     />
-                    <div className="note-title-rule" />
                     <div
-                        className="flex items-center gap-2.5 mt-2"
+                        className="flex items-center gap-3 mt-3.5"
                         style={{ color: "var(--note-ink-faint)" }}
                     >
-                        <span className="note-eyebrow">
-                            {new Date(note.updatedAt).toLocaleDateString("zh-CN", {
-                                year: "numeric",
-                                month: "long",
-                                day: "numeric",
-                            })}
-                        </span>
-                        <span className="note-meta-sep">❧</span>
+                        <span className="note-eyebrow">{dateText}</span>
+                        <span className="note-meta-sep">·</span>
                         <span className="note-eyebrow">{wordCount} 字</span>
                         {readingMinutes > 0 && (
                             <>
-                                <span className="note-meta-sep">❧</span>
+                                <span className="note-meta-sep">·</span>
                                 <span className="note-eyebrow">约 {readingMinutes} 分钟</span>
                             </>
                         )}
-                        <span className="note-meta-sep">❧</span>
-                        <span className="note-eyebrow">
-                            {note.revisionCount} 次修订
-                        </span>
+                        <span className="note-meta-sep">·</span>
+                        <span className="note-eyebrow">{revisionText}</span>
                     </div>
                 </div>
-                <div className="flex flex-col items-end gap-2 flex-shrink-0">
+                <div className="flex flex-col items-end gap-2 justify-self-end">
                     {showStatus && (
                         <span className={statusClass}>
                             <span className="dot" />
                             {STATUS_LABEL[status]}
                         </span>
                     )}
-                    <div className="note-seg" role="group" aria-label="视图模式">
+                    <div className="flex items-center gap-2">
                         <button
                             type="button"
-                            className={`note-seg-btn ${viewMode === "write" ? "is-active" : ""}`}
-                            onClick={() => setViewMode("write")}
-                            title="仅写作"
+                            onClick={onShare}
+                            className="note-btn is-ghost"
+                            title="分享"
+                            aria-label="分享"
                         >
-                            写作
+                            <Share2 className="w-3.5 h-3.5" />
                         </button>
                         <button
                             type="button"
-                            className={`note-seg-btn ${viewMode === "split" ? "is-active" : ""}`}
-                            onClick={() => setViewMode("split")}
-                            title="分屏"
+                            onClick={onDelete}
+                            className="note-btn is-ghost is-danger"
+                            title="删除"
+                            aria-label="删除"
                         >
-                            分屏
+                            <Trash2 className="w-3.5 h-3.5" />
                         </button>
-                        <button
-                            type="button"
-                            className={`note-seg-btn ${viewMode === "read" ? "is-active" : ""}`}
-                            onClick={() => setViewMode("read")}
-                            title="仅阅读"
-                        >
-                            阅读
-                        </button>
+                        <span style={{ width: 1, height: 18, background: "var(--note-line)", flexShrink: 0 }} />
+                        <div className="note-seg" role="group" aria-label="视图模式">
+                            <button
+                                type="button"
+                                className={`note-seg-btn ${viewMode === "write" ? "is-active" : ""}`}
+                                onClick={() => setViewMode("write")}
+                                title="仅写作"
+                            >
+                                写作
+                            </button>
+                            <button
+                                type="button"
+                                className={`note-seg-btn ${viewMode === "split" ? "is-active" : ""}`}
+                                onClick={() => setViewMode("split")}
+                                title="分屏"
+                            >
+                                分屏
+                            </button>
+                            <button
+                                type="button"
+                                className={`note-seg-btn ${viewMode === "read" ? "is-active" : ""}`}
+                                onClick={() => setViewMode("read")}
+                                title="仅阅读"
+                            >
+                                阅读
+                            </button>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -267,22 +311,22 @@ export default function NoteEditor({ note, onChanged }: NoteEditorProps) {
             {/* Edit grid — write / split / read modes */}
             <div className={`flex-1 grid min-h-0 note-edit-grid is-${viewMode}`}>
                 <div
-                    className="overflow-auto px-8 py-5 note-pane-write"
+                    className="overflow-auto pl-32 pr-20 py-6 note-pane-write"
                     style={{
-                        borderRight: "1px solid var(--note-line-soft)",
+                        borderRight: "1px solid var(--note-line)",
                         background: "var(--note-paper)",
                     }}
                 >
                     <textarea
                         value={content}
                         onChange={(e) => setContent(e.target.value)}
-                        placeholder={"从此处开始落笔…\n\n支持完整 Markdown 语法。"}
+                        placeholder="从此处开始落笔…"
                         className="note-textarea"
                         spellCheck={false}
                     />
                 </div>
                 <div
-                    className="overflow-auto px-8 py-5 note-preview note-pane-preview"
+                    className="overflow-auto pl-28 pr-16 py-6 note-preview note-pane-preview"
                     style={{ background: "var(--note-paper-elev)" }}
                 >
                     {content ? (
@@ -293,11 +337,12 @@ export default function NoteEditor({ note, onChanged }: NoteEditorProps) {
                         <p
                             style={{
                                 color: "var(--note-ink-faint)",
-                                fontStyle: "italic",
-                                fontFamily: "var(--note-serif)",
+                                fontFamily: "var(--note-sans)",
+                                fontSize: 14,
+                                lineHeight: 1.6,
                             }}
                         >
-                            预览区
+                            编辑 Markdown 内容后，此处将实时展示预览效果
                         </p>
                     )}
                 </div>

--- a/frontend/components/dock-modules/notes/index.tsx
+++ b/frontend/components/dock-modules/notes/index.tsx
@@ -3,8 +3,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
     Plus,
-    Trash2,
-    Share2,
     Search,
     X,
 } from "lucide-react";
@@ -22,11 +20,12 @@ type TargetType = "video" | "cloud_file";
 
 function targetLabel(t: TargetType, id: string): string {
     if (t === "video") {
+        if (!id) return "速记";
         if (id.startsWith("scratch:")) return "速记";
         const [bvid, cid] = id.split(":");
         return cid ? `视频 ${bvid} · P${cid}` : `视频 ${bvid}`;
     }
-    return `云盘文件 #${id}`;
+    return id ? `云盘文件 #${id}` : "云盘文件";
 }
 
 function timeAgo(iso: string): string {
@@ -108,14 +107,18 @@ export default function NotesPanel() {
     }, [refreshDetail]);
 
     const createNew = async () => {
-        const created = await notesApi.create({
-            targetType: "video",
-            targetId: `scratch:${Date.now()}`,
-            title: "无标题",
-            contentMd: "",
-        });
-        await refreshList();
-        setSelectedUuid(created.uuid);
+        try {
+            const created = await notesApi.create({
+                targetType: "video",
+                targetId: `scratch:${Date.now()}`,
+                title: "无标题",
+                contentMd: "",
+            });
+            await refreshList();
+            setSelectedUuid(created.uuid);
+        } catch (e) {
+            alert("新建笔记失败:" + (e instanceof Error ? e.message : "请稍后重试"));
+        }
     };
 
     const remove = async (uuid: string) => {
@@ -128,8 +131,12 @@ export default function NotesPanel() {
     };
 
     const togglePin = async (note: NoteMeta) => {
-        await notesApi.update(note.uuid, { isPinned: !note.isPinned });
-        await refreshList();
+        try {
+            await notesApi.update(note.uuid, { isPinned: !note.isPinned });
+            await refreshList();
+        } catch (e) {
+            alert("置顶失败:" + (e instanceof Error ? e.message : "请稍后重试"));
+        }
     };
 
     const filtered = query.trim()
@@ -146,19 +153,6 @@ export default function NotesPanel() {
         if (a.isPinned !== b.isPinned) return a.isPinned ? -1 : 1;
         return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
     });
-
-    // Stable folio numbers: derived from the FULL list (unfiltered), so
-    // searching no longer renumbers every visible row. Pinned still sort
-    // first, so their folios reflect the canonical archive order.
-    const folioMap = useMemo(() => {
-        const full = [...notes].sort((a, b) => {
-            if (a.isPinned !== b.isPinned) return a.isPinned ? -1 : 1;
-            return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
-        });
-        const m = new Map<string, string>();
-        full.forEach((n, i) => m.set(n.uuid, String(i + 1).padStart(2, "0")));
-        return m;
-    }, [notes]);
 
     // Group visible notes: pinned first, then by recency bucket. Mirrors the
     // editorial-archive feel of the chat-history sidebar.
@@ -185,50 +179,34 @@ export default function NotesPanel() {
         <div className="notes-scope flex h-full bg-[var(--note-paper)]">
             {/* Sidebar */}
             <div
-                className="w-72 flex flex-col"
-                style={{ borderRight: "1px solid var(--note-line)" }}
+                className="w-64 flex flex-col"
+                style={{
+                    borderRight: "1px solid var(--note-line)",
+                    background: "var(--note-paper-sunken)",
+                }}
             >
                 {/* Header */}
                 <div
-                    className="px-5 pt-5 pb-4 flex items-center justify-between"
+                    className="px-5 pt-9 pb-6 grid grid-cols-3 items-center"
                     style={{ borderBottom: "1px solid var(--note-line-soft)" }}
                 >
-                    <div className="flex flex-col gap-1">
-                        <span
-                            className="note-eyebrow"
-                            style={{ color: "var(--note-folio)" }}
-                        >
-                            Atelier
-                        </span>
-                        <div className="flex items-baseline gap-2.5">
-                            <span
-                                style={{
-                                    fontFamily: "var(--note-serif)",
-                                    fontSize: 24,
-                                    fontWeight: 500,
-                                    color: "var(--note-ink)",
-                                    letterSpacing: "-0.018em",
-                                    fontVariationSettings: '"opsz" 48',
-                                }}
-                            >
-                                笔记
-                            </span>
-                            <span
-                                style={{
-                                    fontFamily: "var(--note-serif)",
-                                    fontStyle: "italic",
-                                    fontSize: 13,
-                                    color: "var(--note-folio)",
-                                    fontVariationSettings: '"opsz" 9',
-                                }}
-                            >
-                                №&nbsp;{String(notes.length).padStart(2, "0")}
-                            </span>
-                        </div>
-                    </div>
+                    <span />
+                    <span
+                        style={{
+                            fontFamily: "var(--note-sans)",
+                            fontSize: 11,
+                            fontWeight: 600,
+                            color: "var(--note-ink-faint)",
+                            letterSpacing: "0.18em",
+                            textAlign: "center",
+                            textTransform: "uppercase",
+                        }}
+                    >
+                        笔记
+                    </span>
                     <button
                         onClick={createNew}
-                        className="note-btn is-ghost"
+                        className="note-btn is-ghost justify-self-end"
                         title="新建笔记"
                         aria-label="新建笔记"
                     >
@@ -237,22 +215,9 @@ export default function NotesPanel() {
                 </div>
 
                 {/* Search */}
-                <div className="px-4 py-3">
-                    <div
-                        className="flex items-center gap-2 px-3 py-1.5 rounded-lg"
-                        style={{
-                            background: "var(--note-paper-sunken)",
-                            border: "1px solid transparent",
-                            transition: "border-color 180ms var(--note-ease)",
-                        }}
-                        onFocus={(e) =>
-                            (e.currentTarget.style.borderColor = "var(--note-line)")
-                        }
-                        onBlur={(e) =>
-                            (e.currentTarget.style.borderColor = "transparent")
-                        }
-                    >
-                        <Search className="w-3.5 h-3.5" style={{ color: "var(--note-ink-faint)" }} />
+                <div className="px-4 py-4">
+                    <div className="note-search">
+                        <Search className="w-4 h-4" style={{ color: "var(--note-ink-faint)" }} />
                         <input
                             value={query}
                             onChange={(e) => setQuery(e.target.value)}
@@ -270,7 +235,7 @@ export default function NotesPanel() {
                                 aria-label="清除搜索"
                                 title="清除搜索"
                             >
-                                <X className="w-2.5 h-2.5" />
+                                <X className="w-3 h-3" />
                             </button>
                         )}
                     </div>
@@ -282,9 +247,6 @@ export default function NotesPanel() {
                         <>
                             {[0, 1, 2, 3].map((i) => (
                                 <div className="note-skel" key={i}>
-                                    <div className="note-skel-mark">
-                                        <span />
-                                    </div>
                                     <div className="note-skel-body">
                                         <div className="note-skel-line" />
                                         <div className="note-skel-line" />
@@ -296,23 +258,9 @@ export default function NotesPanel() {
                     )}
                     {!loading && sorted.length === 0 && (
                         <div
-                            className="px-5 py-10 flex flex-col items-start gap-1"
+                            className="px-5 pt-20 pb-10 flex flex-col items-start gap-1"
                             style={{ color: "var(--note-ink-faint)" }}
                         >
-                            <span
-                                style={{
-                                    fontFamily: "var(--note-serif)",
-                                    fontStyle: "italic",
-                                    fontSize: 40,
-                                    color: "var(--note-folio)",
-                                    opacity: 0.5,
-                                    lineHeight: 1,
-                                    marginBottom: 6,
-                                    fontVariationSettings: '"opsz" 144',
-                                }}
-                            >
-                                ❦
-                            </span>
                             {query ? (
                                 <>
                                     <span
@@ -334,27 +282,16 @@ export default function NotesPanel() {
                                     </span>
                                 </>
                             ) : (
-                                <>
-                                    <span className="note-eyebrow">Folio</span>
                                     <span
                                         style={{
-                                            fontFamily: "var(--note-serif)",
-                                            fontStyle: "italic",
+                                            fontFamily: "var(--note-sans)",
                                             fontSize: 15,
                                             color: "var(--note-ink-soft)",
-                                            fontVariationSettings: '"opsz" 24',
+                                            lineHeight: 1.5,
                                         }}
                                     >
                                         还没有笔记。落笔写下第一条吧。
                                     </span>
-                                    <button
-                                        onClick={createNew}
-                                        className="note-first-cta"
-                                    >
-                                        <Plus className="w-3.5 h-3.5" />
-                                        新建笔记
-                                    </button>
-                                </>
                             )}
                         </div>
                     )}
@@ -364,12 +301,11 @@ export default function NotesPanel() {
                                 <div className="note-group">
                                     <span>{g.label}</span>
                                     <span className="note-group-count">
-                                        {String(g.notes.length).padStart(2, "0")}
+                                        · {g.notes.length} 条
                                     </span>
                                 </div>
                                 {g.notes.map((n, i) => {
                                     const isSelected = selectedUuid === n.uuid;
-                                    const folio = folioMap.get(n.uuid) ?? "·";
                                     return (
                                         <div
                                             key={n.uuid}
@@ -385,7 +321,6 @@ export default function NotesPanel() {
                                             className={`note-row note-stagger ${isSelected ? "is-selected" : ""}`}
                                             style={{ animationDelay: `${Math.min(i * 24, 192)}ms` }}
                                         >
-                                            <span className="note-folio">§{folio}</span>
                                             <div className="note-row-body flex flex-col min-w-0">
                                                 <div className="flex items-start gap-2">
                                                     {n.isPinned && (
@@ -421,13 +356,7 @@ export default function NotesPanel() {
                                                         </div>
                                                     </div>
                                                 </div>
-                                                <div
-                                                    className="flex gap-1 mt-1.5 -ml-1"
-                                                    style={{
-                                                        opacity: isSelected ? 1 : 0,
-                                                        transition: "opacity 150ms var(--note-ease)",
-                                                    }}
-                                                >
+                                                <div className="note-row-actions flex gap-1 mt-1.5 -ml-1">
                                                     <button
                                                         onClick={(e) => {
                                                             e.stopPropagation();
@@ -437,16 +366,6 @@ export default function NotesPanel() {
                                                         style={{ fontSize: 10.5, padding: "2px 7px" }}
                                                     >
                                                         {n.isPinned ? "取消置顶" : "置顶"}
-                                                    </button>
-                                                    <button
-                                                        onClick={(e) => {
-                                                            e.stopPropagation();
-                                                            remove(n.uuid);
-                                                        }}
-                                                        className="note-btn is-ghost is-danger"
-                                                        style={{ fontSize: 10.5, padding: "2px 7px" }}
-                                                    >
-                                                        删除
                                                     </button>
                                                 </div>
                                             </div>
@@ -461,28 +380,12 @@ export default function NotesPanel() {
             {/* Editor pane */}
             <div className="flex-1 flex flex-col min-w-0">
                 {detail ? (
-                    <>
-                        <div
-                            className="flex items-center justify-end gap-1 px-5 py-2"
-                            style={{ borderBottom: "1px solid var(--note-line-soft)" }}
-                        >
-                            <button
-                                onClick={() => setShowShare(true)}
-                                className="note-btn"
-                            >
-                                <Share2 className="w-3.5 h-3.5" />
-                                {shareInfo ? "管理分享" : "分享"}
-                            </button>
-                            <button
-                                onClick={() => remove(detail.uuid)}
-                                className="note-btn is-danger"
-                            >
-                                <Trash2 className="w-3.5 h-3.5" />
-                                删除
-                            </button>
-                        </div>
-                        <NoteEditor note={detail} onChanged={refreshDetail} />
-                    </>
+                    <NoteEditor
+                        note={detail}
+                        onChanged={refreshDetail}
+                        onShare={() => setShowShare(true)}
+                        onDelete={() => remove(detail.uuid)}
+                    />
                 ) : (
                     <div
                         className="flex-1 flex flex-col items-center justify-center gap-4"
@@ -490,31 +393,9 @@ export default function NotesPanel() {
                     >
                         <div
                             style={{
-                                fontFamily: "var(--note-serif)",
-                                fontStyle: "italic",
-                                fontSize: 84,
-                                color: "var(--note-folio)",
-                                opacity: 0.5,
-                                lineHeight: 1,
-                                fontVariationSettings: '"opsz" 144',
-                                marginBottom: 4,
-                            }}
-                        >
-                            ❦
-                        </div>
-                        <div
-                            className="note-eyebrow"
-                            style={{ color: "var(--note-folio)" }}
-                        >
-                            Folio
-                        </div>
-                        <div
-                            style={{
-                                fontFamily: "var(--note-serif)",
-                                fontStyle: "italic",
-                                fontSize: 17,
+                                fontFamily: "var(--note-sans)",
+                                fontSize: 15,
                                 color: "var(--note-ink-soft)",
-                                fontVariationSettings: '"opsz" 24',
                             }}
                         >
                             选择左侧笔记，或新建一条开始落笔

--- a/frontend/components/dock-modules/notes/notes.css
+++ b/frontend/components/dock-modules/notes/notes.css
@@ -3,34 +3,33 @@
    Warm ivory paper, deep ink, burnt-sienna accent, hairline rules.
    Scoped under .notes-scope so we don't leak into the rest of the app. */
 
-@import url("https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;1,9..144,400;1,9..144,500&display=swap");
-@import url("https://fonts.googleapis.com/css2?family=Hanken+Grotesk:wght@400;500;600;700&display=swap");
-
-/* Color + type tokens are shared between the in-app panel (.notes-scope)
-   and the public reading page (.notes-reading), so the latter doesn't have
-   to redeclare them inline. */
+/* Color + type tokens - Editorial Atelier: warm ivory paper, deep ink,
+   burnt-sienna accent, hairline rules. Shared between the in-app panel
+   (.notes-scope) and the public reading page (.notes-reading) so the
+   latter doesn't have to redeclare them inline.
+   Solid surfaces only - no glassmorphism, no gradients, just hairlines. */
 .notes-scope,
 .notes-reading {
   --note-paper: #faf8f3;
-  --note-paper-elev: #fffefb;
-  --note-paper-sunken: #f3efe5;
-  --note-ink: #1a1a1c;
-  --note-ink-soft: #54545a;
-  --note-ink-faint: #a8a39b;
-  --note-line: #e3dccb;
-  --note-line-soft: #ede7d8;
-  --note-accent: #8b2500;
-  --note-accent-soft: #f7e3d2;
-  --note-accent-ink: #6b1d00;
-  --note-teal: #0e6b78;
-  --note-danger: #9c2a1a;
-  --note-danger-soft: #f8e3df;
-  --note-folio: #c4b89f;
-  --note-rule-ink: #2a2a2e;
+  --note-paper-elev: #fdfbf7;
+  --note-paper-sunken: #f6f3ec;
+  --note-ink: #2b2622;
+  --note-ink-soft: #6b6358;
+  --note-ink-faint: #9a9183;
+  --note-line: #e3dccd;
+  --note-line-soft: #ece6d8;
+  --note-accent: #b8602f;
+  --note-accent-soft: #f4e6d8;
+  --note-accent-ink: #8f4520;
+  --note-teal: #3d6b6e;
+  --note-danger: #c0392b;
+  --note-danger-soft: #f6e0db;
+  --note-folio: #9a9183;
+  --note-rule-ink: #e3dccd;
 
-  --note-serif: "Fraunces", "Source Han Serif SC", "Noto Serif SC", Georgia, serif;
-  --note-sans: "Hanken Grotesk", "Noto Sans SC", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  --note-mono: "JetBrains Mono", "SF Mono", ui-monospace, monospace;
+  --note-serif: var(--font-fraunces), "Songti SC", "Source Han Serif SC", "Noto Serif SC", Georgia, serif;
+  --note-sans: var(--font-hanken), var(--font-body), -apple-system, "Segoe UI", sans-serif;
+  --note-mono: "SF Mono", ui-monospace, "JetBrains Mono", monospace;
 
   --note-ease: cubic-bezier(0.22, 1, 0.36, 1);
   --note-ease-precise: cubic-bezier(0.4, 0, 0.2, 1);
@@ -48,14 +47,14 @@
   inset: 0;
   pointer-events: none;
   z-index: 0;
-  opacity: 0.035;
+  opacity: 0;
   mix-blend-mode: multiply;
   background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='180' height='180'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0.1 0 0 0 0 0.08 0 0 0 0 0.05 0 0 0 0.9 0'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>");
 }
 .notes-scope > * { position: relative; z-index: 1; }
 
 /* ─── Small-caps editorial meta label ─────────────────────────────── */
-.notes-scope .note-eyebrow {
+.note-eyebrow {
   font-family: var(--note-sans);
   font-size: 10px;
   font-weight: 600;
@@ -68,31 +67,30 @@
 .notes-scope .note-row {
   position: relative;
   display: flex;
-  gap: 14px;
-  padding: 13px 18px 13px 20px;
-  border-bottom: 1px solid var(--note-line-soft);
+  gap: 12px;
+  padding: 12px 14px;
+  margin: 3px 10px;
+  border-radius: 8px;
   cursor: default;
-  transition: background 180ms var(--note-ease);
-}
-.notes-scope .note-row::before {
-  content: "";
-  position: absolute;
-  left: 0;
-  top: 50%;
-  width: 2px;
-  height: 0;
-  background: var(--note-accent);
-  transform: translateY(-50%);
-  transition: height 240ms var(--note-ease);
+  transition: background 160ms var(--note-ease);
 }
 .notes-scope .note-row:hover {
-  background: var(--note-paper-sunken);
+  background: rgba(0, 0, 0, 0.04);
 }
 .notes-scope .note-row.is-selected {
-  background: var(--note-paper-sunken);
+  background: var(--note-accent-soft);
 }
-.notes-scope .note-row.is-selected::before {
-  height: 26px;
+
+/* Row actions: hidden by default, revealed on hover/selected (reduces noise
+   + protects against accidental clicks). Delete lives only in the editor
+   header to avoid duplicate high-risk entry points. */
+.notes-scope .note-row-actions {
+  opacity: 0;
+  transition: opacity 150ms var(--note-ease);
+}
+.notes-scope .note-row:hover .note-row-actions,
+.notes-scope .note-row.is-selected .note-row-actions {
+  opacity: 1;
 }
 
 .notes-scope .note-folio {
@@ -118,45 +116,27 @@
   min-width: 0;
 }
 
-/* ─── Editorial title input (Fraunces, high opsz) ──────────────────── */
+/* ─── Title input ─────────────────────────────────────────────────── */
 .notes-scope .note-title-input {
   font-family: var(--note-serif);
-  font-size: 30px;
+  font-size: 32px;
   line-height: 1.18;
-  font-weight: 500;
-  letter-spacing: -0.015em;
+  font-weight: 600;
+  letter-spacing: -0.012em;
   color: var(--note-ink);
   background: transparent;
   border: none;
   outline: none;
   width: 100%;
-  padding: 4px 0 2px;
-  font-variation-settings: "opsz" 96;
+  padding: 2px 0 8px;
+  font-variation-settings: "opsz" 144;
 }
 .notes-scope .note-title-input::placeholder {
   color: var(--note-ink-faint);
-  font-style: italic;
-  font-weight: 400;
+  font-weight: 500;
 }
 
-/* Em-rule ornament under the title */
-.notes-scope .note-title-rule {
-  width: 48px;
-  height: 1px;
-  background: var(--note-rule-ink);
-  margin: 10px 0 8px;
-  opacity: 0.7;
-}
-.notes-scope .note-title-rule::after {
-  content: "";
-  display: block;
-  width: 4px;
-  height: 4px;
-  border-radius: 50%;
-  background: var(--note-accent);
-  margin-top: -1.5px;
-  transform: translateY(-1px);
-}
+/* Em-rule ornament removed - Apple minimalism. */
 
 /* ─── Status pill ──────────────────────────────────────────────────── */
 .notes-scope .note-status-pill {
@@ -188,10 +168,10 @@
   animation: note-pulse 1.1s ease-in-out infinite;
 }
 .notes-scope .note-status-pill.is-saved {
-  color: #4d6b3f;
-  background: #e6eedd;
+  color: #5e7148;
+  background: #eef0e3;
 }
-.notes-scope .note-status-pill.is-saved .dot { background: #6b8a52; }
+.notes-scope .note-status-pill.is-saved .dot { background: #5e7148; }
 .notes-scope .note-status-pill.is-error {
   color: var(--note-danger);
   background: var(--note-danger-soft);
@@ -210,9 +190,9 @@
 
 /* ─── Writing surface (textarea) ───────────────────────────────────── */
 .notes-scope .note-textarea {
-  font-family: var(--note-serif);
-  font-size: 16.5px;
-  line-height: 1.78;
+  font-family: var(--note-sans);
+  font-size: 16px;
+  line-height: 1.65;
   color: var(--note-ink);
   background: transparent;
   border: none;
@@ -221,129 +201,121 @@
   width: 100%;
   height: 100%;
   padding: 8px 0;
-  letter-spacing: 0.003em;
-  font-variation-settings: "opsz" 16;
   caret-color: var(--note-accent);
 }
 .notes-scope .note-textarea::placeholder {
   color: var(--note-ink-faint);
-  font-style: italic;
 }
 
-/* ─── Preview typography (editorial) ───────────────────────────────── */
-.notes-scope .note-preview {
+/* ─── Preview typography ───────────────────────────────────────────── */
+.note-preview {
   font-family: var(--note-sans);
-  font-size: 15px;
-  line-height: 1.78;
+  font-size: 16px;
+  line-height: 1.65;
   color: var(--note-ink);
 }
-.notes-scope .note-preview h1 {
+.note-preview h1 {
   font-family: var(--note-serif);
   font-size: 28px;
-  font-weight: 500;
-  letter-spacing: -0.018em;
-  margin: 1.3em 0 0.5em;
+  font-weight: 600;
+  letter-spacing: -0.012em;
+  margin: 1.4em 0 0.5em;
   line-height: 1.22;
-  font-variation-settings: "opsz" 72;
+  font-variation-settings: "opsz" 144;
 }
-.notes-scope .note-preview h2 {
+.note-preview h2 {
   font-family: var(--note-serif);
   font-size: 21px;
-  font-weight: 500;
-  letter-spacing: -0.012em;
-  margin: 1.3em 0 0.45em;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin: 1.4em 0 0.45em;
   line-height: 1.28;
-  font-variation-settings: "opsz" 48;
+  font-variation-settings: "opsz" 72;
 }
-.notes-scope .note-preview h3 {
-  font-family: var(--note-sans);
-  font-size: 13px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+.note-preview h3 {
+  font-family: var(--note-serif);
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: -0.005em;
   margin: 1.4em 0 0.4em;
-  color: var(--note-ink-soft);
+  color: var(--note-ink);
+  font-variation-settings: "opsz" 36;
 }
-.notes-scope .note-preview p {
+.note-preview p {
   margin: 0.7em 0;
   hyphens: auto;
 }
-.notes-scope .note-preview code {
+.note-preview code {
   font-family: var(--note-mono);
-  font-size: 0.84em;
+  font-size: 0.85em;
   background: var(--note-paper-sunken);
-  padding: 2px 6px;
-  border-radius: 3px;
+  padding: 2px 5px;
+  border-radius: 4px;
   color: var(--note-accent-ink);
+  border: 1px solid var(--note-line-soft);
 }
-.notes-scope .note-preview pre {
+.note-preview pre {
   font-family: var(--note-mono);
-  font-size: 12.5px;
+  font-size: 13px;
   background: var(--note-paper-sunken);
   padding: 14px 16px;
-  border-radius: 4px;
+  border-radius: 6px;
   overflow-x: auto;
   margin: 1em 0;
-  border-left: 2px solid var(--note-accent);
+  border: 1px solid var(--note-line);
   line-height: 1.6;
 }
-.notes-scope .note-preview pre code {
+.note-preview pre code {
   background: transparent;
   padding: 0;
   color: inherit;
+  border: none;
 }
-.notes-scope .note-preview blockquote {
-  border-left: 2px solid var(--note-accent);
-  padding: 4px 0 4px 18px;
+.note-preview blockquote {
+  border-left: 3px solid var(--note-accent);
+  padding: 6px 0 6px 16px;
   margin: 1em 0;
   color: var(--note-ink-soft);
-  font-style: italic;
-  font-family: var(--note-serif);
-  font-size: 16px;
-  font-variation-settings: "opsz" 24;
 }
-.notes-scope .note-preview blockquote p { margin: 0.3em 0; }
-.notes-scope .note-preview ul,
-.notes-scope .note-preview ol {
-  padding-left: 1.4em;
+.note-preview blockquote p { margin: 0.3em 0; }
+.note-preview ul,
+.note-preview ol {
+  padding-left: 1.6em;
   margin: 0.6em 0;
+  list-style-position: outside;
 }
-.notes-scope .note-preview li { margin: 0.28em 0; }
-.notes-scope .note-preview a {
+.note-preview ul { list-style-type: disc; }
+.note-preview ol { list-style-type: decimal; }
+.note-preview li { margin: 0.32em 0; }
+.note-preview li > p { margin: 0; }
+.note-preview a {
   color: var(--note-teal);
   text-decoration: none;
   border-bottom: 1px solid color-mix(in srgb, var(--note-teal) 35%, transparent);
   transition: border-color 180ms var(--note-ease);
 }
-.notes-scope .note-preview a:hover {
+.note-preview a:hover {
   border-bottom-color: var(--note-teal);
 }
-.notes-scope .note-preview hr {
+.note-preview hr {
   border: none;
-  text-align: center;
-  margin: 1.8em 0;
-  height: 14px;
+  border-top: 1px solid var(--note-line);
+  margin: 2em 0;
+  height: 0;
 }
-.notes-scope .note-preview hr::before {
-  content: "❦";
-  display: inline-block;
-  font-family: var(--note-serif);
-  font-size: 14px;
-  color: var(--note-folio);
-}
-.notes-scope .note-preview table {
+.note-preview table {
   border-collapse: collapse;
   margin: 1em 0;
   font-size: 13.5px;
   width: auto;
 }
-.notes-scope .note-preview th,
-.notes-scope .note-preview td {
+.note-preview th,
+.note-preview td {
   border: 1px solid var(--note-line);
   padding: 7px 14px;
   text-align: left;
 }
-.notes-scope .note-preview th {
+.note-preview th {
   background: var(--note-paper-sunken);
   font-weight: 600;
   font-family: var(--note-sans);
@@ -351,12 +323,12 @@
   font-size: 12px;
   text-transform: uppercase;
 }
-.notes-scope .note-preview img {
+.note-preview img {
   max-width: 100%;
   border-radius: 3px;
   margin: 1em 0;
 }
-.notes-scope .note-preview strong {
+.note-preview strong {
   font-weight: 600;
   color: var(--note-ink);
 }
@@ -367,7 +339,7 @@
   align-items: center;
   gap: 6px;
   padding: 6px 12px;
-  border-radius: 4px;
+  border-radius: 8px;
   font-size: 12px;
   font-family: var(--note-sans);
   font-weight: 500;
@@ -431,8 +403,13 @@
 .notes-scope ::-webkit-scrollbar-thumb {
   background: var(--note-line);
   border-radius: 4px;
+  border: 2px solid transparent;
+  background-clip: padding-box;
 }
-.notes-scope ::-webkit-scrollbar-thumb:hover { background: var(--note-ink-faint); }
+.notes-scope ::-webkit-scrollbar-thumb:hover {
+  background: var(--note-ink-faint);
+  background-clip: padding-box;
+}
 
 /* ─── Text selection ───────────────────────────────────────────────── */
 .notes-scope ::selection {
@@ -440,18 +417,23 @@
   color: var(--note-accent-ink);
 }
 
+/* Placeholder - Apple faint grey */
+.notes-scope input::placeholder {
+  color: var(--note-ink-faint);
+}
+
 /* ─── Modal ────────────────────────────────────────────────────────── */
 .notes-scope .note-modal-backdrop {
-  background: rgba(26, 26, 28, 0.34);
+  background: rgba(43, 38, 34, 0.36);
   backdrop-filter: blur(2px);
 }
 .notes-scope .note-modal {
   background: var(--note-paper-elev);
-  border-radius: 6px;
+  border-radius: 12px;
   box-shadow:
-    0 1px 0 rgba(0, 0, 0, 0.04),
-    0 24px 60px rgba(60, 40, 20, 0.16),
-    0 4px 12px rgba(0, 0, 0, 0.06);
+    0 1px 2px rgba(0, 0, 0, 0.04),
+    0 12px 32px rgba(0, 0, 0, 0.12),
+    0 4px 8px rgba(0, 0, 0, 0.04);
   border: 1px solid var(--note-line-soft);
 }
 
@@ -462,35 +444,25 @@
   position: relative;
   isolation: isolate;
 }
-.notes-reading::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  z-index: 0;
-  opacity: 0.04;
-  mix-blend-mode: multiply;
-  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='180' height='180'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0.1 0 0 0 0 0.08 0 0 0 0 0.05 0 0 0 0.9 0'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>");
-}
 .notes-reading > * { position: relative; z-index: 1; }
 
 .notes-reading .note-article {
   background: var(--note-paper-elev);
-  border-radius: 4px;
+  border-radius: 10px;
   border: 1px solid var(--note-line-soft);
   box-shadow:
-    0 1px 0 rgba(0, 0, 0, 0.03),
-    0 12px 40px rgba(60, 40, 20, 0.06);
+    0 1px 2px rgba(0, 0, 0, 0.04),
+    0 8px 24px rgba(0, 0, 0, 0.06);
 }
 
 /* Drop cap — only on the very first paragraph of the article body */
 .notes-reading .note-article-body > p:first-of-type::first-letter {
   font-family: var(--note-serif);
-  font-weight: 600;
+  font-weight: 500;
   font-size: 3.6em;
-  line-height: 0.86;
+  line-height: 0.82;
   float: left;
-  margin: 0.06em 0.1em 0 -0.04em;
+  margin: 0.06em 0.1em 0 0;
   color: var(--note-accent);
   font-variation-settings: "opsz" 144;
 }
@@ -535,15 +507,15 @@
   from { opacity: 0; transform: translateY(4px); }
   to { opacity: 1; transform: translateY(0); }
 }
-.notes-scope .note-fade-in {
+.note-fade-in {
   animation: note-fade-in 320ms var(--note-ease);
 }
-.notes-scope .note-stagger {
+.note-stagger {
   animation: note-fade-in 360ms var(--note-ease) both;
 }
 
 /* Ornament — fleuron between meta items */
-.notes-scope .note-meta-sep {
+.note-meta-sep {
   font-family: var(--note-serif);
   font-style: italic;
   color: var(--note-folio);
@@ -586,9 +558,10 @@
 /* ─── List skeleton (shimmer) ──────────────────────────────────────── */
 .notes-scope .note-skel {
   display: flex;
-  gap: 14px;
-  padding: 14px 18px 14px 20px;
-  border-bottom: 1px solid var(--note-line-soft);
+  gap: 12px;
+  padding: 10px 12px;
+  margin: 2px 8px;
+  border-radius: 8px;
 }
 .notes-scope .note-skel-mark {
   width: 22px;
@@ -632,6 +605,22 @@
   100% { background-position: -120% 0; }
 }
 
+/* ─── Search field ─────────────────────────────────────────────────── */
+.notes-scope .note-search {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-radius: 10px;
+  background: var(--note-paper);
+  border: 1px solid transparent;
+  transition: border-color 160ms var(--note-ease), box-shadow 160ms var(--note-ease);
+}
+.notes-scope .note-search:focus-within {
+  border-color: var(--note-accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--note-accent) 18%, transparent);
+}
+
 /* ─── Search clear button ──────────────────────────────────────────── */
 .notes-scope .note-search-clear {
   display: inline-flex;
@@ -656,7 +645,7 @@
   display: inline-flex;
   align-items: center;
   padding: 2px;
-  border-radius: 6px;
+  border-radius: 8px;
   background: var(--note-paper-sunken);
   border: 1px solid var(--note-line-soft);
 }
@@ -688,7 +677,7 @@
 /* ─── Editor single-pane modes ─────────────────────────────────────── */
 /* Split by default; write/read modes collapse the inactive pane. */
 .notes-scope .note-edit-grid {
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: 1.15fr 1fr;
 }
 .notes-scope .note-edit-grid.is-write {
   grid-template-columns: 1fr;
@@ -719,21 +708,21 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  margin-top: 14px;
+  margin-top: 16px;
   padding: 8px 16px;
-  border-radius: 4px;
-  background: var(--note-ink);
-  color: var(--note-paper-elev);
+  border-radius: 8px;
+  background: var(--note-accent);
+  color: #ffffff;
   font-family: var(--note-sans);
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 500;
-  letter-spacing: 0.02em;
+  letter-spacing: 0.01em;
   border: none;
   cursor: pointer;
   transition: background 160ms var(--note-ease-precise);
 }
 .notes-scope .note-first-cta:hover {
-  background: #000;
+  background: var(--note-accent-ink);
 }
 
 /* ─── Reading-time pill (shared page colophon) ─────────────────────── */
@@ -749,4 +738,119 @@
   color: var(--note-accent);
   text-transform: none;
   letter-spacing: 0;
+}
+
+/* ─── Reading page: atmosphere + display typography ───────────────── */
+
+/* Paper grain - extremely subtle warm noise on the reading surface only.
+   The in-app editor stays clean for legibility; the reading page earns
+   the texture. */
+.notes-reading::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  opacity: 0.5;
+  mix-blend-mode: multiply;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='180' height='180'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0.55 0 0 0 0 0.5 0 0 0 0 0.42 0 0 0 0.08 0'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>");
+}
+.notes-reading > * { position: relative; z-index: 1; }
+
+/* Centered loading / 404 state */
+.notes-reading-center {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Inline fleuron inside an eyebrow row */
+.note-fleuron {
+  font-family: var(--note-serif);
+  font-style: italic;
+  font-size: 14px;
+  color: var(--note-accent);
+  text-transform: none;
+  letter-spacing: 0;
+  margin-right: 8px;
+}
+
+/* Large loading fleuron */
+.note-fleuron-lg {
+  font-family: var(--note-serif);
+  font-style: italic;
+  font-size: 40px;
+  color: var(--note-ink-faint);
+  opacity: 0.6;
+  line-height: 1;
+  font-variation-settings: "opsz" 144;
+  animation: note-fade-in 600ms var(--note-ease);
+}
+
+/* "A Note from MindBase" eyebrow row */
+.notes-reading .note-eyebrow-lg {
+  display: flex;
+  align-items: center;
+  margin-bottom: 18px;
+  font-size: 10px;
+}
+
+/* Article display title */
+.notes-reading .note-article-title {
+  font-family: var(--note-serif);
+  font-size: 44px;
+  font-weight: 500;
+  letter-spacing: -0.018em;
+  line-height: 1.12;
+  color: var(--note-ink);
+  font-variation-settings: "opsz" 144;
+}
+
+/* Hairline rule under the title */
+.notes-reading .note-title-rule {
+  width: 56px;
+  height: 1px;
+  background: var(--note-ink);
+  opacity: 0.55;
+  margin-top: 22px;
+}
+
+/* Meta row (date · views) */
+.notes-reading .note-article-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+  margin-top: 20px;
+  color: var(--note-ink-faint);
+  font-family: var(--note-sans);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+/* Empty-note body line */
+.notes-reading .note-empty-body {
+  color: var(--note-ink-faint);
+  font-family: var(--note-sans);
+  font-style: italic;
+}
+
+/* 404 state */
+.notes-reading .note-404 {
+  font-family: var(--note-serif);
+  font-size: 88px;
+  font-style: italic;
+  color: var(--note-ink-faint);
+  opacity: 0.6;
+  line-height: 1;
+  font-variation-settings: "opsz" 144;
+}
+.notes-reading .note-404-msg {
+  font-size: 13px;
+  font-family: var(--note-sans);
+  color: var(--note-ink-soft);
+  letter-spacing: 0.02em;
 }

--- a/frontend/components/dock-modules/notes/share-dialog.tsx
+++ b/frontend/components/dock-modules/notes/share-dialog.tsx
@@ -82,10 +82,11 @@ export default function ShareDialog({
                         <h3
                             style={{
                                 fontFamily: "var(--note-serif)",
-                                fontSize: 22,
+                                fontSize: 19,
                                 fontWeight: 500,
                                 color: "var(--note-ink)",
-                                letterSpacing: "-0.01em",
+                                letterSpacing: "-0.005em",
+                                fontVariationSettings: '"opsz" 72',
                             }}
                         >
                             分享笔记

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -65,6 +65,17 @@ async function request<T>(
     return response.json();
 }
 
+// Like `request`, but recursively converts snake_case response keys to
+// camelCase. Use for endpoints whose Pydantic models serialize with snake_case
+// field names (notes, etc.) so callers can consume camelCase directly.
+async function requestCamel<T>(
+    endpoint: string,
+    options: RequestInit = {}
+): Promise<T> {
+    const raw = await request<T>(endpoint, options);
+    return snakeToCamel<T>(raw);
+}
+
 // ==================== 类型定义 ====================
 
 export interface QRCodeResponse {
@@ -2018,7 +2029,7 @@ async function fetchNotesList(
         } catch {}
         throw new Error(sanitizeError({ status: response.status, detail: rawDetail }));
     }
-    const items = (await response.json()) as NoteMeta[];
+    const items = snakeToCamel<NoteMeta[]>(await response.json());
     const total = Number(response.headers.get("X-Total-Count") ?? "0");
     return { items, total: Number.isFinite(total) ? total : 0 };
 }
@@ -2032,35 +2043,51 @@ export const notesApi = {
         return fetchNotesList(params);
     },
     create: (data: NoteCreateParams) =>
-        request<NoteDetail>("/notes", { method: "POST", body: JSON.stringify(data) }),
+        requestCamel<NoteDetail>("/notes", {
+            method: "POST",
+            body: JSON.stringify({
+                title: data.title,
+                target_type: data.targetType,
+                target_id: data.targetId,
+                content_md: data.contentMd,
+            }),
+        }),
     get: (uuid: string) =>
-        request<NoteDetail>(`/notes/${uuid}`),
+        requestCamel<NoteDetail>(`/notes/${uuid}`),
     update: (uuid: string, data: NoteUpdateParams, ifMatch?: string) =>
-        request<NoteDetail>(`/notes/${uuid}`, {
+        requestCamel<NoteDetail>(`/notes/${uuid}`, {
             method: "PATCH",
-            body: JSON.stringify(data),
+            body: JSON.stringify({
+                title: data.title,
+                content_md: data.contentMd,
+                is_pinned: data.isPinned,
+            }),
             headers: ifMatch ? { "If-Match": ifMatch } : undefined,
         }),
     delete: (uuid: string) =>
         request<void>(`/notes/${uuid}`, { method: "DELETE" }),
     addAnchor: (uuid: string, data: { blockId: string; position: number; label?: string }) =>
-        request<NoteAnchor>(`/notes/${uuid}/anchors`, {
+        requestCamel<NoteAnchor>(`/notes/${uuid}/anchors`, {
             method: "POST",
-            body: JSON.stringify(data),
+            body: JSON.stringify({
+                block_id: data.blockId,
+                position: data.position,
+                label: data.label,
+            }),
         }),
     deleteAnchor: (uuid: string, anchorId: number) =>
         request<void>(`/notes/${uuid}/anchors/${anchorId}`, { method: "DELETE" }),
     listRevisions: (uuid: string) =>
-        request<NoteRevision[]>(`/notes/${uuid}/revisions`),
+        requestCamel<NoteRevision[]>(`/notes/${uuid}/revisions`),
     restoreRevision: (uuid: string, revisionId: string) =>
-        request<NoteDetail>(`/notes/${uuid}/revisions/restore/${revisionId}`, { method: "POST" }),
+        requestCamel<NoteDetail>(`/notes/${uuid}/revisions/restore/${revisionId}`, { method: "POST" }),
     createShare: (uuid: string, expiresInDays?: number) =>
-        request<NoteShareInfo>(`/notes/${uuid}/share`, {
+        requestCamel<NoteShareInfo>(`/notes/${uuid}/share`, {
             method: "POST",
             body: JSON.stringify({ expires_in_days: expiresInDays ?? null }),
         }),
     revokeShare: (uuid: string) =>
         request<void>(`/notes/${uuid}/share`, { method: "DELETE" }),
     getShared: (token: string) =>
-        request<NoteSharedView>(`/notes/shared/${token}`),
+        requestCamel<NoteSharedView>(`/notes/shared/${token}`),
 };


### PR DESCRIPTION
## 变更摘要

本次 PR 完成 feat/notes-ui 分支的笔记模块改造，包含三个核心部分：

### 1. 修复自动保存内容丢失
- 后端 update_note / create_note 返回完整 NoteDetail（含 content_md），修复 PATCH 500
- 前端 notesApi 响应统一做 snake_case → camelCase 转换，修复 reopen 时 contentMd / updatedAt 为 undefined 导致内容空白

### 2. Editorial Atelier 视觉重品牌
- 接入 Fraunces（衬线显示）+ Hanken Grotesk（UI 无衬线）
- 调色板：象牙纸面 #faf8f3 / 深墨 #2b2622 / 赭石 #b8602f
- 统一编辑器、列表、分享对话框、公开阅读页视觉
- 公开分享页启用首字下沉、花饰、colophon

### 3. 排版与 Markdown 渲染优化
- 增加写作区/预览区左内边距，远离边界
- 侧栏宽度 w-72 → w-64，默认面板宽度 1100 → 1200
- 修复 Markdown 有序/无序列表样式、增强代码块样式

## 测试计划
- [x] 创建笔记 → 输入内容 → 等待自动保存 → 关闭重新打开，内容保留
- [x] 输入 # 标题、1. 列表项、代码块，预览区正确渲染
- [x] 测试 If-Match 乐观并发：两个标签页同时编辑应触发 409
- [x] 公开分享页正常展示，404 提示友好
- [x] python -m ruff check app/services/notes/service.py 通过
- [x] npx tsc --noEmit -p tsconfig.json 通过

## 影响范围
- 笔记 CRUD / 自动保存 / 公开分享
- 不改动 chat / rag / 收藏夹 / 云盘等其他模块

🤖 Generated with [Claude Code](https://claude.com/code)
