### PR TITLE
[infra] fix: frontendv2 stream 直连 + skills 路由缺失

### DIFF
--- a/frontendv2/lib/api/chat.ts
+++ b/frontendv2/lib/api/chat.ts
@@ -117,13 +117,14 @@ export const chatApi = {
         payload: ChatRequestPayload,
         signal?: AbortSignal
     ): Promise<ReadableStream<Uint8Array>> => {
-        const streamBase =
-            API_BASE_URL ||
-            (typeof window !== "undefined"
-                ? process.env.NEXT_PUBLIC_APISIX_HOST
-                    ? `http://${process.env.NEXT_PUBLIC_APISIX_HOST}`
-                    : "http://localhost:8000"
-                : "http://backend:8000");
+        // Use API_BASE_URL directly: in the browser it's "" (relative) so fetch
+        // hits the current origin (nginx in prod, which has proxy_buffering off
+        // for /chat); SSR gets the internal absolute URL (http://nginx:80). Do
+        // NOT fall back to NEXT_PUBLIC_APISIX_HOST - in docker prod it's the
+        // container name "nginx:80" which the browser can't DNS-resolve, which
+        // was the root cause of "生成失败". Dev: set NEXT_PUBLIC_API_URL to an
+        // absolute apisix URL to bypass dev-proxy SSE buffering.
+        const streamBase = API_BASE_URL;
         const res = await fetch(`${streamBase}/chat/ask/agent/stream`, {
             method: "POST",
             headers: { "Content-Type": "application/json", ...getAuthHeaders() },

--- a/frontendv2/lib/api/task-quiz.ts
+++ b/frontendv2/lib/api/task-quiz.ts
@@ -118,13 +118,11 @@ export const taskQuizApi = {
         handlers: TaskQuizStreamHandlers,
         signal?: AbortSignal,
     ): Promise<void> => {
-        const streamBase =
-            API_BASE_URL ||
-            (typeof window !== "undefined"
-                ? process.env.NEXT_PUBLIC_APISIX_HOST
-                    ? `http://${process.env.NEXT_PUBLIC_APISIX_HOST}`
-                    : "http://localhost:8000"
-                : "http://backend:8000");
+        // Use API_BASE_URL directly: browser "" (relative) -> nginx; SSR gets
+        // http://nginx:80. Do NOT fall back to NEXT_PUBLIC_APISIX_HOST - in
+        // docker prod it's the container name "nginx:80" which the browser
+        // can't DNS-resolve. Mirrors chatApi.askStream's stream-base resolution.
+        const streamBase = API_BASE_URL;
 
         const resp = await fetch(`${streamBase}/task-quiz/chat`, {
             method: "POST",

--- a/nginx/locations.conf
+++ b/nginx/locations.conf
@@ -83,6 +83,7 @@ location /knowledge {
 
 # ASR - no cache (status polling)
 location /asr         { proxy_pass http://apisix; }
+location /skills      { proxy_pass http://apisix; }
 location /vec         { proxy_pass http://apisix; }
 
 # Credentials / settings - strict, no cache


### PR DESCRIPTION
## 概述

PR #59 合并后续发现的两个链路问题修复。

## 改动

### [frontend] fix: stream 直连容器名 nginx:80 浏览器无法解析导致"生成失败" (93fc06a)
- **根因**：`askStream` / `streamChat` 的 `streamBase = API_BASE_URL || fallback`，浏览器端 `API_BASE_URL` 是 `""`（相对路径，falsy），fallthrough 到 `http://${NEXT_PUBLIC_APISIX_HOST}`。docker build 时该值为容器名 `nginx:80`，浏览器无法 DNS 解析 -> fetch 失败 -> "生成失败"
- 普通请求走 `request()`（`API_BASE_URL=""` 相对路径 -> nginx）正常，所以 `/chat/sessions` 等 200，只有 stream 失败
- **修复**：`streamBase` 直接用 `API_BASE_URL`（浏览器 `""` 相对路径走 nginx，SSR 是容器内绝对 URL）

### [infra] fix: nginx 缺 /skills location 导致请求转发到 frontend (5b71af0)
- **根因**：nginx `locations.conf` 无 `/skills` location，`/skills/*` 走 default `location / { proxy_pass http://frontend }` -> 转发到 Next.js 返回 HTML，没到 apisix/backend
- **修复**：加 `location /skills { proxy_pass http://apisix; }`，与 `/asr` `/vec` 一致

## 测试计划

- [ ] stream：frontendv2 对话流式正常（重建 frontendv2 容器后）
- [ ] skills：`docker compose exec nginx nginx -s reload` 后，skills 商店列表加载正常
