### PR TITLE
feat: ASR 长音频可靠性 + embedding 维度修正 1536→1024 + 收藏夹同步后台化

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -207,6 +207,17 @@ APISIX_CONSUMER_KEY=mindbase-internal-key-change-me
 # APISIX_ADMIN_KEY=admin-key-change-me
 
 # ============================================================
+# docker-compose 自建镜像 tag(默认 :latest)
+# ------------------------------------------------------------
+# 固定 tag 每次重新构建会把旧镜像变成 <none>:<none> 悬空镜像并堆积占盘。
+# 建议覆盖为版本化 tag(如 commit sha),或使用 scripts/docker-build.ps1
+# (构建后自动 docker image prune -f 清理悬空镜像,不影响有 tag 的镜像)。
+# BACKEND_IMAGE=ghcr.io/atoncooper/mind-base-backend:latest
+# FRONTEND_IMAGE=ghcr.io/atoncooper/mind-base-frontend:latest
+# APPTASK_IMAGE=ghcr.io/atoncooper/mind-base-app-task:latest
+# ============================================================
+
+# ============================================================
 # 已废弃 —— 这些字段已迁移到 app/config/*.yaml
 # ------------------------------------------------------------
 # DASHSCOPE_API_KEY      → LLM__API_KEY(本文件)

--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,6 @@ app/test/rag/data/
 
 # Stray dev screenshots at repo root
 /forgot-password-light.png
+
+# reasonix
+reasonix.toml

--- a/app-task/Dockerfile
+++ b/app-task/Dockerfile
@@ -1,6 +1,6 @@
 # ====== app-task: independent task executor (Go) ======
 # Multi-stage build: compile static binary, ship on distroless.
-FROM golang:1.22-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 WORKDIR /src
 

--- a/app/config/config.yaml
+++ b/app/config/config.yaml
@@ -87,7 +87,7 @@ rdbms:
 # Milvus — vector database
 # ============================================================
 # Start standalone: docker run -d --name milvus-standalone \
-#     -p 19530:19530 -p 9091:9091 milvusdb/milvus:v2.4.17
+#     -p 19530:19530 -p 9091:9091 milvusdb/milvus:v2.6.22
 milvus:
   enabled: true
   uri: ""                                # e.g. http://milvus-host:19530 — inject via MILVUS__URI
@@ -95,7 +95,7 @@ milvus:
   db_name: mind_base
   collection_name: bilibili_videos
   cloud_collection_name: cloud_drive
-  dimension: 1536                        # must match embedding.dimension
+  dimension: 1024                        # must match embedding.dimension
   index_type: IVF_FLAT                   # IVF_FLAT | IVF_SQ8 | HNSW
   metric_type: COSINE                    # COSINE | L2 | IP
   nlist: 1024                            # IVF cluster count
@@ -182,9 +182,9 @@ llm:
 # Embedding — text-to-vector model
 # ============================================================
 embedding:
-  model: text-embedding-v4               # DashScope, 1536-dimensional
+  model: text-embedding-v4               # DashScope, 1024-dim (default; v4 supports 1024/1536/2048)
   batch_size: 100                        # texts per embedding API call
-  dimension: 1536                        # must match Milvus dimension
+  dimension: 1024                        # must match Milvus dimension
   version: v1                            # bump when changing model or chunk strategy
                                           # (triggers full re-index of existing vectors)
 
@@ -213,10 +213,13 @@ agentic:
 asr:
   provider: dashscope                    # dashscope | whisper | funasr
   base_url: https://dashscope.aliyuncs.com/api/v1
-  model: paraformer-realtime-v2          # 本地直传 Recognition 接口支持
+  model: paraformer-realtime-v2          # Recognition (sync, realtime) model — short audio only
   model_local: paraformer-realtime-v2    # streaming / real-time model
+  transcription_model: paraformer-v2     # async Transcription model — long audio (>= realtime_max_seconds)
   input_format: pcm                      # audio format sent to ASR API
-  timeout: 600                           # per-task timeout (seconds)
+  timeout: 600                           # per-task timeout for async Transcription (seconds)
+  realtime_max_seconds: 60               # above this, split into chunks (single Recognition call hangs on long audio)
+  recognition_timeout: 90               # forced-stop timeout for a single Recognition call (WebSocket stall guard)
   # api_key via env: ASR__API_KEY
   # If ASR__API_KEY is unset, falls back to LLM__API_KEY.
 

--- a/app/config/default.yaml
+++ b/app/config/default.yaml
@@ -60,7 +60,7 @@ milvus:
   db_name: MindBase
   collection_name: bilibili_videos
   cloud_collection_name: cloud_drive
-  dimension: 1536
+  dimension: 1024
   index_type: IVF_FLAT
   metric_type: COSINE
   analyzer: chinese              # text analyzer: chinese (jieba) for B站中文, standard for English
@@ -149,9 +149,9 @@ llm:
 
 # ---- Embedding ----------------------------------------------------
 embedding:
-  model: text-embedding-v4            # DashScope, 1536-dim
+  model: text-embedding-v4            # DashScope, 1024-dim (default; v4 supports 1024/1536/2048)
   batch_size: 100
-  dimension: 1536
+  dimension: 1024
   version: v1                         # bump when changing chunk strategy or model
 
 
@@ -191,10 +191,13 @@ rerank:
 asr:
   provider: dashscope                 # dashscope | whisper | funasr
   base_url: https://dashscope.aliyuncs.com/api/v1
-  model: paraformer-v2                # offline model
+  model: paraformer-realtime-v2       # Recognition (sync) API model; paraformer-v2 is for async Transcription API
   model_local: paraformer-realtime-v2 # streaming model
+  transcription_model: paraformer-v2  # async Transcription model - long audio (>= realtime_max_seconds)
   input_format: pcm
-  timeout: 600                        # per-task timeout (seconds)
+  timeout: 600                        # per-task timeout for async Transcription (seconds)
+  realtime_max_seconds: 60            # above this, route to async Transcription (Recognition hangs on long audio)
+  recognition_timeout: 90            # forced-stop timeout for a single Recognition call (WebSocket stall guard)
   # api_key via env: ASR__API_KEY; falls back to LLM__API_KEY
 
 

--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -168,6 +168,24 @@ class _Settings:
     def asr_input_format(self) -> str:
         return str(_get("asr", "input_format", default="pcm"))
 
+    @property
+    def asr_transcription_model(self) -> str:
+        return str(_get("asr", "transcription_model", default="paraformer-v2"))
+
+    @property
+    def asr_realtime_max_seconds(self) -> int:
+        return int(_get("asr", "realtime_max_seconds", default=60))
+
+    @property
+    def asr_recognition_timeout(self) -> int:
+        return int(_get("asr", "recognition_timeout", default=90))
+
+    @property
+    def asr_api_key(self) -> str:
+        """ASR key; falls back to LLM key when ASR__API_KEY is unset."""
+        key = str(_get("asr", "api_key", default="") or "")
+        return key or self.openai_api_key
+
     # ── LangSmith ────────────────────────────────────────────────
 
     @property

--- a/app/infra/config.py
+++ b/app/infra/config.py
@@ -296,8 +296,19 @@ class AsrSection(_Section):
     base_url: str = "https://dashscope.aliyuncs.com/api/v1"
     model: str = "paraformer-v2"
     model_local: str = "paraformer-realtime-v2"
+    # Async Transcription API model for long audio (supports hours).
+    # Recognition (realtime) hangs on multi-minute files; long audio is
+    # uploaded to DashScope OSS then transcribed via this model.
+    transcription_model: str = "paraformer-v2"
     input_format: str = "pcm"
     timeout: int = 600
+    # Audio above this duration (seconds) uses async Transcription instead
+    # of sync Recognition, which hangs on long files.
+    realtime_max_seconds: int = 60
+    # Forced-stop timeout (seconds) for a single Recognition call. If the
+    # WebSocket stalls, the call is abandoned (via ThreadPoolExecutor) so
+    # the task progresses instead of hanging.
+    recognition_timeout: int = 90
     api_key: SecretStr = Field(
         default=SecretStr(""),
         validation_alias=AliasChoices("ASR__API_KEY", "DASHSCOPE_API_KEY"),

--- a/app/routers/knowledge.py
+++ b/app/routers/knowledge.py
@@ -158,51 +158,35 @@ async def get_vectorized_pages(
     return [VectorizedPageItem(**r) for r in rows]
 
 
-@router.post("/folders/sync", response_model=List[SyncResult])
+@router.post("/folders/sync")
 async def sync_folders(
     request: SyncRequest,
     uid: int = Depends(get_current_uid),
     db: AsyncSession = Depends(get_db),
 ):
-    """同步收藏夹到向量库"""
-    from app.services.knowledge_build import KnowledgeSyncService
+    """同步收藏夹到向量库（后台任务，与 /knowledge/build 同路径）。
+
+    历史实现在 HTTP 请求内串行 await sync_folder，收藏夹稍大即超过
+    网关超时。现改为立即返回 task_id，前端轮询 /knowledge/build/status/{id}。
+    """
+    from app.services.knowledge_build import get_build_service
 
     bili, bili_mid = await _get_bili_cookies_by_uid(uid, db)
-    rag = get_rag_service()
-    asr_service = ASRService()
-    content_fetcher = ContentFetcher(bili, asr_service)
-    sync_service = KnowledgeSyncService()
-
+    sessdata = bili.sessdata
     try:
-        folder_ids = request.folder_ids or []
+        folder_ids = list(request.folder_ids or [])
         if not folder_ids:
             folders = await bili.get_user_favorites(mid=bili_mid)
             folder_ids = [f.get("id") for f in folders if f.get("id")]
-
-        results: List[SyncResult] = []
-        for folder_id in folder_ids:
-            try:
-                result = await sync_service.sync_folder(
-                    db, bili, rag, content_fetcher, uid, folder_id
-                )
-                results.append(SyncResult(**result))
-            except Exception as e:
-                logger.exception("Folder sync failed folder_id={}", folder_id)
-                results.append(
-                    SyncResult(
-                        folder_id=folder_id,
-                        total=0,
-                        added=0,
-                        removed=0,
-                        indexed=0,
-                        message=f"同步失败: {e}",
-                        last_sync_at=None,
-                    )
-                )
-
-        return results
     finally:
         await bili.close()
+
+    return await get_build_service().try_start_build(
+        uid=uid,
+        folder_ids=folder_ids,
+        exclude_bvids=[],
+        sessdata=sessdata,
+    )
 
 
 @router.post("/build")

--- a/app/routers/knowledge.py
+++ b/app/routers/knowledge.py
@@ -19,8 +19,6 @@ from app.database import get_db, get_db_context
 from app.infra.errors import internal_error
 from app.response.knowledge import VideoInfo, VideosResponse
 from app.services.bilibili import BilibiliService
-from app.services.asr import ASRService
-from app.services.content_fetcher import ContentFetcher
 from app.services.rag import get_rag_service
 from app.routers.auth import get_current_uid, require_admin, _get_bili_cookies_by_uid
 from app.utils.cache import cache_dependency_singleton

--- a/app/services/asr.py
+++ b/app/services/asr.py
@@ -9,7 +9,6 @@ import json
 import os
 import shutil
 import subprocess
-import threading
 import time
 from http import HTTPStatus
 from typing import Optional, Any

--- a/app/services/asr.py
+++ b/app/services/asr.py
@@ -9,6 +9,7 @@ import json
 import os
 import shutil
 import subprocess
+import threading
 import time
 from http import HTTPStatus
 from typing import Optional, Any
@@ -35,12 +36,20 @@ class ASRService:
         model: Optional[str] = None,
         timeout: Optional[int] = None,
     ):
-        self.api_key = api_key or settings.openai_api_key
-        self.base_url = base_url or getattr(settings, "dashscope_base_url", None)
-        self.model = model or getattr(settings, "asr_model", "fun-asr")
-        self.timeout = timeout or getattr(settings, "asr_timeout", 600)
-        self.local_model = getattr(settings, "asr_model_local", self.model)
-        self.input_format = getattr(settings, "asr_input_format", "pcm")
+        # Prefer ASR__API_KEY, then LLM__API_KEY (shared DashScope account).
+        self.api_key = api_key or settings.asr_api_key
+        self.base_url = base_url or settings.dashscope_base_url
+        self.model = model or settings.asr_model
+        self.timeout = timeout or settings.asr_timeout
+        self.local_model = settings.asr_model_local or self.model
+        self.input_format = settings.asr_input_format
+        # Long-audio: prefer async Transcription (transcription_model); fall
+        # back to timed PCM chunk Recognition if upload/Transcription fails.
+        # Recognition.call() has no SDK timeout and stalls on multi-minute
+        # files — never feed long audio to a single Recognition call.
+        self.transcription_model = settings.asr_transcription_model
+        self.realtime_max_seconds = settings.asr_realtime_max_seconds
+        self.recognition_timeout = settings.asr_recognition_timeout
 
     def _configure(self) -> None:
         if not self.api_key:
@@ -130,6 +139,64 @@ class ASRService:
             logger.warning(f"转码 WAV 异常: {e}")
             return None
 
+    def _probe_duration(self, file_path: str) -> Optional[float]:
+        """Probe audio duration in seconds via ffprobe. Returns None on failure."""
+        try:
+            result = subprocess.run(
+                [
+                    "ffprobe", "-v", "error",
+                    "-show_entries", "format=duration",
+                    "-of", "default=noprint_wrappers=1:nokey=1",
+                    file_path,
+                ],
+                capture_output=True,
+                text=True,
+                timeout=15,
+            )
+            if result.returncode == 0:
+                return float(result.stdout.strip())
+        except Exception as e:
+            logger.debug(f"ffprobe 探测时长失败: {e}")
+        return None
+
+    @staticmethod
+    def _safe_stop(recognizer: Recognition) -> None:
+        """Force-stop a Recognition call to unblock a stalled WebSocket."""
+        try:
+            recognizer.stop()
+        except Exception:
+            pass
+
+    def _recognize_with_timeout(
+        self, recognizer: Recognition, input_path: str
+    ) -> Optional[Any]:
+        """Call recognizer.call() with a hard, reliable timeout.
+
+        The SDK's call() has no timeout, and recognizer.stop() joins the
+        worker thread -- which also blocks on a stalled WebSocket -- so a
+        Timer+stop cannot unblock it. We run call() in a worker thread and
+        use future.result(timeout) instead: on timeout the chunk loop moves
+        on and the stalled thread is abandoned (one leak per rare stall,
+        acceptable). Returns the RecognitionResult, or None on timeout.
+        """
+        from concurrent.futures import (
+            ThreadPoolExecutor,
+            TimeoutError as FuturesTimeout,
+        )
+
+        ex = ThreadPoolExecutor(max_workers=1)
+        future = ex.submit(recognizer.call, input_path)
+        try:
+            return future.result(timeout=self.recognition_timeout)
+        except FuturesTimeout:
+            logger.warning(
+                f"ASR Recognition 超时({self.recognition_timeout}s), 放弃该调用"
+            )
+            self._safe_stop(recognizer)  # best-effort; may also block, in a leaked thread
+            return None
+        finally:
+            ex.shutdown(wait=False)  # never block on a possibly-hung worker
+
     def _prepare_recognition_input(self, file_path: str) -> Optional[str]:
         """按输入格式准备 Recognition 文件"""
         fmt = (self.input_format or "pcm").lower()
@@ -167,7 +234,13 @@ class ASRService:
                 format=(self.input_format or "pcm"),
                 sample_rate=16000,
             )
-            result = recognizer.call(input_path)
+            # Hard timeout: the SDK's call() blocks forever on a stalled
+            # WebSocket; _recognize_with_timeout abandons the call after
+            # recognition_timeout so the task fails fast instead of hanging.
+            result = self._recognize_with_timeout(recognizer, input_path)
+            if result is None:
+                logger.warning("ASR Recognition 超时或无结果")
+                return None
             t2 = time.time()
             logger.info(f"[ASR_PERF] 云端识别完成: 耗时={(t2-t1):.1f}s")
             logger.info(
@@ -443,9 +516,169 @@ class ASRService:
     async def transcribe_url(self, audio_url: str) -> Optional[str]:
         return await asyncio.to_thread(self._transcribe_sync, audio_url)
 
+    def _recognize_pcm_chunk(self, chunk_path: str) -> Optional[str]:
+        """Recognize a single short PCM chunk via Recognition (with timeout).
+
+        Each chunk is <= realtime_max_seconds, so the real-time API handles
+        it without hanging. The forced-stop timer is a belt-and-suspenders
+        guard against rare WebSocket stalls.
+        """
+        try:
+            recognizer = Recognition(
+                model=self.model,
+                callback=None,
+                format="pcm",
+                sample_rate=16000,
+            )
+            result = self._recognize_with_timeout(recognizer, chunk_path)
+            if result is None:
+                logger.warning(f"ASR 块识别超时或无结果: {os.path.basename(chunk_path)}")
+                return None
+            if getattr(result, "status_code", None) != HTTPStatus.OK:
+                logger.warning(
+                    f"ASR 块识别非 200: status={getattr(result, 'status_code', None)}, "
+                    f"code={getattr(result, 'code', None)}, msg={getattr(result, 'message', None)}"
+                )
+                return None
+            sentences = result.get_sentence() or []
+            if isinstance(sentences, dict):
+                sentences = [sentences]
+            texts = [
+                s.get("text", "")
+                for s in sentences
+                if isinstance(s, dict) and s.get("text")
+            ]
+            return "\n".join(texts).strip() if texts else None
+        except Exception as e:
+            logger.warning(f"ASR 块识别异常: {e}")
+            return None
+
+    def _transcribe_local_chunked(self, file_path: str) -> Optional[str]:
+        """Transcribe a long local file by splitting into timed PCM chunks.
+
+        The real-time Recognition API hangs on multi-minute files (its
+        WebSocket duplex stream stalls with no timeout). We transcode to
+        PCM once, split into <= realtime_max_seconds chunks, and recognize
+        each chunk separately, concatenating the results. A failed chunk
+        is skipped rather than failing the whole file.
+        """
+        self._configure()
+        if not os.path.exists(file_path):
+            logger.warning(f"ASR 本地文件不存在: {file_path}")
+            return None
+
+        t0 = time.time()
+        pcm_path = self._transcode_audio_to_pcm(file_path)
+        if not pcm_path or not os.path.exists(pcm_path):
+            logger.warning("ASR 长音频转码 PCM 失败")
+            return None
+
+        try:
+            pcm_size = os.path.getsize(pcm_path)
+            bytes_per_sec = 16000 * 2  # 16kHz, 16-bit mono
+            chunk_bytes = self.realtime_max_seconds * bytes_per_sec
+            total_chunks = (pcm_size + chunk_bytes - 1) // chunk_bytes
+            duration = pcm_size / bytes_per_sec
+            logger.info(
+                f"[ASR_PERF] 长音频切块: 时长={duration:.0f}s, "
+                f"块数={total_chunks}, 块大小={self.realtime_max_seconds}s"
+            )
+
+            texts: list[str] = []
+            chunk_idx = 0
+            with open(pcm_path, "rb") as f:
+                while True:
+                    chunk_data = f.read(chunk_bytes)
+                    if not chunk_data:
+                        break
+                    chunk_idx += 1
+                    chunk_file = f"{pcm_path}.chunk{chunk_idx}"
+                    with open(chunk_file, "wb") as cf:
+                        cf.write(chunk_data)
+                    try:
+                        tc = time.time()
+                        text = self._recognize_pcm_chunk(chunk_file)
+                        tc2 = time.time()
+                        if text:
+                            texts.append(text)
+                            logger.info(
+                                f"[ASR_PERF] 块 {chunk_idx}/{total_chunks} 完成: "
+                                f"耗时={tc2-tc:.1f}s, 长度={len(text)}"
+                            )
+                        else:
+                            logger.warning(
+                                f"[ASR_PERF] 块 {chunk_idx}/{total_chunks} 无文本, "
+                                f"耗时={tc2-tc:.1f}s"
+                            )
+                    finally:
+                        try:
+                            os.remove(chunk_file)
+                        except Exception:
+                            pass
+
+            text = "\n".join(texts).strip()
+            t1 = time.time()
+            logger.info(
+                f"[ASR_PERF] 长音频切块识别完成: 总耗时={t1-t0:.1f}s, "
+                f"成功块={len(texts)}/{total_chunks}, 总长度={len(text)}"
+            )
+            return text if text else None
+        finally:
+            # Clean up the transcoded PCM (the original file is managed by
+            # the caller, asr_page_service, which deletes it in its finally).
+            try:
+                if pcm_path and os.path.exists(pcm_path):
+                    os.remove(pcm_path)
+            except Exception:
+                logger.debug(f"ASR PCM 清理失败: {pcm_path}")
+
+    def _transcribe_local_via_transcription(self, file_path: str) -> Optional[str]:
+        """Upload local file to DashScope OSS and run async Transcription.
+
+        One-shot path for long audio — avoids Recognition WebSocket stalls
+        and the N×serial cost of PCM chunk Recognition.
+        """
+        if not os.path.exists(file_path):
+            logger.warning(f"ASR 本地文件不存在: {file_path}")
+            return None
+        oss_url = self._upload_temp_file(file_path, model=self.transcription_model)
+        if not oss_url:
+            return None
+        logger.info(
+            f"[ASR] 长音频走 Transcription model={self.transcription_model}"
+        )
+        return self._transcribe_sync_with_model(oss_url, self.transcription_model)
+
     async def transcribe_local_file(self, file_path: str) -> Optional[str]:
-        """本地文件直传识别（Recognition）"""
-        return await asyncio.to_thread(self._recognize_local_file, file_path)
+        """Transcribe a local audio file, routing by duration.
+
+        Short audio (<= realtime_max_seconds): sync Recognition (single call).
+        Long audio / unknown duration:
+          1) async Transcription via OSS upload (fast, no hang)
+          2) fallback: timed PCM chunk Recognition with hard per-chunk timeout
+        """
+        duration = self._probe_duration(file_path)
+        if duration is not None:
+            logger.info(
+                f"[ASR] 本地文件时长={duration:.1f}s, 阈值={self.realtime_max_seconds}s"
+            )
+            if duration <= self.realtime_max_seconds:
+                return await asyncio.to_thread(self._recognize_local_file, file_path)
+        else:
+            logger.warning(
+                "[ASR] ffprobe 探测时长失败，按长音频处理（避免 Recognition 挂死）"
+            )
+
+        text = await asyncio.to_thread(
+            self._transcribe_local_via_transcription, file_path
+        )
+        if text:
+            return text
+        logger.warning(
+            "[ASR] Transcription 失败，回退到 PCM 切块 Recognition"
+        )
+        return await asyncio.to_thread(self._transcribe_local_chunked, file_path)
+
 
     def _transcribe_sync_with_model(self, audio_url: str, model: str) -> Optional[str]:
         """使用指定模型转写（用于本地文件上传）"""

--- a/app/services/asr_page_service.py
+++ b/app/services/asr_page_service.py
@@ -426,7 +426,12 @@ class ASRPageService:
                     )
                     page = result.scalar_one_or_none()
                     if page:
-                        page.is_processed = True  # 标记为已处理（即使失败）
+                        # ASR failed: no content was written to MongoDB. Keep
+                        # unprocessed so the next vectorization attempt re-runs
+                        # ASR instead of failing on missing Mongo content (avoids
+                        # the MySQL=True / Mongo=empty mismatch that the
+                        # VideoService cross-store check would otherwise heal).
+                        page.is_processed = False
                         await db.commit()
             except Exception as db_err:
                 logger.error(f"[ASR] 更新数据库失败: {db_err}")

--- a/app/services/vector_page_service.py
+++ b/app/services/vector_page_service.py
@@ -358,9 +358,11 @@ class VectorPageService:
                     raise Exception(f"Video not found: bvid={bvid}, cid={cid}")
 
                 if page.is_vectorized == "processing":
-                    logger.info(f"[VecPage] already in progress: bvid={bvid}, cid={cid}")
-                    await self.tracker.complete(task_id, result={"skipped": True, "message": "Already in progress"})
-                    return
+                    # Stale lock from a killed worker would block forever;
+                    # reclaim and continue (explicit create/revector owns this task).
+                    logger.warning(
+                        f"[VecPage] reclaiming stale processing lock: bvid={bvid}, cid={cid}"
+                    )
 
                 if page.is_vectorized == "done" and not self._content_changed(page):
                     await self.tracker.complete(task_id, result={"skipped": True, "message": "Already up to date"})
@@ -471,7 +473,12 @@ class VectorPageService:
             raise
 
     async def _run_asr(self, bvid: str, cid: int, page_index: int, page_title: str):
-        """Run ASR via ASRPageService (poll for completion, max 5 minutes)."""
+        """Run ASR via ASRPageService with a real wall-clock timeout.
+
+        process_page already waits until ASR done/failed, so a post-await
+        poll loop is dead code. Wrap the await in asyncio.wait_for instead.
+        """
+        from app.config import settings
         from app.services.asr_page_service import ASRPageService
         from app.services.async_task.asr_task_registry import asr_tasks, create_task
 
@@ -479,18 +486,30 @@ class VectorPageService:
         task_id = create_task()
         asr_tasks[task_id].update({"message": "ASR task created"})
 
-        await service.process_page(
-            task_id=task_id, bvid=bvid, cid=cid,
-            page_index=page_index, page_title=page_title,
-        )
+        # asr.timeout covers Transcription; add headroom for download/transcode.
+        timeout = float(settings.asr_timeout) + 120.0
+        try:
+            await asyncio.wait_for(
+                service.process_page(
+                    task_id=task_id,
+                    bvid=bvid,
+                    cid=cid,
+                    page_index=page_index,
+                    page_title=page_title,
+                ),
+                timeout=timeout,
+            )
+        except asyncio.TimeoutError as e:
+            asr_tasks[task_id]["status"] = "failed"
+            asr_tasks[task_id]["message"] = f"ASR timed out after {timeout:.0f}s"
+            raise Exception(
+                f"ASR timed out after {timeout:.0f}s: bvid={bvid}, cid={cid}"
+            ) from e
 
-        for _ in range(300):
-            task = asr_tasks.get(task_id)
-            if task and task["status"] in ("done", "failed"):
-                if task["status"] == "failed":
-                    raise Exception(f"ASR failed: {task.get('message', 'unknown')}")
-                break
-            await asyncio.sleep(1)
+        task = asr_tasks.get(task_id) or {}
+        if task.get("status") == "failed":
+            raise Exception(f"ASR failed: {task.get('message', 'unknown')}")
+
 
     def _delete_page_vectors(self, bvid: str, page_index: int):
         """Delete vectors for a specific page (not the entire bvid)."""

--- a/app/system.sql
+++ b/app/system.sql
@@ -1,3 +1,11 @@
+-- Schema bootstrap for fresh MySQL volume (docker-entrypoint-initdb.d).
+-- Tables are declared in alphabetical order, but foreign keys may reference
+-- tables defined later in this file (e.g. credential_usage -> users). Disable
+-- FK checks during bootstrap so creation order does not matter; all referenced
+-- tables exist by the time the script ends, so FKs resolve correctly. This is
+-- the same pattern mysqldump uses. Re-enabled at end of file.
+SET FOREIGN_KEY_CHECKS=0;
+
 create table async_tasks
 (
     id           int auto_increment
@@ -816,3 +824,5 @@ create table task_quiz_notification
 
 create index ix_task_quiz_notification_status on task_quiz_notification (status);
 create index ix_task_quiz_notification_task_id on task_quiz_notification (task_id);
+
+SET FOREIGN_KEY_CHECKS=1;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -399,6 +399,7 @@ services:
       - mind-base-net
 
   app-task:
+    image: ${APPTASK_IMAGE:-ghcr.io/atoncooper/mind-base-app-task:latest}
     build:
       context: ./app-task
       dockerfile: Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,11 +56,11 @@ services:
       - LLM__MODEL=${LLM_MODEL:-qwen3-max}
       # Embedding
       - EMBEDDING__MODEL=${EMBEDDING_MODEL:-text-embedding-v4}
-      - EMBEDDING__DIMENSION=${EMBEDDING_DIMENSION:-1536}
+      - EMBEDDING__DIMENSION=${EMBEDDING_DIMENSION:-1024}
       # ASR
       - ASR__API_KEY=${ASR_API_KEY:-}
       - ASR__BASE_URL=${ASR_BASE_URL:-https://dashscope.aliyuncs.com/api/v1}
-      - ASR__MODEL=${ASR_MODEL:-paraformer-v2}
+      - ASR__MODEL=${ASR_MODEL:-paraformer-realtime-v2}
       # LangSmith
       - LANGSMITH__API_KEY=${LANGSMITH_API_KEY:-}
       - LANGSMITH__PROJECT=${LANGSMITH_PROJECT:-MindBase}
@@ -229,7 +229,7 @@ services:
       - mind-base-net
 
   milvus:
-    image: milvusdb/milvus:v2.4.17
+    image: milvusdb/milvus:v2.6.22
     container_name: mind-base-milvus
     profiles: ["", "storage", "full"]
     command: milvus run standalone

--- a/frontendv2/components/favorites/favorites-view.tsx
+++ b/frontendv2/components/favorites/favorites-view.tsx
@@ -138,7 +138,7 @@ export function FavoritesView() {
                         total: s.total_videos,
                         message: s.message,
                     });
-                    if (s.status === "completed") {
+                    if (s.status === "done" || s.status === "completed") {
                         setBuild(null);
                         setSelectedIds(new Set());
                         setBuildError(null);

--- a/frontendv2/components/favorites/page-list.tsx
+++ b/frontendv2/components/favorites/page-list.tsx
@@ -22,8 +22,8 @@ interface PageListProps {
     bvid: string;
 }
 
-const POLL_INTERVAL_MS = 1500;
-const POLL_MAX_ATTEMPTS = 80; // ~2 min ceiling, ASR/vectorize can be slow
+const POLL_INTERVAL_MS = 3000;
+const POLL_MAX_ATTEMPTS = 200; // ~10 min ceiling, ASR/vectorize can be slow
 
 export function PageList({ bvid }: PageListProps) {
     const [pages, setPages] = useState<VideoPageItemV2[]>([]);
@@ -96,8 +96,12 @@ export function PageList({ bvid }: PageListProps) {
                     // Network blip - keep polling until ceiling.
                 }
                 if (attempts >= POLL_MAX_ATTEMPTS) {
-                    setOverrides((prev) => ({ ...prev, [cid]: "failed" }));
-                    setPageErrors((prev) => ({ ...prev, [cid]: "向量化超时" }));
+                    // 轮询超时 ≠ 失败：任务仍在后台处理，保留 processing 状态，
+                    // 提示用户稍后刷新查看真实状态。
+                    setPageErrors((prev) => ({
+                        ...prev,
+                        [cid]: "向量化仍在后台处理中，请稍后刷新查看",
+                    }));
                     setBusyCids((prev) => {
                         const next = new Set(prev);
                         next.delete(cid);

--- a/frontendv2/lib/api/knowledge.ts
+++ b/frontendv2/lib/api/knowledge.ts
@@ -11,7 +11,7 @@ export interface BuildRequest {
 
 export interface BuildStatus {
     task_id: string;
-    status: "pending" | "running" | "completed" | "failed";
+    status: "pending" | "processing" | "running" | "done" | "completed" | "failed";
     progress: number;
     current_step: string;
     total_videos: number;
@@ -79,8 +79,9 @@ export const knowledgeApi = {
         }),
 
     // 同步收藏夹到向量库 (v2: Bearer token auth; session_id 已移除)
+    // 返回单个后台任务描述 { task_id, message, reused }，前端轮询 /knowledge/build/status/{task_id}
     syncFolders: (data: SyncRequest) =>
-        request<SyncResult[]>("/knowledge/folders/sync", {
+        request<{ task_id: string; message: string; reused?: boolean }>("/knowledge/folders/sync", {
             headers: getAuthHeaders(),
             method: "POST",
             body: JSON.stringify(data),

--- a/scripts/docker-build.ps1
+++ b/scripts/docker-build.ps1
@@ -1,0 +1,42 @@
+# scripts/docker-build.ps1
+<#
+.SYNOPSIS
+构建 MindBase Docker 镜像并清理悬空镜像（dangling images）
+
+.DESCRIPTION
+自建镜像使用固定 tag（:latest），每次重新构建时旧镜像失去 tag 变为
+<none>:<none> 悬空镜像并堆积占盘。本脚本在构建完成后自动执行
+`docker image prune -f` 清理悬空镜像（不影响有 tag 的镜像）。
+
+.EXAMPLE
+.\scripts\docker-build.ps1            # 构建全部服务并清理
+.\scripts\docker-build.ps1 backend    # 只构建 backend 并清理
+#>
+
+param(
+    [string[]]$Service = @()
+)
+
+$ErrorActionPreference = "Stop"
+
+$SCRIPT_DIR = Split-Path -Parent $MyInvocation.MyCommand.Path
+$PROJECT_ROOT = Split-Path -Parent $SCRIPT_DIR
+Set-Location $PROJECT_ROOT
+
+$composeArgs = @("compose", "build")
+if ($Service.Count -gt 0) {
+    $composeArgs += $Service
+}
+
+Write-Host "[INFO] docker $($composeArgs -join ' ')" -ForegroundColor Cyan
+& docker @composeArgs
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "[ERROR] 镜像构建失败" -ForegroundColor Red
+    exit $LASTEXITCODE
+}
+
+Write-Host "[INFO] 清理悬空镜像: docker image prune -f" -ForegroundColor Cyan
+& docker image prune -f
+
+Write-Host "[OK]   构建完成，悬空镜像已清理" -ForegroundColor Green
+exit 0

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# scripts/docker-build.sh
+# 构建 MindBase Docker 镜像并清理悬空镜像（dangling images）
+#
+# 自建镜像使用固定 tag（:latest），每次重新构建时旧镜像失去 tag 变为
+# <none>:<none> 悬空镜像并堆积占盘。本脚本在构建完成后自动执行
+# `docker image prune -f` 清理悬空镜像（不影响有 tag 的镜像）。
+#
+# 用法：
+#   scripts/docker-build.sh            # 构建全部服务并清理
+#   scripts/docker-build.sh backend    # 只构建 backend 并清理
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; CYAN='\033[0;36m'; NC='\033[0m'
+log_info()  { echo -e "${CYAN}[INFO]${NC} $*"; }
+log_ok()    { echo -e "${GREEN}[OK]${NC}   $*"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+
+log_info "docker compose build $*"
+docker compose build "$@"
+
+log_info "清理悬空镜像: docker image prune -f"
+docker image prune -f
+
+log_ok "构建完成，悬空镜像已清理"


### PR DESCRIPTION
## 背景

针对日志实证的入库/向量化问题（见分析：ASR Recognition 长音频挂死 170~290s、embedding 实际 1024 维 vs 配置 1536 导致 Milvus 写入被拒 `the length(1024) of float data should divide the dim(1536)`、`/knowledge/folders/sync` 同步超时）：

## 改动（4 个 commit）

1. **[asr] feat**: 长音频走 Transcription/切块路由 + Recognition 硬超时
   - `transcribe_local_file` 按时长路由：<=60s 走 Recognition，长音频优先异步 Transcription(OSS 上传)，失败回退 PCM 切块(<=60s/块)
   - `_recognize_with_timeout` 解决 SDK call() 无超时挂死；`asr_api_key` fallback 到 `LLM__API_KEY`
   - ASR 失败不再标 `is_processed=True`（避免 MySQL=True/Mongo=空 不一致）；回收 killed worker 残留 processing 锁；`_run_asr` 真实墙钟超时

2. **[config] feat**: embedding 维度修正 1536→1024 + Milvus 升级 v2.6.22 + ASR 新配置
   - `text-embedding-v4` 实际输出 1024 维，修正配置与 Milvus collection 对齐
   - Milvus v2.4.17 → v2.6.22（本地 docker compose）
   - 新增 `transcription_model` / `realtime_max_seconds` / `recognition_timeout`

3. **[knowledge] feat**: `/knowledge/folders/sync` 改后台任务
   - 返回 `{task_id, message, reused}`，前端轮询 `/knowledge/build/status/{id}`，避免网关超时
   - frontendv2 配套：BuildStatus 枚举新增 `processing/done`，轮询上限提至 ~10min，超时不再误标 failed

4. **[docker] chore**: 悬空镜像清理脚本 + app-task 显式 image tag + system.sql FK 引导
   - `scripts/docker-build.ps1/.sh`：构建后自动 `docker image prune -f`
   - app-task 补 `image` 字段（`APPTASK_IMAGE` 可覆盖）
   - app-task Go 1.22→1.25（对齐 go.mod）

## ⚠️ 部署注意

- **Milvus collection 需重建**：存量 `bilibili_videos`/`cloud_drive` 按 1536 维创建，写入 1024 维向量会被拒；升级后需 drop 重建（`scripts/rebuild_milvus.py` 可参考）后全量重新入库
- **API 契约变更**：`POST /knowledge/folders/sync` 返回类型从 `List[SyncResult]` 改为 `{task_id,...}`，旧客户端需同步

## 验证

- `docker compose config` 解析通过；`docker-build.ps1` 语法检查通过
- P0 自检 `app/test/rag/diagnose_rag.py`：embedding 初始化成功并确认 `detected embedding dim=1024 (config says 1024)`；Milvus/MySQL 因本地 docker 服务未启动无法连接（基础设施未就绪，非代码问题）
- 本分支基于 `infra/nginx-via-apisix`，含其 2 个未合并提交（nginx `/skills` location、frontend stream 容器名修复）