### PR TITLE
fix: 公网部署可访问（nginx HTTPS 可选）+ 安装文档

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       # Redis — override via .env for external Redis
       - REDIS__URL=${REDIS__URL:-redis://:mind-base@redis:6379/1}
       # LLM
-      - LLM__API_KEY=${LLM_API_KEY}
+      - LLM__API_KEY=${LLM__API_KEY:-}
       - LLM__BASE_URL=${LLM_BASE_URL:-https://dashscope.aliyuncs.com/compatible-mode/v1}
       - LLM__MODEL=${LLM_MODEL:-qwen3-max}
       # Embedding
@@ -53,9 +53,9 @@ services:
       - LANGSMITH__API_KEY=${LANGSMITH_API_KEY:-}
       - LANGSMITH__PROJECT=${LANGSMITH_PROJECT:-MindBase}
       # Session
-      - SESSION__SECRET=${SESSION_SECRET}
+      - SESSION__SECRET=${SESSION__SECRET:-}
       # Security
-      - SECURITY__API_KEY_ENCRYPTION_KEY=${API_KEY_ENCRYPTION_KEY}
+      - SECURITY__API_KEY_ENCRYPTION_KEY=${SECURITY__API_KEY_ENCRYPTION_KEY:-}
       # Plan 0021: MinIO object storage
       - MINIO__ENABLED=${MINIO__ENABLED:-true}
       - MINIO__ENDPOINT=${MINIO__ENDPOINT:-http://minio:9000}
@@ -97,7 +97,7 @@ services:
       - "${FRONTEND_PORT:-3000}:3000"
     environment:
       - NODE_ENV=production
-      - NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL:-http://localhost:9080}
+      - NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL:-}
     depends_on:
       backend:
         condition: service_healthy
@@ -118,6 +118,7 @@ services:
       - "443:443"
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./nginx/locations.conf:/etc/nginx/locations.conf:ro
       - ./nginx/certs:/etc/nginx/certs:ro
       - certbot_www:/var/www/certbot
       - nginx_video_cache:/var/cache/nginx/video   # Plan 0021
@@ -359,7 +360,7 @@ services:
       # Shared DB with main app (same db, task_quiz_* tables owned by main app)
       - APPTASK__RDBMS__URL=mysql+aiomysql://${MYSQL_USER:-mind_base}:${MYSQL_PASSWORD:-mind-base}@mysql:3306/mind_base
       - APPTASK__MONGO__URI=mongodb://${MONGO_USER:-admin}:${MONGO_PASSWORD:-mind-base}@mongo:27017/?authSource=admin
-      - APPTASK__MONGO__DB_NAME=MindBase
+      - APPTASK__MONGO__DB_NAME=mind_base
       # Main app via APISIX gateway
       - APPTASK__APP__BASE_URL=http://apisix:9080
       - APPTASK__APP__CONSUMER_KEY=${APISIX_CONSUMER_KEY:-mindbase-internal-key-change-me}

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -1,0 +1,257 @@
+# MindBase 安装与运行指南
+
+> 手把手从零把 MindBase 跑起来。按顺序做就行。
+
+---
+
+## 第 1 步：装 Docker
+
+MindBase 用 Docker 部署，最省事。
+
+- Windows / Mac：下载 [Docker Desktop](https://www.docker.com/products/docker-desktop) 安装
+- Linux：`curl -fsSL https://get.docker.com | sh && sudo systemctl enable --now docker`
+
+装完确认能用：
+
+```bash
+docker --version
+docker compose version
+```
+
+---
+
+## 第 2 步：拉代码
+
+```bash
+git clone https://github.com/atoncooper/MindBase.git
+cd MindBase
+```
+
+---
+
+## 第 3 步：申请 API Key
+
+系统需要几个 key，先去申请。
+
+### 3.1 DashScope（必填，不配跑不起来）
+
+MindBase 的 LLM、向量化、语音识别都走阿里云 DashScope。
+
+1. 开通 DashScope：https://dashscope.console.aliyun.com/
+2. 创建 API Key：https://dashscope.console.aliyun.com/apiKey
+3. 复制那个 `sk-` 开头的 key，下一步用
+
+### 3.2 Resend（只用定时出题功能才需要，否则跳过）
+
+定时出题到点发邮件用。
+
+1. 注册：https://resend.com（免费 100 封/天）
+2. 创建 API Key：https://resend.com/api-keys，复制 `re_` 开头的 key
+3. 验证发件域名：后台 Domains → Add Domain，按提示加 3 条 DNS 记录等生效
+   - 不验证域名只能用测试地址 `onboarding@resend.dev`，且只能发给你自己注册 Resend 的邮箱
+
+---
+
+## 第 4 步：配置 `.env`
+
+在项目根目录执行：
+
+```bash
+cp .env.example .env
+```
+
+打开 `.env`，找到下面几项填上值（其他保持默认即可，数据库等 Docker 会自动起）：
+
+```bash
+# ===== 必填 =====
+
+# DashScope API Key（第 3.1 步拿的）
+LLM__API_KEY=sk-这里填你的DashScope密钥
+
+# Session 签名密钥——执行下面命令生成，把输出粘进来
+# python -c "import secrets; print(secrets.token_urlsafe(48))"
+SESSION__SECRET=
+
+# 用户 API Key 加密密钥——执行下面命令生成，把输出粘进来
+# python -c "import base64, os; print(base64.b64encode(os.urandom(32)).decode())"
+# ⚠️ 部署后绝不能改这个值，否则已存的用户 API Key 全部无法解密
+SECURITY__API_KEY_ENCRYPTION_KEY=
+
+# 服务间通信密钥——执行下面命令生成，把输出粘进来
+# python -c "import secrets; print(secrets.token_urlsafe(32))"
+APISIX_CONSUMER_KEY=
+
+# ===== 定时出题功能才填（不用出题就留空）=====
+
+# Resend API Key（第 3.2 步拿的）
+APPTASK_EMAIL_API_KEY=
+```
+
+数据库、MongoDB、Redis、Milvus 这些 Docker 会自动起，**不用你配**。
+
+---
+
+## 第 5 步：（只用出题功能才做）改发件人地址
+
+不用出题功能就跳到第 6 步。
+
+打开 `app-task/default.yaml`，找到 `from_email`，改成你在 Resend 验证过的域名：
+
+```yaml
+email:
+  from_email: "MindBase <noreply@你的域名.com>"
+```
+
+---
+
+## 第 6 步：启动
+
+```bash
+docker compose --profile full up -d --build
+```
+
+- `--profile full` 启动全部服务（含向量库 Milvus、出题执行器 app-task）
+- `--build` 首次或改了代码要加，会编译后端、前端、app-task
+
+首次跑要几分钟（拉镜像 + 编译）。完成后看状态：
+
+```bash
+docker compose ps
+```
+
+所有服务应该是 `running` 或 `healthy`。如果有 `unhealthy` 或 `Exited`，看日志：
+
+```bash
+docker compose logs backend      # 主服务
+docker compose logs app-task     # 出题执行器
+```
+
+---
+
+## 第 7 步：验证
+
+浏览器打开 **http://localhost:3000**，能看到登录页就说明前端起来了。
+
+或命令行验证后端：
+
+```bash
+curl http://localhost:8000/health
+# 返回 {"status":"healthy",...} 即正常
+
+curl http://localhost:8001/health
+# app-task 健康检查（出题执行器）
+```
+
+如果 `/health` 报错，最常见是 `.env` 没填全或填错变量名（回第 4 步检查）。
+
+---
+
+## 第 8 步：开始用
+
+1. 打开 http://localhost:3000
+2. 用 B 站 App 扫码登录
+3. 选要同步的收藏夹，点同步
+4. 触发知识库构建（会做语音识别 + 向量化，等几分钟）
+5. 构建完就能在对话框问收藏夹里的内容了
+6. 定时出题：进「定时出题」，填出题方向（如"数学一填空题"）+ 触发时间，到点自动出题并发邮件到你的邮箱
+
+---
+
+## 常见问题
+
+### 启动后 3000 端口打不开
+
+前端还在构建。看日志等到 `ready`：
+
+```bash
+docker compose logs -f frontend
+```
+
+### backend `/health` 报错 / 启动失败
+
+```bash
+docker compose logs backend | tail -50
+```
+
+最常见原因：
+- `.env` 的 `LLM_API_KEY` / `SESSION_SECRET` / `API_KEY_ENCRYPTION_KEY` 没填或填成了双下划线（应该是 `LLM_API_KEY` 不是 `LLM__API_KEY`）
+- `API_KEY_ENCRYPTION_KEY` 不是合法的 base64（重新用第 4 步的命令生成）
+
+### app-task 启动失败 `config validation failed`
+
+`APISIX_CONSUMER_KEY` 没填。回第 4 步填上（三个服务间密钥要一致，docker-compose 会自动传给 app-task）。
+
+### 到点没收到邮件
+
+先看出题执行器日志：
+
+```bash
+docker compose logs app-task | grep -E "TASK|NOTIFICATION"
+```
+
+再查通知状态：
+
+```bash
+docker compose exec mysql mysql -umind_base -pmind-base mind_base -e "SELECT status, last_error FROM task_quiz_notification ORDER BY id DESC LIMIT 5;"
+```
+
+- `status=dry_run`：`APPTASK_EMAIL_API_KEY` 没配，邮件没发（配了才会发）
+- `status=failed`：Resend 拒绝了，看 `last_error`——多半是发件域名没在 Resend 验证，或 `from_email` 还用的默认 `onboarding@resend.dev`
+- `status=sent`：真发了，去垃圾箱找
+
+### 前端题目显示原始 `\frac{...}` 不渲染
+
+前端依赖没装好。进前端容器重装：
+
+```bash
+docker compose exec frontend npm install katex
+docker compose restart frontend
+```
+
+### CI 报 `npm ci 504 Gateway Time-out`
+
+前端 `package-lock.json` 指向了国内镜像。本地跑：
+
+```bash
+cd frontend
+sed -i 's|registry.npmmirror.com|registry.npmjs.org|g' package-lock.json
+```
+
+提交改完的 lock。
+
+### 想用本地开发（不用 Docker）
+
+需要自己起 MySQL / MongoDB / Redis / Milvus（可以只起这些 infra 用 Docker，程序本地跑）。
+
+```bash
+# 起 infra
+docker compose up -d mysql mongo redis
+docker compose --profile storage up -d milvus
+
+# 后端
+python -m pip install -r requirements.txt
+export LLM__API_KEY=sk-xxx
+export RDBMS__URL="mysql+aiomysql://mind_base:mind-base@127.0.0.1:3306/mind_base"
+export MONGO__URI="mongodb://admin:mind-base@127.0.0.1:27017/?authSource=admin"
+uvicorn app.main:app --reload --port 8000
+
+# 前端（另开终端）
+cd frontend && npm install && npm run dev
+
+# 出题执行器（另开终端）
+go run ./app-task
+```
+
+本地开发时 `.env` 用 `.env.example` 的**双下划线**变量名（`LLM__API_KEY` 等），程序直接读。
+
+---
+
+## 停止 / 清理
+
+```bash
+# 停止所有服务（保留数据）
+docker compose --profile full down
+
+# 彻底清理（删所有数据，慎用）
+docker compose --profile full down -v
+```

--- a/nginx/locations.conf
+++ b/nginx/locations.conf
@@ -1,0 +1,286 @@
+# ============================================================
+# Shared location blocks - included by both :80 and :443 servers
+# ============================================================
+
+# Common proxy settings
+proxy_http_version      1.1;
+proxy_set_header        Host                $host;
+proxy_set_header        X-Real-IP           $remote_addr;
+proxy_set_header        X-Forwarded-For     $proxy_add_x_forwarded_for;
+proxy_set_header        X-Forwarded-Proto   $scheme;
+proxy_set_header        X-Forwarded-Host    $host;
+proxy_set_header        X-Forwarded-Port    $server_port;
+
+proxy_connect_timeout   75s;
+proxy_read_timeout      300s;  # SSE / streaming
+# proxy_buffering / proxy_cache are NOT set at server level -
+# each location sets its own. Cacheable locations enable
+# proxy_buffering on; streaming locations (/chat, /minio-proxy/)
+# set proxy_buffering off explicitly.
+
+client_max_body_size    50m;
+
+# ============================================================
+# Backend API routes
+# ============================================================
+
+# Task-quiz (定时出题) - via APISIX (forward-auth injects X-Uid)
+# /task-quiz/chat is SSE -> no buffering
+location /task-quiz/ {
+    limit_req zone=api burst=10 nodelay;
+    proxy_pass http://apisix;
+    proxy_set_header Host $host;
+    proxy_buffering off;
+    proxy_read_timeout 300s;
+}
+
+# Task list/detail/answer - via APISIX (forward-auth injects X-Uid)
+location /tasks {
+    limit_req zone=api burst=10 nodelay;
+    proxy_pass http://apisix;
+    proxy_set_header Host $host;
+}
+
+# Auth (login QR, verification codes) – strict rate limit, no cache
+location /auth {
+    limit_req zone=auth burst=3 nodelay;
+    limit_conn conn_per_ip 5;
+    proxy_cache off;
+    proxy_pass http://backend;
+}
+
+# Chat - SSE streaming, MUST NOT cache or buffer
+location /chat {
+    limit_req zone=api burst=10 nodelay;
+    limit_conn conn_per_ip 20;
+    proxy_cache off;
+    proxy_buffering off;
+    proxy_read_timeout 300s;
+    proxy_pass http://backend;
+}
+
+# Favorites - read-heavy, short cache to avoid repeated B站 API calls
+location /favorites {
+    limit_req zone=api burst=5 nodelay;
+    proxy_buffering on;
+    proxy_cache api_cache;
+    proxy_cache_key "$scheme$request_method$host$request_uri";
+    proxy_cache_valid 200 30s;
+    proxy_cache_valid 404 10s;
+    add_header X-Cache-Status $upstream_cache_status;
+    proxy_pass http://backend;
+}
+
+# Knowledge - read-heavy folder/video status
+location /knowledge {
+    proxy_buffering on;
+    proxy_cache api_cache;
+    proxy_cache_key "$scheme$request_method$host$request_uri";
+    proxy_cache_valid 200 10s;
+    add_header X-Cache-Status $upstream_cache_status;
+    proxy_pass http://backend;
+}
+
+# ASR - no cache (status polling)
+location /asr         { proxy_pass http://backend; }
+location /vec         { proxy_pass http://backend; }
+
+# Credentials / settings - strict, no cache
+location /credentials {
+    limit_req zone=auth burst=3 nodelay;
+    proxy_cache off;
+    proxy_pass http://backend;
+}
+location /settings {
+    limit_req zone=auth burst=3 nodelay;
+    proxy_cache off;
+    proxy_pass http://backend;
+}
+
+# Billing - read-only, medium cache
+location /billing {
+    proxy_buffering on;
+    proxy_cache api_cache;
+    proxy_cache_key "$scheme$request_method$host$request_uri";
+    proxy_cache_valid 200 60s;
+    add_header X-Cache-Status $upstream_cache_status;
+    proxy_pass http://backend;
+}
+
+# Public shared quiz - cacheable (no auth, content is public).
+# MUST come before /quiz - nginx longest-prefix match means /quiz/shared/xxx
+# would otherwise hit the /quiz block (which has no cache).
+location /quiz/shared/ {
+    limit_req zone=api burst=5 nodelay;
+    proxy_buffering on;
+    proxy_cache api_cache;
+    proxy_cache_key "$host$request_uri";
+    proxy_cache_valid 200 60s;
+    proxy_cache_valid 404 10s;   # absorb token-guessing traffic
+    add_header X-Cache-Status $upstream_cache_status;
+    proxy_pass http://backend;
+}
+
+# Quiz (authed endpoints) - moderate, no cache
+location /quiz {
+    limit_req zone=api burst=10 nodelay;
+    proxy_pass http://backend;
+}
+
+# Public shared note - cacheable (no auth, content is public).
+# MUST come before /notes - nginx longest-prefix match means
+# /notes/shared/xxx would otherwise hit the /notes block below.
+location /notes/shared/ {
+    limit_req zone=api burst=5 nodelay;
+    proxy_buffering on;
+    proxy_cache api_cache;
+    proxy_cache_key "$host$request_uri";
+    proxy_cache_valid 200 60s;
+    proxy_cache_valid 404 10s;   # absorb token-guessing traffic
+    add_header X-Cache-Status $upstream_cache_status;
+    proxy_pass http://backend;
+}
+
+# Notes (authed endpoints) - moderate, no cache
+location /notes {
+    limit_req zone=api burst=10 nodelay;
+    proxy_pass http://backend;
+}
+
+# Health / docs / OpenAPI - cacheable
+location /health {
+    proxy_buffering on;
+    proxy_cache api_cache;
+    proxy_cache_key "$host$request_uri";
+    proxy_cache_valid 200 5s;
+    add_header X-Cache-Status $upstream_cache_status;
+    proxy_pass http://backend;
+}
+location /docs        { proxy_pass http://backend; }
+location /openapi.json {
+    proxy_buffering on;
+    proxy_cache api_cache;
+    proxy_cache_key "$host$request_uri";
+    proxy_cache_valid 200 1h;
+    add_header X-Cache-Status $upstream_cache_status;
+    proxy_pass http://backend;
+}
+
+# ---- Wallpaper: custom (backend -> MinIO) + presets (frontend static) ----
+location /wallpaper/file/ {
+    proxy_pass http://backend;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_cache wallpaper_cache;
+    proxy_cache_key "$uri";
+    proxy_cache_valid 200 7d;
+    proxy_cache_valid 404 1m;
+    proxy_cache_revalidate on;
+    proxy_buffering on;
+    add_header X-Cache-Status $upstream_cache_status;
+}
+
+location /wallpapers/ {
+    proxy_pass http://frontend;
+    proxy_set_header Host $host;
+    proxy_cache wallpaper_cache;
+    proxy_cache_key "$uri";
+    proxy_cache_valid 200 7d;
+    expires 7d;
+    add_header Cache-Control "public, max-age=604800";
+}
+
+# ---- MinIO public proxy (presigned URLs from browser) ----
+location /minio-proxy/ {
+    rewrite ^/minio-proxy/(.*) /$1 break;
+    proxy_pass http://minio:9000;
+    proxy_set_header Host minio:9000;
+    proxy_cache off;  # upload chunks must not be cached
+    proxy_buffering off;
+    client_max_body_size 50m;
+}
+
+# ---- Cloud drive video streaming (internal redirect from backend) ----
+location /cloud-stream/ {
+    internal;
+    rewrite ^/cloud-stream/(.*) /$1 break;
+    proxy_pass http://minio:9000;
+    proxy_cache video_cache;
+    proxy_cache_key "$uri";
+    proxy_cache_valid 200 24h;
+    proxy_cache_valid 206 24h;
+    proxy_set_header Range $http_range;
+    proxy_set_header If-Range $http_if_range;
+    proxy_cache_revalidate on;
+    proxy_buffering on;
+    proxy_buffer_size 4k;
+    proxy_buffers 100 1m;
+    proxy_max_temp_file_size 2048m;
+    proxy_set_header Host minio:9000;
+    proxy_hide_header x-amz-request-id;
+    proxy_hide_header x-amz-id-2;
+}
+
+# ---- Plan 0021: Cloud drive API ----
+location /cloud/ {
+    # Upload init/complete: moderate; chunked upload heartbeats: generous
+    limit_req zone=api burst=30 nodelay;
+    limit_conn conn_per_ip 10;
+    client_max_body_size 5g;
+    proxy_pass http://backend;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+}
+
+# ---- Plan 0023: Workspace API ----
+location /workspaces {
+    limit_req zone=api burst=10 nodelay;
+    # Bypass cache for write methods
+    set $ws_bypass 0;
+    if ($request_method != GET) { set $ws_bypass 1; }
+    proxy_buffering on;
+    proxy_cache api_cache;
+    proxy_cache_key "$scheme$request_method$host$request_uri";
+    proxy_cache_valid 200 15s;
+    proxy_cache_valid 404 10s;
+    proxy_cache_bypass $ws_bypass;
+    proxy_no_cache $ws_bypass;
+    add_header X-Cache-Status $upstream_cache_status;
+    proxy_pass http://backend;
+}
+
+location /cache       { proxy_pass http://backend; }
+
+# ---- WebSocket for task notifications ----
+location /ws {
+    proxy_pass            http://backend;
+    proxy_set_header      Upgrade           $http_upgrade;
+    proxy_set_header      Connection        "upgrade";
+    proxy_read_timeout    86400s;
+}
+
+# ============================================================
+# Frontend
+# ============================================================
+
+# Next.js static assets (long cache)
+location /_next/static {
+    proxy_pass          http://frontend;
+    expires             1y;
+    add_header          Cache-Control "public, immutable";
+}
+
+# Frontend SSR pages - cache rendered HTML
+location / {
+    proxy_pass          http://frontend;
+    proxy_set_header    Upgrade           $http_upgrade;
+    proxy_set_header    Connection        "upgrade";
+    proxy_buffering     on;
+    proxy_cache         pages_cache;
+    proxy_cache_key     "$host$request_uri";
+    proxy_cache_valid   200 5m;
+    proxy_cache_valid   404 1m;
+}

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -68,17 +68,10 @@ http {
         inactive=30d
         use_temp_path=off;
 
-    # ---- Rate limiting zones ----
-    # Per-IP request rate (10 r/s burst 20) — general protection
+    # ---- Rate limiting Zones ----
     limit_req_zone $binary_remote_addr zone=general:10m rate=10r/s;
-
-    # Per-IP request rate (1 r/s burst 3) — auth / sensitive endpoints
     limit_req_zone $binary_remote_addr zone=auth:10m rate=1r/s;
-
-    # Per-IP request rate (20 r/s burst 30) — API endpoints
     limit_req_zone $binary_remote_addr zone=api:10m rate=20r/s;
-
-    # Per-IP connection limit (prevents single-IP connection exhaustion)
     limit_conn_zone $binary_remote_addr zone=conn_per_ip:10m;
 
     # ---- Upstreams ----
@@ -94,338 +87,57 @@ http {
         server apisix:9080;
     }
 
-    # ---- HTTP → HTTPS redirect ----
+    # ============================================================
+    # HTTP server (default - works without SSL certs)
+    # 公网部署开箱即用。如需 HTTPS，把证书放到 nginx/certs/ 并启用下方 443 server。
+    # ============================================================
     server {
         listen       80;
         server_name  _;
+        server_tokens off;
 
-        # Let's Encrypt ACME challenge
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options        "SAMEORIGIN" always;
+        add_header Referrer-Policy        "strict-origin-when-cross-origin" always;
+
+        # Let's Encrypt ACME challenge (申请证书时用)
         location /.well-known/acme-challenge/ {
             root  /var/www/certbot;
         }
 
-        location / {
-            return 301 https://$host$request_uri;
-        }
+        include /etc/nginx/locations.conf;
     }
 
-    # ---- HTTPS main server ----
-    server {
-        listen       443 ssl;
-        http2        on;
-        server_name  _;
-
-        # ---- SSL ----
-        ssl_certificate       /etc/nginx/certs/fullchain.pem;
-        ssl_certificate_key   /etc/nginx/certs/privkey.pem;
-        ssl_protocols         TLSv1.2 TLSv1.3;
-        ssl_ciphers           ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305;
-        ssl_prefer_server_ciphers off;
-        ssl_session_cache     shared:SSL:10m;
-        ssl_session_timeout   10m;
-
-        # ---- Security headers ----
-        add_header Strict-Transport-Security "max-age=63072000" always;
-        add_header X-Content-Type-Options    "nosniff"         always;
-        add_header X-Frame-Options           "SAMEORIGIN"      always;
-        add_header X-XSS-Protection          "0"               always;
-        server_tokens off;
-        add_header Referrer-Policy          "strict-origin-when-cross-origin" always;
-        add_header Permissions-Policy       "camera=(), microphone=(), geolocation=()" always;
-
-        # ---- Common proxy settings ----
-        proxy_http_version      1.1;
-        proxy_set_header        Host                $host;
-        proxy_set_header        X-Real-IP           $remote_addr;
-        proxy_set_header        X-Forwarded-For     $proxy_add_x_forwarded_for;
-        proxy_set_header        X-Forwarded-Proto   $scheme;
-        proxy_set_header        X-Forwarded-Host    $host;
-        proxy_set_header        X-Forwarded-Port    $server_port;
-
-        proxy_connect_timeout   75s;
-        proxy_read_timeout      300s;  # SSE / streaming
-        # proxy_buffering / proxy_cache are NOT set at server level —
-        # each location sets its own. Cacheable locations enable
-        # proxy_buffering on; streaming locations (/chat, /minio-proxy/)
-        # set proxy_buffering off explicitly.
-
-        client_max_body_size    50m;
-
-        # ============================================================
-        # Backend API routes
-        # ============================================================
-
-        # Task-quiz (定时出题) - via APISIX (forward-auth injects X-Uid)
-        # /task-quiz/chat is SSE -> no buffering
-        location /task-quiz/ {
-            limit_req zone=api burst=10 nodelay;
-            proxy_pass http://apisix;
-            proxy_set_header Host $host;
-            proxy_buffering off;
-            proxy_read_timeout 300s;
-        }
-
-        # Task list/detail/answer - via APISIX (forward-auth injects X-Uid)
-        location /tasks {
-            limit_req zone=api burst=10 nodelay;
-            proxy_pass http://apisix;
-            proxy_set_header Host $host;
-        }
-
-        # Auth (login QR, verification codes) – strict rate limit, no cache
-        location /auth {
-            limit_req zone=auth burst=3 nodelay;
-            limit_conn conn_per_ip 5;
-            proxy_cache off;
-            proxy_pass http://backend;
-        }
-
-        # Chat — SSE streaming, MUST NOT cache or buffer
-        location /chat {
-            limit_req zone=api burst=10 nodelay;
-            limit_conn conn_per_ip 20;
-            proxy_cache off;
-            proxy_buffering off;
-            proxy_read_timeout 300s;
-            proxy_pass http://backend;
-        }
-
-        # Favorites — read-heavy, short cache to avoid repeated B站 API calls
-        location /favorites {
-            limit_req zone=api burst=5 nodelay;
-            proxy_buffering on;
-            proxy_cache api_cache;
-            proxy_cache_key "$scheme$request_method$host$request_uri";
-            proxy_cache_valid 200 30s;
-            proxy_cache_valid 404 10s;
-            add_header X-Cache-Status $upstream_cache_status;
-            proxy_pass http://backend;
-        }
-
-        # Knowledge — read-heavy folder/video status
-        location /knowledge {
-            proxy_buffering on;
-            proxy_cache api_cache;
-            proxy_cache_key "$scheme$request_method$host$request_uri";
-            proxy_cache_valid 200 10s;
-            add_header X-Cache-Status $upstream_cache_status;
-            proxy_pass http://backend;
-        }
-
-        # ASR — no cache (status polling)
-        location /asr         { proxy_pass http://backend; }
-        location /vec         { proxy_pass http://backend; }
-
-        # Credentials / settings — strict, no cache
-        location /credentials {
-            limit_req zone=auth burst=3 nodelay;
-            proxy_cache off;
-            proxy_pass http://backend;
-        }
-        location /settings {
-            limit_req zone=auth burst=3 nodelay;
-            proxy_cache off;
-            proxy_pass http://backend;
-        }
-
-        # Billing — read-only, medium cache
-        location /billing {
-            proxy_buffering on;
-            proxy_cache api_cache;
-            proxy_cache_key "$scheme$request_method$host$request_uri";
-            proxy_cache_valid 200 60s;
-            add_header X-Cache-Status $upstream_cache_status;
-            proxy_pass http://backend;
-        }
-
-        # Public shared quiz — cacheable (no auth, content is public).
-        # MUST come before /quiz — nginx longest-prefix match means /quiz/shared/xxx
-        # would otherwise hit the /quiz block (which has no cache).
-        location /quiz/shared/ {
-            limit_req zone=api burst=5 nodelay;
-            proxy_buffering on;
-            proxy_cache api_cache;
-            proxy_cache_key "$host$request_uri";
-            proxy_cache_valid 200 60s;
-            proxy_cache_valid 404 10s;   # absorb token-guessing traffic
-            add_header X-Cache-Status $upstream_cache_status;
-            proxy_pass http://backend;
-        }
-
-        # Quiz (authed endpoints) — moderate, no cache
-        location /quiz {
-            limit_req zone=api burst=10 nodelay;
-            proxy_pass http://backend;
-        }
-
-        # Public shared note — cacheable (no auth, content is public).
-        # MUST come before /notes — nginx longest-prefix match means
-        # /notes/shared/xxx would otherwise hit the /notes block below.
-        location /notes/shared/ {
-            limit_req zone=api burst=5 nodelay;
-            proxy_buffering on;
-            proxy_cache api_cache;
-            proxy_cache_key "$host$request_uri";
-            proxy_cache_valid 200 60s;
-            proxy_cache_valid 404 10s;   # absorb token-guessing traffic
-            add_header X-Cache-Status $upstream_cache_status;
-            proxy_pass http://backend;
-        }
-
-        # Notes (authed endpoints) — moderate, no cache
-        location /notes {
-            limit_req zone=api burst=10 nodelay;
-            proxy_pass http://backend;
-        }
-
-        # Health / docs / OpenAPI — cacheable
-        location /health {
-            proxy_buffering on;
-            proxy_cache api_cache;
-            proxy_cache_key "$host$request_uri";
-            proxy_cache_valid 200 5s;
-            add_header X-Cache-Status $upstream_cache_status;
-            proxy_pass http://backend;
-        }
-        location /docs        { proxy_pass http://backend; }
-        location /openapi.json {
-            proxy_buffering on;
-            proxy_cache api_cache;
-            proxy_cache_key "$host$request_uri";
-            proxy_cache_valid 200 1h;
-            add_header X-Cache-Status $upstream_cache_status;
-            proxy_pass http://backend;
-        }
-
-        # ---- Wallpaper: custom (backend -> MinIO) + presets (frontend static) ----
-        # Public-read, cached by URI for 7d. Object keys are UUID-based, so a
-        # changed wallpaper yields a new URI -> new cache entry automatically.
-        location /wallpaper/file/ {
-            proxy_pass http://backend;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_cache wallpaper_cache;
-            proxy_cache_key "$uri";
-            proxy_cache_valid 200 7d;
-            proxy_cache_valid 404 1m;
-            proxy_cache_revalidate on;
-            proxy_buffering on;
-            add_header X-Cache-Status $upstream_cache_status;
-        }
-
-        location /wallpapers/ {
-            proxy_pass http://frontend;
-            proxy_set_header Host $host;
-            proxy_cache wallpaper_cache;
-            proxy_cache_key "$uri";
-            proxy_cache_valid 200 7d;
-            expires 7d;
-            add_header Cache-Control "public, max-age=604800";
-        }
-
-        # ---- MinIO public proxy (presigned URLs from browser) ----
-        # The backend rewrites internal http://minio:9000 URLs to
-        #   https://<host>/minio-proxy/<object-key>
-        # before returning presigned links to the frontend.
-        # This location strips the /minio-proxy prefix and forwards to MinIO.
-        location /minio-proxy/ {
-            rewrite ^/minio-proxy/(.*) /$1 break;
-            proxy_pass http://minio:9000;
-            proxy_set_header Host minio:9000;
-            proxy_cache off;  # upload chunks must not be cached
-            proxy_buffering off;
-            client_max_body_size 50m;
-        }
-
-        # ---- Cloud drive video streaming (internal redirect from backend) ----
-        location /cloud-stream/ {
-            internal;
-            rewrite ^/cloud-stream/(.*) /$1 break;
-            proxy_pass http://minio:9000;
-            proxy_cache video_cache;
-            proxy_cache_key "$uri";
-            proxy_cache_valid 200 24h;
-            proxy_cache_valid 206 24h;
-            proxy_set_header Range $http_range;
-            proxy_set_header If-Range $http_if_range;
-            proxy_cache_revalidate on;
-            proxy_buffering on;
-            proxy_buffer_size 4k;
-            proxy_buffers 100 1m;
-            proxy_max_temp_file_size 2048m;
-            proxy_set_header Host minio:9000;
-            proxy_hide_header x-amz-request-id;
-            proxy_hide_header x-amz-id-2;
-        }
-
-        # ---- Plan 0021: Cloud drive API ----
-        location /cloud/ {
-            # Upload init/complete: moderate; chunked upload heartbeats: generous
-            limit_req zone=api burst=30 nodelay;
-            limit_conn conn_per_ip 10;
-            client_max_body_size 5g;
-            proxy_pass http://backend;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-
-        # ---- Plan 0023: Workspace API ----
-        # GET /workspaces: cached 15s. POST/PATCH/DELETE: no cache, strict rate limit.
-        location /workspaces {
-            limit_req zone=api burst=10 nodelay;
-            # Bypass cache for write methods
-            set $ws_bypass 0;
-            if ($request_method != GET) { set $ws_bypass 1; }
-            proxy_buffering on;
-            proxy_cache api_cache;
-            proxy_cache_key "$scheme$request_method$host$request_uri";
-            proxy_cache_valid 200 15s;
-            proxy_cache_valid 404 10s;
-            proxy_cache_bypass $ws_bypass;
-            proxy_no_cache $ws_bypass;
-            add_header X-Cache-Status $upstream_cache_status;
-            proxy_pass http://backend;
-        }
-
-        location /cache       { proxy_pass http://backend; }
-
-        # ---- WebSocket for task notifications ----
-        location /ws {
-            proxy_pass            http://backend;
-            proxy_set_header      Upgrade           $http_upgrade;
-            proxy_set_header      Connection        "upgrade";
-            proxy_read_timeout    86400s;
-        }
-
-        # ============================================================
-        # Frontend
-        # ============================================================
-
-        # Next.js static assets (long cache)
-        location /_next/static {
-            proxy_pass          http://frontend;
-            expires             1y;
-            add_header          Cache-Control "public, immutable";
-        }
-
-        # Frontend SSR pages — cache rendered HTML
-        location / {
-            proxy_pass          http://frontend;
-            proxy_set_header    Upgrade           $http_upgrade;
-            proxy_set_header    Connection        "upgrade";
-            proxy_buffering     on;
-            proxy_cache         pages_cache;
-            proxy_cache_key     "$host$request_uri";
-            proxy_cache_valid   200 5m;
-            proxy_cache_valid   404 1m;
-            # Auth state lives in localStorage (client-side), so SSR HTML
-            # is login-agnostic and safe to cache uniformly.
-            # Don't cache WebSocket upgrade
-            proxy_cache_bypass   $http_upgrade;
-            add_header           X-Cache-Status $upstream_cache_status;
-        }
-    }
+    # ============================================================
+    # HTTPS server (optional - 放证书后取消注释启用)
+    # 启用步骤：
+    #   1. 把 fullchain.pem + privkey.pem 放到 nginx/certs/
+    #   2. 删除下面 server 块每行开头的 '# '
+    #   3. （可选）把上面 80 server 改成强制跳转：
+    #        location / { return 301 https://$host$request_uri; }
+    #      并把 include /etc/nginx/locations.conf; 移到 443 server
+    # ============================================================
+    # server {
+    #     listen       443 ssl;
+    #     http2        on;
+    #     server_name  _;
+    #     server_tokens off;
+    #
+    #     ssl_certificate       /etc/nginx/certs/fullchain.pem;
+    #     ssl_certificate_key   /etc/nginx/certs/privkey.pem;
+    #     ssl_protocols         TLSv1.2 TLSv1.3;
+    #     ssl_ciphers           ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305;
+    #     ssl_prefer_server_ciphers off;
+    #     ssl_session_cache     shared:SSL:10m;
+    #     ssl_session_timeout   10m;
+    #
+    #     add_header Strict-Transport-Security "max-age=63072000" always;
+    #     add_header X-Content-Type-Options    "nosniff"         always;
+    #     add_header X-Frame-Options           "SAMEORIGIN"      always;
+    #     add_header X-XSS-Protection          "0"               always;
+    #     add_header Referrer-Policy           "strict-origin-when-cross-origin" always;
+    #     add_header Permissions-Policy        "camera=(), microphone=(), geolocation=()" always;
+    #
+    #     include /etc/nginx/locations.conf;
+    # }
 }


### PR DESCRIPTION
## 概述
修复 Docker 部署到公网云服务器无法访问的问题，并补充从零安装运行文档。

## 问题根因
nginx 80 端口 `return 301 https://$host`（强制跳 HTTPS），443 需证书 `/etc/nginx/certs/fullchain.pem`。没证书 nginx 启动失败，80 也跟着挂--公网完全访问不了。

## 改动

### [infra] 公网部署修复
- **nginx 80 端口默认服务**（不再强制跳 HTTPS），443 改可选（放证书后取消注释启用）
- location 块抽到 `nginx/locations.conf`，80/443 共用
- docker-compose 敏感变量名对齐 `.env.example` 双下划线（`LLM__API_KEY` / `SESSION__SECRET` / `SECURITY__API_KEY_ENCRYPTION_KEY`）--原 `${LLM_API_KEY}` 取不到值会把容器 key 覆盖成空，backend 起不来
- docker-compose `APPTASK__MONGO__DB_NAME` 改 `mind_base`（对齐主 app，原 `MindBase` 导致 app-task 读不到题目）
- docker-compose `NEXT_PUBLIC_API_URL` 默认空（原 `localhost:9080` 导致浏览器 API 请求发到用户本地）
- docker-compose nginx 挂载 `locations.conf`

### [docs] 安装指南
- `docs/setup-guide.md`：8 步从零安装教程（Docker / API Key 申请 / .env 配置 / 启动 / 验证 / 常见问题），无让用户改 bug 的步骤

## 部署验证
```bash
docker compose --profile full up -d --build
# 云安全组放行 80（HTTPS 再放 443）
curl http://公网IP/health
```
HTTP 开箱即用，不需证书。HTTPS：放证书到 `nginx/certs/` + 取消 `nginx.conf` 443 server 注释。
