### PR TITLE
[security] fix: CORS 收紧为配置驱动白名单，移除 allow_origins=["*"]

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,14 @@ SESSION__SECRET=
 # ⚠️ 部署后不要修改此密钥,否则所有已存储的用户 API Key 将无法解密
 SECURITY__API_KEY_ENCRYPTION_KEY=
 
+# ------------------------------------------------------------
+# CORS 允许的前端来源(逗号分隔)
+# ------------------------------------------------------------
+# 对应 YAML: security.cors.allow_origins
+# 生产环境必须改为真实前端域名,禁止用 * (allow_credentials=True 时 * 会被
+# Starlette 回显为请求 Origin,等于任意站点可携凭证跨域访问)
+# SECURITY__CORS__ALLOW_ORIGINS=https://app.example.com,https://admin.example.com
+
 # ============================================================
 # 可选基础设施敏感字段(只在 enabled=true 时需要)
 # ============================================================

--- a/app/config/default.yaml
+++ b/app/config/default.yaml
@@ -223,6 +223,16 @@ session:
 # becomes undecryptable.
 # Generate: python -c "import base64,os; print(base64.b64encode(os.urandom(32)).decode())"
 security:
+  # CORS allowlist - explicit origins permitted to call the API cross-origin.
+  # Override via env (comma-separated):
+  #   SECURITY__CORS__ALLOW_ORIGINS=https://app.example.com,https://admin.example.com
+  # NEVER use ["*"] together with allow_credentials=True: Starlette echoes the
+  # request Origin header, allowing any site to make credentialed cross-origin
+  # requests (CSRF / credential theft surface).
+  cors:
+    allow_origins:
+      - http://localhost:3000   # user frontend (Next.js dev server)
+
   # Plan 0028: per-endpoint rate limits + login cooldown.
   # All windows are seconds. Override via env:
   #   SECURITY__RATE_LIMIT__LOGIN__IP_MAX=20

--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -64,6 +64,26 @@ class _Settings:
     def app_port(self) -> int:
         return int(_get("server", "port", default=8000))
 
+    # ── Security ────────────────────────────────────────────────
+
+    @property
+    def cors_allow_origins(self) -> list[str]:
+        """CORS allowlist.
+
+        YAML stores a list; env overrides (``SECURITY__CORS__ALLOW_ORIGINS``)
+        arrive as a comma-separated string, so normalise both to a list.
+        """
+        origins = _get("security", "cors", "allow_origins",
+                       default=["http://localhost:3000"])
+        if isinstance(origins, str):
+            origins = [o.strip() for o in origins.split(",") if o.strip()]
+        if not origins:
+            # Empty env override or empty YAML list -> dev default.
+            # Production is same-origin behind nginx so CORS never fires;
+            # this only affects local dev (frontend :3000 -> backend :8000).
+            origins = ["http://localhost:3000"]
+        return list(origins)
+
     # ── RDBMS ────────────────────────────────────────────────────
 
     @property

--- a/app/main.py
+++ b/app/main.py
@@ -418,13 +418,20 @@ async def request_context_middleware(request: Request, call_next):
             )
 
 
-# CORS 中间件
+# CORS 中间件 - 显式白名单，禁止 allow_origins=["*"] + allow_credentials=True
+# (Starlette 会回显 Origin，导致任意站点可携凭证跨域请求)
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],  # 生产环境应该限制
+    allow_origins=settings.cors_allow_origins,
     allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_methods=["GET", "POST", "PATCH", "DELETE", "OPTIONS"],
+    allow_headers=[
+        "Authorization",
+        "Content-Type",
+        "If-Match",
+        "X-Request-Id",
+    ],
+    expose_headers=["X-Total-Count"],
 )
 
 # Plan 0023: Rate limiting middleware (second line of defense after nginx).


### PR DESCRIPTION
## 背景

安全扫描发现 `app/main.py` 的 CORS 配置存在风险：

```python
allow_origins=["*"],  # 生产环境应该限制
allow_credentials=True,
```

`allow_origins=["*"]` 配合 `allow_credentials=True` 时，Starlette 会**回显任意请求 Origin** 并发送 `Allow-Credentials: true`，等于任何恶意网站都能跨域发请求并读取响应，形成 CSRF / 凭证盗窃面。

## 改动

| 文件 | 改动 |
|------|------|
| `app/main.py` | `allow_origins` 从 `["*"]` 改为 `settings.cors_allow_origins` 白名单；`allow_methods`/`allow_headers` 从 `["*"]` 收窄为显式枚举；新增 `expose_headers: X-Total-Count` |
| `app/config/settings.py` | 新增 `cors_allow_origins` property，兼容 YAML list 与 env 逗号字符串，空值回退开发默认 |
| `app/config/default.yaml` | 新增 `security.cors.allow_origins`（默认 `http://localhost:3000`） |
| `.env.example` | 同步 `SECURITY__CORS__ALLOW_ORIGINS` 文档 |

## 部署架构说明

经核实 `nginx/nginx.conf`：生产为 **nginx 单入口同源部署**（`/` -> frontend、`/api` -> backend，同 `https://$host`），同源请求不触发 CORS，此修复对生产无影响，主要覆盖本地开发跨源场景（`localhost:3000` -> `localhost:8000`）。

若将来跨源部署，在 `.env` 设 `SECURITY__CORS__ALLOW_ORIGINS=https://app.example.com` 即可，无需改 docker-compose / nginx（`env_file: .env` 已自动加载）。

## Test Plan

- [x] Python / YAML 语法检查
- [x] 配置加载验证（默认 / env 有效值 / env 空字符串回退 三种场景）
- [x] 本地开发联调：`frontend:3000` -> `backend:8000` 跨域请求正常
- [x] 生产同源回归：nginx 部署下请求正常（CORS 不触发）
