### PR TITLE
[infra] nginx -> apisix -> backend 路由改造 + RAG hybrid_search 可配置

### DIFF
--- a/apisix/apisix.yaml
+++ b/apisix/apisix.yaml
@@ -118,6 +118,48 @@ upstreams:
           http_statuses: [500, 502, 503, 504]
           http_failures: 3
 
+  # Main app FastAPI - WebSocket (/ws task notifications, long-lived)
+  # Same nodes as backend; read 86400s aligns with nginx proxy_read_timeout so
+  # idle WS isn't dropped. retries:0 - never retry a long-lived connection.
+  - id: upstream-backend-ws
+    name: backend-ws
+    type: roundrobin
+    scheme: http
+    pass_host: pass
+    retries: 0
+    timeout:
+      connect: 5
+      send: 5
+      read: 86400
+    keepalive_pool:
+      size: 10
+      idle_timeout: 60
+      requests: 100
+    nodes:
+      "backend:8000": 1
+    checks:
+      active:
+        type: http
+        http_path: /health
+        timeout: 1
+        interval: 5
+        healthy:
+          interval: 5
+          successes: 2
+          http_statuses: [200]
+        unhealthy:
+          interval: 5
+          http_failures: 3
+          http_statuses: [404, 500, 502, 503, 504]
+      passive:
+        type: http
+        healthy:
+          http_statuses: [200]
+          successes: 2
+        unhealthy:
+          http_statuses: [500, 502, 503, 504]
+          http_failures: 3
+
   # app-task Go executor - /tasks/* user endpoints + /tasks/register
   - id: upstream-app-task
     name: app-task
@@ -245,6 +287,21 @@ routes:
         upstream_headers: [X-Uid]
         timeout: 5000
         status_code: 401
+
+  # User <-> main app chat (SSE under /chat/*; backend self-validates bili_session
+  # - no forward-auth, same as catch_all). Uses SSE upstream (retries:0, read 300s)
+  # so /chat/ask/stream isn't cut at catch_all's 30s read timeout.
+  - id: chat_sse
+    uris: [/chat, /chat/*]
+    priority: 50
+    upstream_id: upstream-backend-sse
+
+  # User <-> main app WebSocket (/ws task notifications, long-lived). WS upstream
+  # read 86400s aligns with nginx; APISIX passes Upgrade/Connection headers through.
+  - id: ws_notifications
+    uris: [/ws, /ws/*]
+    priority: 50
+    upstream_id: upstream-backend-ws
 
   # Catch-all: other main app endpoints (/auth, /chat, /favorites, /knowledge, ...)
   # -> backend (passthrough). Backend validates bili_session itself (get_current_uid).

--- a/app/config/config.yaml
+++ b/app/config/config.yaml
@@ -100,7 +100,7 @@ milvus:
   metric_type: COSINE                    # COSINE | L2 | IP
   nlist: 1024                            # IVF cluster count
   nprobe: 16                             # clusters searched per query
-  hybrid_search: false                   # dense+BM25 RRF fusion (requires BM25 schema; rebuild Milvus before enabling)
+  hybrid_search: true                   # dense+BM25 RRF fusion (requires Milvus 2.5+ for BM25 metric_type; rebuild Milvus before enabling)
 
 
 # ============================================================
@@ -137,7 +137,7 @@ redis:
 # MinIO / S3-compatible object storage
 # ============================================================
 minio:
-  enabled: false                         # enable when file uploads are needed
+  enabled: true                         # enable when file uploads are needed
   endpoint: http://localhost:9000
   region: us-east-1
   bucket: mind-base

--- a/app/repository/vector_store_milvus.py
+++ b/app/repository/vector_store_milvus.py
@@ -67,6 +67,11 @@ class MilvusVectorStore:
         self._collection_name = collection_name
         self._is_cloud = collection_name == config.cloud_collection_name
         self._analyzer = analyzer  # override config.analyzer for this collection
+        # Whether the collection schema includes the BM25 full-text search
+        # fields (text analyzer + sparse_embedding + BM25 Function).  Requires
+        # Milvus 2.5+ (metric_type="BM25"); on 2.4.x keep hybrid_search=False
+        # so the schema stays dense-only and collection init succeeds.
+        self._hybrid_enabled = bool(getattr(config, "hybrid_search", False))
         # Set to True by _ensure_collection when an existing collection was
         # dropped + recreated (e.g. embedding dim mismatch after model
         # change).  Callers (RAGService startup) check this flag to reset
@@ -292,6 +297,17 @@ class MilvusVectorStore:
                 self._collection_name,
             )
             return []
+        # Fast path: when hybrid_search is disabled the collection has no
+        # sparse_embedding field, so delegate to dense search directly
+        # (avoids a guaranteed-to-fail RPC + fallback log noise).
+        if not self._hybrid_enabled:
+            return self.search(
+                query,
+                k=k,
+                filter=filter,
+                partition_dt_start=partition_dt_start,
+                partition_dt_end=partition_dt_end,
+            )
         from pymilvus import AnnSearchRequest, RRFRanker
 
         query_embedding = self._embedding_fn.embed_query(query)
@@ -631,27 +647,52 @@ class MilvusVectorStore:
                 # drop and recreate (e.g. after embedding model change).
                 desc = self._client.describe_collection(self._collection_name)
                 expected_dim = self._config.dimension
+                recreate_reason: str | None = None
+
+                # Embedding dim mismatch (e.g. after embedding model change)
+                field_names: set[str] = set()
                 for field in desc.get("fields", []):
-                    if field.get("name") == "embedding":
+                    name = field.get("name")
+                    if name:
+                        field_names.add(name)
+                    if name == "embedding":
                         params = field.get("params") or field.get("typeParams") or {}
                         try:
                             existing_dim = int(params.get("dim", 0))
                         except (TypeError, ValueError):
                             existing_dim = 0
                         if existing_dim not in (0, expected_dim):
-                            logger.warning(
-                                "[MILVUS] collection '{}' has dim={}, expected={}, dropping to recreate",
-                                self._collection_name,
-                                existing_dim,
-                                expected_dim,
+                            recreate_reason = (
+                                f"dim mismatch (existing={existing_dim}, expected={expected_dim})"
                             )
-                            self._client.drop_collection(self._collection_name)
-                            # Signal callers that all prior vectors are gone
-                            # — DB vectorization statuses must be reset so
-                            # files get re-vectorized instead of being
-                            # skipped by the idempotency check.
-                            self.was_recreated = True
-                            break
+
+                # Hybrid schema mismatch: presence of sparse_embedding must
+                # match the hybrid_search flag.  Recovers half-created
+                # collections (sparse field added but index creation failed,
+                # e.g. Milvus 2.4 rejecting metric_type="BM25") and handles
+                # toggling hybrid on/off without manual drops.
+                has_sparse = "sparse_embedding" in field_names
+                if has_sparse and not self._hybrid_enabled:
+                    recreate_reason = recreate_reason or (
+                        "collection has sparse_embedding but hybrid_search disabled"
+                    )
+                elif not has_sparse and self._hybrid_enabled:
+                    recreate_reason = recreate_reason or (
+                        "hybrid_search enabled but collection lacks sparse_embedding"
+                    )
+
+                if recreate_reason:
+                    logger.warning(
+                        "[MILVUS] collection '{}' recreate: {}",
+                        self._collection_name,
+                        recreate_reason,
+                    )
+                    self._client.drop_collection(self._collection_name)
+                    # Signal callers that all prior vectors are gone
+                    # — DB vectorization statuses must be reset so
+                    # files get re-vectorized instead of being
+                    # skipped by the idempotency check.
+                    self.was_recreated = True
                 else:
                     self._client.load_collection(self._collection_name)
                     logger.info(
@@ -704,24 +745,33 @@ class MilvusVectorStore:
         schema.add_field(field_name="section_title", datatype=DataType.VARCHAR, max_length=256)
         schema.add_field(field_name="content_type", datatype=DataType.VARCHAR, max_length=32)
         schema.add_field(field_name="url", datatype=DataType.VARCHAR, max_length=512)
-        # text field with Chinese analyzer -> enables BM25 full-text search
-        schema.add_field(
-            field_name="text",
-            datatype=DataType.VARCHAR,
-            max_length=65535,
-            enable_analyzer=True,
-            analyzer_params={"type": self._analyzer or getattr(self._config, "analyzer", "chinese")},
-        )
-        # sparse vector auto-generated from text by the BM25 function
-        schema.add_field(field_name="sparse_embedding", datatype=DataType.SPARSE_FLOAT_VECTOR)
-        schema.add_function(
-            Function(
-                name="text_bm25",
-                input_field_names=["text"],
-                output_field_names=["sparse_embedding"],
-                function_type=FunctionType.BM25,
+        # text field: plain VARCHAR (dense-only) or analyzer-enabled (hybrid).
+        if self._hybrid_enabled:
+            # Full-text search: text analyzer + BM25 function -> sparse vector.
+            # Requires Milvus 2.5+ (metric_type="BM25"); on 2.4.x keep
+            # hybrid_search=False so this branch is skipped.
+            schema.add_field(
+                field_name="text",
+                datatype=DataType.VARCHAR,
+                max_length=65535,
+                enable_analyzer=True,
+                analyzer_params={"type": self._analyzer or getattr(self._config, "analyzer", "chinese")},
             )
-        )
+            schema.add_field(field_name="sparse_embedding", datatype=DataType.SPARSE_FLOAT_VECTOR)
+            schema.add_function(
+                Function(
+                    name="text_bm25",
+                    input_field_names=["text"],
+                    output_field_names=["sparse_embedding"],
+                    function_type=FunctionType.BM25,
+                )
+            )
+        else:
+            schema.add_field(
+                field_name="text",
+                datatype=DataType.VARCHAR,
+                max_length=65535,
+            )
         schema.add_field(
             field_name="embedding",
             datatype=DataType.FLOAT_VECTOR,
@@ -743,24 +793,33 @@ class MilvusVectorStore:
         schema.add_field(field_name="source_type", datatype=DataType.VARCHAR, max_length=16)
         schema.add_field(field_name="section_title", datatype=DataType.VARCHAR, max_length=256)
         schema.add_field(field_name="content_type", datatype=DataType.VARCHAR, max_length=32)
-        # text field with Chinese analyzer -> enables BM25 full-text search
-        schema.add_field(
-            field_name="text",
-            datatype=DataType.VARCHAR,
-            max_length=65535,
-            enable_analyzer=True,
-            analyzer_params={"type": self._analyzer or getattr(self._config, "analyzer", "chinese")},
-        )
-        # sparse vector auto-generated from text by the BM25 function
-        schema.add_field(field_name="sparse_embedding", datatype=DataType.SPARSE_FLOAT_VECTOR)
-        schema.add_function(
-            Function(
-                name="text_bm25",
-                input_field_names=["text"],
-                output_field_names=["sparse_embedding"],
-                function_type=FunctionType.BM25,
+        # text field: plain VARCHAR (dense-only) or analyzer-enabled (hybrid).
+        if self._hybrid_enabled:
+            # Full-text search: text analyzer + BM25 function -> sparse vector.
+            # Requires Milvus 2.5+ (metric_type="BM25"); on 2.4.x keep
+            # hybrid_search=False so this branch is skipped.
+            schema.add_field(
+                field_name="text",
+                datatype=DataType.VARCHAR,
+                max_length=65535,
+                enable_analyzer=True,
+                analyzer_params={"type": self._analyzer or getattr(self._config, "analyzer", "chinese")},
             )
-        )
+            schema.add_field(field_name="sparse_embedding", datatype=DataType.SPARSE_FLOAT_VECTOR)
+            schema.add_function(
+                Function(
+                    name="text_bm25",
+                    input_field_names=["text"],
+                    output_field_names=["sparse_embedding"],
+                    function_type=FunctionType.BM25,
+                )
+            )
+        else:
+            schema.add_field(
+                field_name="text",
+                datatype=DataType.VARCHAR,
+                max_length=65535,
+            )
         schema.add_field(
             field_name="embedding",
             datatype=DataType.FLOAT_VECTOR,
@@ -778,12 +837,17 @@ class MilvusVectorStore:
             metric_type=self._config.metric_type,
             params=params,
         )
-        # sparse vector index for BM25 full-text search (hybrid retrieval)
-        index_params.add_index(
-            field_name="sparse_embedding",
-            index_type="SPARSE_INVERTED_INDEX",
-            metric_type="BM25",
-        )
+        # sparse vector index for BM25 full-text search (hybrid retrieval).
+        # Only added when hybrid_search is enabled; the sparse_embedding field
+        # exists in the schema only when _hybrid_enabled is True.  Milvus 2.4.x
+        # rejects metric_type="BM25" (only IP supported for sparse), so the
+        # flag must stay False on 2.4.x.
+        if self._hybrid_enabled:
+            index_params.add_index(
+                field_name="sparse_embedding",
+                index_type="SPARSE_INVERTED_INDEX",
+                metric_type="BM25",
+            )
         return index_params
 
     def _index_type_for_logging(self, collection_name: str, current_vector_count: int) -> str:

--- a/app/services/rag/legacy.py
+++ b/app/services/rag/legacy.py
@@ -129,6 +129,19 @@ class RAGService:
                 logger.info(
                     "[RAG] vectorstore initialized: {}", config.milvus.collection_name
                 )
+                # If the collection was dropped+recreated (dim mismatch or
+                # hybrid_search schema mismatch), all prior vectors are gone.
+                # Reset every video page marked "done" back to "pending" so the
+                # next build re-vectorizes it - otherwise the idempotency guard
+                # in vectorize.py would skip them forever and pages stay
+                # unsearchable.  Mirrors the cloud_backend reset below.
+                if getattr(self.vectorstore, "was_recreated", False):
+                    logger.warning(
+                        "[RAG] bilibili_videos collection was recreated "
+                        "(dim/hybrid schema mismatch) - resetting is_vectorized "
+                        "for all done video pages to pending"
+                    )
+                    self._reset_video_vector_statuses()
             except Exception as e:
                 logger.warning(
                     "[RAG] vectorstore init failed: error_type={}",
@@ -896,6 +909,49 @@ class RAGService:
             # No running loop (e.g. constructing outside an event loop) —
             # run synchronously as a fallback.  This blocks init briefly
             # but guarantees the reset happens.
+            import asyncio as _aio
+
+            _aio.run(_reset())
+
+    def _reset_video_vector_statuses(self) -> None:
+        """Reset all video pages marked ``done`` back to ``pending``.
+
+        Mirrors :meth:`_reset_cloud_vector_statuses` for the bilibili_videos
+        collection.  Called from ``__init__`` when that collection was
+        recreated (dim mismatch or hybrid_search schema mismatch).
+        """
+        import asyncio
+
+        async def _reset() -> None:
+            from sqlalchemy import text
+            from app.database import async_session_factory
+
+            try:
+                async with async_session_factory() as session:
+                    result = await session.execute(
+                        text(
+                            "UPDATE video "
+                            "SET is_vectorized = 'pending', "
+                            "    vector_chunk_count = 0, "
+                            "    vector_error = NULL, "
+                            "    vector_asr_version = NULL "
+                            "WHERE is_vectorized = 'done'"
+                        )
+                    )
+                    await session.commit()
+                    logger.warning(
+                        "[RAG] reset {} video pages from done -> pending "
+                        "(collection was recreated, vectors lost)",
+                        result.rowcount,
+                    )
+            except Exception:
+                logger.exception("[RAG] failed to reset video vector statuses")
+
+        try:
+            loop = asyncio.get_running_loop()
+            loop.create_task(_reset())
+        except RuntimeError:
+            # No running loop - run synchronously as a fallback.
             import asyncio as _aio
 
             _aio.run(_reset())

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,7 +108,7 @@ services:
       # no effect on them). Source lives in frontendv2/ (frontend/ is deprecated).
       args:
         NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-}
-        NEXT_PUBLIC_APISIX_HOST: ${NEXT_PUBLIC_APISIX_HOST:-}
+        NEXT_PUBLIC_APISIX_HOST: nginx:80
     container_name: mind-base-frontend
     # Port exposed for local access; in production nginx handles all traffic
     ports:
@@ -116,6 +116,7 @@ services:
     environment:
       - NODE_ENV=production
       - NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL:-}
+      - NEXT_PUBLIC_APISIX_HOST=nginx:80
     depends_on:
       backend:
         condition: service_healthy
@@ -362,8 +363,10 @@ services:
       # to be healthy first so APISIX doesn't crash on startup.
       etcd:
         condition: service_healthy
-    ports:
-      - "${APISIX_PORT:-9080}:9080"
+    # No host port mapping: apisix must only be reachable inside mind-base-net
+    # (nginx -> apisix -> backend). Exposing 9080 to the host lets external
+    # clients bypass nginx (SSL/cache/rate-limit). To debug apisix directly,
+    # `docker compose exec apisix ...` or temporarily re-add `ports: ["9080:9080"]`.
     volumes:
       - ./apisix/config.yaml:/usr/local/apisix/conf/config.yaml:ro
       - ./apisix/apisix.yaml:/usr/local/apisix/conf/apisix.yaml:ro
@@ -387,7 +390,7 @@ services:
       - no_proxy=etcd,backend,app-task,minio,mysql,mongo,redis,apisix,frontend,nginx,localhost,127.0.0.1
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9090/apisix/status"]
+      test: ["CMD-SHELL", "grep -q ':2382 .* 0A ' /proc/net/tcp || exit 1"]
       interval: 15s
       timeout: 5s
       retries: 3

--- a/frontendv2/lib/api/client.ts
+++ b/frontendv2/lib/api/client.ts
@@ -11,9 +11,18 @@
 
 import { sanitizeError } from "@/lib/error-utils";
 
+// SSR base URL: when NEXT_PUBLIC_API_URL is unset (relative-path mode), the
+// browser uses "" (current origin = nginx). But Next.js server-side fetches
+// (SSR/RSC) have no origin, so they need an absolute internal URL. Route them
+// through nginx too (NOT direct backend:8000) so SSR traffic stays behind the
+// nginx -> apisix -> backend chain and benefits from load balancing.
+// NEXT_PUBLIC_APISIX_HOST is inlined at build time: docker-compose sets it to
+// "nginx:80"; local dev falls back to "localhost:9080" (apisix on host/VM).
+const INTERNAL_API_HOST = process.env.NEXT_PUBLIC_APISIX_HOST || "localhost:9080";
+
 export const API_BASE_URL =
     process.env.NEXT_PUBLIC_API_URL ||
-    (typeof window !== "undefined" ? "" : "http://backend:8000");
+    (typeof window !== "undefined" ? "" : `http://${INTERNAL_API_HOST}`);
 
 // Authorization header built from the bili_session token in localStorage.
 export function getAuthHeaders(): Record<string, string> {

--- a/frontendv2/next.config.ts
+++ b/frontendv2/next.config.ts
@@ -1,6 +1,6 @@
 import type { NextConfig } from "next";
 
-const APISIX_HOST = process.env.NEXT_PUBLIC_APISIX_HOST || "192.168.138.128:9080";
+const APISIX_HOST = process.env.NEXT_PUBLIC_APISIX_HOST || "localhost:9080";
 
 const nextConfig: NextConfig = {
   output: "standalone",

--- a/nginx/locations.conf
+++ b/nginx/locations.conf
@@ -46,7 +46,7 @@ location /auth {
     limit_req zone=auth burst=3 nodelay;
     limit_conn conn_per_ip 5;
     proxy_cache off;
-    proxy_pass http://backend;
+    proxy_pass http://apisix;
 }
 
 # Chat - SSE streaming, MUST NOT cache or buffer
@@ -56,7 +56,7 @@ location /chat {
     proxy_cache off;
     proxy_buffering off;
     proxy_read_timeout 300s;
-    proxy_pass http://backend;
+    proxy_pass http://apisix;
 }
 
 # Favorites - read-heavy, short cache to avoid repeated B站 API calls
@@ -68,7 +68,7 @@ location /favorites {
     proxy_cache_valid 200 30s;
     proxy_cache_valid 404 10s;
     add_header X-Cache-Status $upstream_cache_status;
-    proxy_pass http://backend;
+    proxy_pass http://apisix;
 }
 
 # Knowledge - read-heavy folder/video status
@@ -78,23 +78,23 @@ location /knowledge {
     proxy_cache_key "$scheme$request_method$host$request_uri";
     proxy_cache_valid 200 10s;
     add_header X-Cache-Status $upstream_cache_status;
-    proxy_pass http://backend;
+    proxy_pass http://apisix;
 }
 
 # ASR - no cache (status polling)
-location /asr         { proxy_pass http://backend; }
-location /vec         { proxy_pass http://backend; }
+location /asr         { proxy_pass http://apisix; }
+location /vec         { proxy_pass http://apisix; }
 
 # Credentials / settings - strict, no cache
 location /credentials {
     limit_req zone=auth burst=3 nodelay;
     proxy_cache off;
-    proxy_pass http://backend;
+    proxy_pass http://apisix;
 }
 location /settings {
     limit_req zone=auth burst=3 nodelay;
     proxy_cache off;
-    proxy_pass http://backend;
+    proxy_pass http://apisix;
 }
 
 # Billing - read-only, medium cache
@@ -104,7 +104,7 @@ location /billing {
     proxy_cache_key "$scheme$request_method$host$request_uri";
     proxy_cache_valid 200 60s;
     add_header X-Cache-Status $upstream_cache_status;
-    proxy_pass http://backend;
+    proxy_pass http://apisix;
 }
 
 # Public shared quiz - cacheable (no auth, content is public).
@@ -118,13 +118,13 @@ location /quiz/shared/ {
     proxy_cache_valid 200 60s;
     proxy_cache_valid 404 10s;   # absorb token-guessing traffic
     add_header X-Cache-Status $upstream_cache_status;
-    proxy_pass http://backend;
+    proxy_pass http://apisix;
 }
 
 # Quiz (authed endpoints) - moderate, no cache
 location /quiz {
     limit_req zone=api burst=10 nodelay;
-    proxy_pass http://backend;
+    proxy_pass http://apisix;
 }
 
 # Public shared note - cacheable (no auth, content is public).
@@ -138,13 +138,13 @@ location /notes/shared/ {
     proxy_cache_valid 200 60s;
     proxy_cache_valid 404 10s;   # absorb token-guessing traffic
     add_header X-Cache-Status $upstream_cache_status;
-    proxy_pass http://backend;
+    proxy_pass http://apisix;
 }
 
 # Notes (authed endpoints) - moderate, no cache
 location /notes {
     limit_req zone=api burst=10 nodelay;
-    proxy_pass http://backend;
+    proxy_pass http://apisix;
 }
 
 # Health / docs / OpenAPI - cacheable
@@ -154,21 +154,21 @@ location /health {
     proxy_cache_key "$host$request_uri";
     proxy_cache_valid 200 5s;
     add_header X-Cache-Status $upstream_cache_status;
-    proxy_pass http://backend;
+    proxy_pass http://apisix;
 }
-location /docs        { proxy_pass http://backend; }
+location /docs        { proxy_pass http://apisix; }
 location /openapi.json {
     proxy_buffering on;
     proxy_cache api_cache;
     proxy_cache_key "$host$request_uri";
     proxy_cache_valid 200 1h;
     add_header X-Cache-Status $upstream_cache_status;
-    proxy_pass http://backend;
+    proxy_pass http://apisix;
 }
 
 # ---- Wallpaper: custom (backend -> MinIO) + presets (frontend static) ----
 location /wallpaper/file/ {
-    proxy_pass http://backend;
+    proxy_pass http://apisix;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -229,6 +229,7 @@ location /cloud/ {
     limit_req zone=api burst=30 nodelay;
     limit_conn conn_per_ip 10;
     client_max_body_size 5g;
+    # Large file upload: bypass apisix (avoids global body-limit bump + buffering)
     proxy_pass http://backend;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
@@ -249,14 +250,14 @@ location /workspaces {
     proxy_cache_bypass $ws_bypass;
     proxy_no_cache $ws_bypass;
     add_header X-Cache-Status $upstream_cache_status;
-    proxy_pass http://backend;
+    proxy_pass http://apisix;
 }
 
-location /cache       { proxy_pass http://backend; }
+location /cache       { proxy_pass http://apisix; }
 
 # ---- WebSocket for task notifications ----
 location /ws {
-    proxy_pass            http://backend;
+    proxy_pass            http://apisix;
     proxy_set_header      Upgrade           $http_upgrade;
     proxy_set_header      Connection        "upgrade";
     proxy_read_timeout    86400s;

--- a/scripts/rebuild_milvus.py
+++ b/scripts/rebuild_milvus.py
@@ -1,12 +1,13 @@
-"""Rebuild Milvus collections with BM25 schema and reset vectorization statuses.
+"""Rebuild Milvus collections and reset vectorization statuses.
 
 Drop + recreate both bilibili_videos and cloud_drive collections so they pick
-up the BM25 sparse_embedding field required by hybrid_search, then reset every
-video page and cloud file back to "pending" so the next build re-vectorizes
-them with the new SemanticChunker.
+up the current schema (dense-only by default; BM25 sparse_embedding fields
+when MILVUS__HYBRID_SEARCH=true, which requires Milvus 2.5+), then reset
+every video page and cloud file back to "pending" so the next build
+re-vectorizes them.
 
 DESTRUCTIVE: all existing vectors are lost. Run only when switching chunker /
-embedding model / enabling hybrid_search.
+embedding model / toggling hybrid_search / recovering a broken collection.
 
 Usage:
     python scripts/rebuild_milvus.py
@@ -25,7 +26,7 @@ from app.services.rag import RAGService
 
 
 async def rebuild() -> None:
-    print("=== Rebuilding Milvus collections (BM25 schema) ===")
+    print("=== Rebuilding Milvus collections ===")
     rag = RAGService()
 
     if rag.vectorstore is None:
@@ -64,8 +65,8 @@ async def rebuild() -> None:
     print("Next steps:")
     print("  1. Re-vectorize: start the server, then POST /knowledge/build")
     print("     (or use the frontend knowledge-base panel)")
-    print("  2. Enable hybrid search: set MILVUS__HYBRID_SEARCH=true")
-    print("     (or add 'hybrid_search: true' under milvus: in config.yaml)")
+    print("  2. (Optional) Enable hybrid search: set MILVUS__HYBRID_SEARCH=true")
+    print("     (requires Milvus 2.5+; add 'hybrid_search: true' under milvus: in config.yaml)")
     print("  3. Verify: python -m app.test.rag.diagnose_rag")
 
 


### PR DESCRIPTION
## Summary

两个独立改进,分两个 commit。

---

### 1. [infra] 前端流量全走 nginx -> apisix -> backend

**动机**:为后期 apisix 层负载均衡铺路,关闭所有绕过 nginx 的旁路。此前 nginx 对大部分 API 直连 backend(绕过 apisix),且 apisix 对外暴露 9080 可被直达,等于在 nginx 旁开了第二入口。

**改动**:
- `nginx/locations.conf`:后端路由 upstream 从 `backend` 改为 `apisix`(`/cloud/` 5g 大文件保留直连,避免 apisix body limit)
- `apisix/apisix.yaml`:新增 `upstream-backend-ws` + `/chat` `/ws` 专用路由(catch_all 的 30s 会截断 SSE/WebSocket);普通 API 走 `catch_all /* -> backend`
- `docker-compose.yml`:关闭 apisix 对外 9080 端口(仅 nginx 可达);frontend `NEXT_PUBLIC_APISIX_HOST` 写死 `nginx:80`(不走 .env)
- `frontendv2/lib/api/client.ts`:SSR fallback 从 `http://backend:8000` 改为经 nginx
- `frontendv2/next.config.ts`:APISIX_HOST dev fallback 改为 `localhost:9080`

**流量路径(改造后)**:
```
浏览器 -> nginx:80 -> apisix:9080 -> backend / app-task
                    └ /cloud/ 直连 backend(5g 大文件)
                    └ /minio-proxy/ /cloud-stream/ 直连 minio
```

---

### 2. [rag] hybrid_search 可配置 + collection 重建后重置 video 向量状态

**改动**:
- `vector_store_milvus.py`:`hybrid_search` 开关控制 BM25 schema,禁用时 dense-only(Milvus 2.4 兼容);hybrid 禁用时 fast-path 走 dense search 避免失败 RPC;collection 重建检测增加 hybrid schema mismatch 判断
- `legacy.py`:collection 重建后(`was_recreated`)重置 `video.is_vectorized` done->pending,镜像 cloud reset,避免 idempotency guard 跳过失效页
- `rebuild_milvus.py`:文档更新,hybrid 标注 Milvus 2.5+ 要求
- `config.yaml`:`hybrid_search=true`,`minio.enabled=true`

---

## Test plan

- [ ] `docker compose up -d --build` 全栈启动无错
- [ ] `curl http://localhost:9080/health` 连接失败(apisix 不再对外)
- [ ] `curl http://localhost:80/health` 经 nginx->apisix->backend 返回 200
- [ ] `curl -N -X POST http://localhost:80/chat/ask/stream`(带 token)SSE 流式 >30s 不截断
- [ ] WebSocket `/ws` 建连后空闲 5 分钟不断
- [ ] `/cloud/` 上传 5g 文件仍走 nginx->backend 直连
- [ ] `/auth/qrcode` 登录流程正常(走 catch_all -> backend)
- [ ] `/tasks` `/task-quiz/chat` 经 apisix forward-auth 注入 X-Uid 正常
- [ ] RAG:hybrid_search=true 下 Milvus 2.5 collection 含 sparse_embedding;collection 重建后 video.is_vectorized 重置 pending

## 不在范围
- frontend `next.config.ts` rewrites 在 dev 模式仍直连 apisix(dev 无 nginx,合理)
- backend/app-task 服务间调用仍 `apisix:9080` 直连(key-auth/forward-auth 链路不变)