### PR TITLE
[ingest] feat: 入库并发控制——分P 向量化与 ASR 切块并行化

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -206,6 +206,12 @@ APISIX_CONSUMER_KEY=mindbase-internal-key-change-me
 # ⚠️ 生产必改;standalone yaml 不支持 ${ENV} 插值,需在 config.yaml 直接写或部署时 sed 替换
 # APISIX_ADMIN_KEY=admin-key-change-me
 
+# ------------------------------------------------------------
+# 入库并发(可选覆盖,默认见 config.yaml 的 ingest 段)
+# ------------------------------------------------------------
+# INGEST__PAGE_CONCURRENCY=3         # 收藏夹同步时分P 并发数(B站 SESSDATA 限流保守值)
+# INGEST__ASR_CHUNK_CONCURRENCY=3    # 长音频 PCM 切块并行识别数(DashScope 并发限流)
+
 # ============================================================
 # docker-compose 自建镜像 tag(默认 :latest)
 # ------------------------------------------------------------

--- a/app/config/config.yaml
+++ b/app/config/config.yaml
@@ -225,6 +225,14 @@ asr:
 
 
 # ============================================================
+# Ingest — 入库并发控制
+# ============================================================
+ingest:
+  page_concurrency: 3               # 收藏夹同步时同 bvid 的分P 并发数（B站 SESSDATA 限流保守值）
+  asr_chunk_concurrency: 3          # 长音频 PCM 切块并行识别数（DashScope 并发限流）
+
+
+# ============================================================
 # LangSmith — LLM tracing & observability
 # ============================================================
 # Requires LANGSMITH_API_KEY env var. Set enabled=false in

--- a/app/config/default.yaml
+++ b/app/config/default.yaml
@@ -201,6 +201,12 @@ asr:
   # api_key via env: ASR__API_KEY; falls back to LLM__API_KEY
 
 
+# ---- Ingest — 入库并发控制 --------------------------------------
+ingest:
+  page_concurrency: 3               # 收藏夹同步时同 bvid 的分P 并发数（B站 SESSDATA 限流保守值）
+  asr_chunk_concurrency: 3          # 长音频 PCM 切块并行识别数（DashScope 并发限流）
+
+
 # ---- LangSmith tracing --------------------------------------------
 # Set enabled=true + LANGSMITH__API_KEY env var to activate.
 langsmith:

--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -186,6 +186,18 @@ class _Settings:
         key = str(_get("asr", "api_key", default="") or "")
         return key or self.openai_api_key
 
+    # ── Ingest ───────────────────────────────────────────────────
+
+    @property
+    def ingest_page_concurrency(self) -> int:
+        """收藏夹同步时同 bvid 的分P 并发数（B站 SESSDATA 限流保守值）。"""
+        return int(_get("ingest", "page_concurrency", default=3))
+
+    @property
+    def ingest_asr_chunk_concurrency(self) -> int:
+        """长音频 PCM 切块并行识别数（DashScope 并发限流）。"""
+        return int(_get("ingest", "asr_chunk_concurrency", default=3))
+
     # ── LangSmith ────────────────────────────────────────────────
 
     @property

--- a/app/services/asr.py
+++ b/app/services/asr.py
@@ -49,6 +49,8 @@ class ASRService:
         self.transcription_model = settings.asr_transcription_model
         self.realtime_max_seconds = settings.asr_realtime_max_seconds
         self.recognition_timeout = settings.asr_recognition_timeout
+        # 长音频 PCM 切块并行识别并发数（DashScope 并发限流约束）。
+        self.chunk_concurrency = settings.ingest_asr_chunk_concurrency
 
     def _configure(self) -> None:
         if not self.api_key:
@@ -583,7 +585,8 @@ class ASRService:
                 f"块数={total_chunks}, 块大小={self.realtime_max_seconds}s"
             )
 
-            texts: list[str] = []
+            # 1) 切块写入临时 PCM 文件
+            chunk_files: list[str] = []
             chunk_idx = 0
             with open(pcm_path, "rb") as f:
                 while True:
@@ -594,26 +597,33 @@ class ASRService:
                     chunk_file = f"{pcm_path}.chunk{chunk_idx}"
                     with open(chunk_file, "wb") as cf:
                         cf.write(chunk_data)
+                    chunk_files.append(chunk_file)
+
+            # 2) 并行识别：块之间无依赖，天然可并行。并发度受 DashScope
+            #    并发限流约束，由 ingest.asr_chunk_concurrency 控制。
+            #    ThreadPoolExecutor.map 保持结果与块顺序一致。
+            from concurrent.futures import ThreadPoolExecutor
+
+            texts: list[str] = []
+            try:
+                with ThreadPoolExecutor(max_workers=self.chunk_concurrency) as ex:
+                    results = list(ex.map(self._recognize_pcm_chunk, chunk_files))
+                for idx, text in enumerate(results, start=1):
+                    if text:
+                        texts.append(text)
+                        logger.info(
+                            f"[ASR_PERF] 块 {idx}/{total_chunks} 完成, 长度={len(text)}"
+                        )
+                    else:
+                        logger.warning(
+                            f"[ASR_PERF] 块 {idx}/{total_chunks} 无文本"
+                        )
+            finally:
+                for chunk_file in chunk_files:
                     try:
-                        tc = time.time()
-                        text = self._recognize_pcm_chunk(chunk_file)
-                        tc2 = time.time()
-                        if text:
-                            texts.append(text)
-                            logger.info(
-                                f"[ASR_PERF] 块 {chunk_idx}/{total_chunks} 完成: "
-                                f"耗时={tc2-tc:.1f}s, 长度={len(text)}"
-                            )
-                        else:
-                            logger.warning(
-                                f"[ASR_PERF] 块 {chunk_idx}/{total_chunks} 无文本, "
-                                f"耗时={tc2-tc:.1f}s"
-                            )
-                    finally:
-                        try:
-                            os.remove(chunk_file)
-                        except Exception:
-                            pass
+                        os.remove(chunk_file)
+                    except Exception:
+                        pass
 
             text = "\n".join(texts).strip()
             t1 = time.time()

--- a/app/services/knowledge_build/sync_service.py
+++ b/app/services/knowledge_build/sync_service.py
@@ -245,11 +245,18 @@ class KnowledgeSyncService:
                     logger.info(
                         f"[{bvid}] queue {len(todo)}/{len(pages)} page(s) for vectorization"
                     )
-                    for p_idx, p in enumerate(todo):
+                    # 分P 并发处理：信号量限流（B站 SESSDATA 并发下载会被 RST，
+                    # 见 build_service 单例锁注释），并发度由 ingest.page_concurrency
+                    # 控制。process_page_vectorization 内部使用独立 DB session +
+                    # 独立 task_id，并发安全；原分P 间 _human_pause 由信号量节流替代。
+                    from app.config import settings as _settings
+
+                    page_sem = asyncio.Semaphore(_settings.ingest_page_concurrency)
+
+                    async def _vectorize_page(p: dict) -> None:
                         cid = p["cid"]
                         page_index = p["page_index"]
                         page_title = p.get("page_title") or f"P{page_index + 1}"
-
                         vec_task_id = await page_tracker.create(
                             uid=uid,
                             task_type="vec_page",
@@ -261,21 +268,23 @@ class KnowledgeSyncService:
                             },
                         )
                         try:
-                            await vector_service.process_page_vectorization(
-                                task_id=vec_task_id,
-                                bvid=bvid,
-                                cid=cid,
-                                page_index=page_index,
-                                page_title=page_title,
-                            )
+                            async with page_sem:
+                                await vector_service.process_page_vectorization(
+                                    task_id=vec_task_id,
+                                    bvid=bvid,
+                                    cid=cid,
+                                    page_index=page_index,
+                                    page_title=page_title,
+                                )
                         except Exception as page_err:
                             logger.warning(
                                 f"[{bvid}] page cid={cid} idx={page_index} failed: {page_err}"
                             )
                             failed_pages.append((bvid, cid))
 
-                        if p_idx < len(todo) - 1:
-                            await _human_pause(1.0, 3.0)
+                    await asyncio.gather(
+                        *(_vectorize_page(p) for p in todo)
+                    )
             except Exception as e:
                 logger.warning(f"[{bvid}] enumerate/process pages failed: {e}")
                 failed_pages.append((bvid, -1))


### PR DESCRIPTION
## 变更内容

针对入库（ingest）链路慢的问题，引入**可配置的并发控制**，共 3 个模块级提交：

### 1. [config] 新增 `ingest` 入库并发配置
- `ingest.page_concurrency`（默认 3）：收藏夹同步时同 bvid 分P 并发数（B站 SESSDATA 限流保守值）
- `ingest.asr_chunk_concurrency`（默认 3）：长音频 PCM 切块并行识别数（DashScope 并发限流）
- 同步更新 `default.yaml` / `config.yaml` / `.env.example` / `settings.py`
- 环境变量覆盖：`INGEST__PAGE_CONCURRENCY` / `INGEST__ASR_CHUNK_CONCURRENCY`

### 2. [asr] 长音频 PCM 切块并行识别
- `app/services/asr.py`：切块写入临时 PCM 后经 `ThreadPoolExecutor` 并行识别（块间无依赖）
- `ex.map` 保证结果与块顺序一致；单块失败跳过，不拖垮整段转录

### 3. [knowledge] 收藏夹同步分P 并发向量化
- `app/services/knowledge_build/sync_service.py`：同 bvid 分P 由「串行 + 人为 sleep」改为 `asyncio.gather` + `asyncio.Semaphore` 限流
- 并发度由 `ingest.page_concurrency` 控制；bvid 之间的人为节流（B站反爬）保留

## 背景

向量化链路主要耗时在同步 embed（阻塞事件循环）与 Milvus 写入，均为 IO 密集。本 PR 先把并发框架与可配并发度落地，为后续继续提升（embedding 线程池化、batch size、独立 worker）打基础。

## 验收

- [x] `ruff check app/` 全部通过（含本次改动文件）
- [x] `python -m py_compile` 语法自检通过
- [x] 工作区干净，提交按模块拆分（config / asr / knowledge）

## 说明

本分支相对 `main` 共 10 个提交，其中前 7 个为此前已在该分支上的提交（ASR 长音频路由、knowledge sync 后台化、docker/nginx 修复等），如需拆分为多个 PR 请告知。
