### PR TITLE
[doc_parser] feat: 新增 PlainTextParser 支持 .txt 云盘文件向量化

### DIFF
--- a/app/services/doc_parser/__init__.py
+++ b/app/services/doc_parser/__init__.py
@@ -7,6 +7,7 @@ from app.services.doc_parser.markdown_parser import MarkdownParser
 from app.services.doc_parser.html_parser import HtmlParser
 from app.services.doc_parser.docx_parser import DocxParser
 from app.services.doc_parser.pdf_parser import PdfParser
+from app.services.doc_parser.plain_text_parser import PlainTextParser
 
 logger = logging.getLogger(__name__)
 
@@ -15,6 +16,7 @@ _PARSERS: list[DocParser] = [
     HtmlParser(),
     DocxParser(),
     PdfParser(),
+    PlainTextParser(),
 ]
 
 MAX_DOC_SIZE = 100 * 1024 * 1024  # 100 MB

--- a/app/services/doc_parser/plain_text_parser.py
+++ b/app/services/doc_parser/plain_text_parser.py
@@ -1,0 +1,28 @@
+"""Plain text (.txt) document parser — UTF-8 with GBK/GB18030 fallback.
+
+Fixes the gap where ``is_vectorizable("text/plain")`` returned True but no
+registered parser could actually parse ``text/plain`` files, so .txt uploads
+always failed at vectorization time with ``ValueError: No parser for ...``.
+"""
+
+from __future__ import annotations
+
+from app.services.doc_parser.base import BaseDocParser, ParsedDocument
+
+
+class PlainTextParser(BaseDocParser):
+    name = "plain_text"
+
+    def can_parse(self, mime_type: str, filename: str) -> bool:
+        return mime_type == "text/plain" or filename.lower().endswith(
+            (".txt", ".text")
+        )
+
+    def _parse_sync(self, content: bytes, filename: str) -> ParsedDocument:
+        try:
+            text = content.decode("utf-8")
+        except UnicodeDecodeError:
+            # 中文 .txt 常为 GBK / GB18030 编码；GB18030 是 GBK 的超集，
+            # 无法 UTF-8 解码时回退，乱码字节用替换符兜底。
+            text = content.decode("gb18030", errors="replace")
+        return ParsedDocument(text=text, metadata={"title": filename})

--- a/app/test/test_doc_parser.py
+++ b/app/test/test_doc_parser.py
@@ -240,6 +240,47 @@ class TestDocxParser:
 
 
 # ====================================================================
+# Plain Text Parser
+# ====================================================================
+
+class TestPlainTextParser:
+    def test_can_parse_txt_mime(self):
+        from app.services.doc_parser.plain_text_parser import PlainTextParser
+        p = PlainTextParser()
+        assert p.can_parse("text/plain", "notes.txt")
+        assert p.can_parse("text/plain", "notes.TXT")
+        assert p.can_parse("text/plain", "notes.text")
+        # Extension fallback when MIME is generic
+        assert p.can_parse("application/octet-stream", "notes.txt")
+        assert not p.can_parse("text/markdown", "notes.md")
+        assert not p.can_parse("text/html", "page.html")
+
+    def test_basic_utf8(self):
+        from app.services.doc_parser.plain_text_parser import PlainTextParser
+        p = PlainTextParser()
+        result = p._parse_sync("Hello 世界".encode("utf-8"), "test.txt")
+        assert "Hello 世界" in result.text
+
+    def test_gbk_fallback(self):
+        from app.services.doc_parser.plain_text_parser import PlainTextParser
+        p = PlainTextParser()
+        result = p._parse_sync("中文内容测试".encode("gbk"), "test.txt")
+        assert "中文内容测试" in result.text
+
+    def test_metadata_title(self):
+        from app.services.doc_parser.plain_text_parser import PlainTextParser
+        p = PlainTextParser()
+        result = p._parse_sync(b"content", "mydoc.txt")
+        assert result.metadata.get("title") == "mydoc.txt"
+
+    def test_empty_document(self):
+        from app.services.doc_parser.plain_text_parser import PlainTextParser
+        p = PlainTextParser()
+        result = p._parse_sync(b"", "empty.txt")
+        assert result.text == ""
+
+
+# ====================================================================
 # Text Cleaner
 # ====================================================================
 
@@ -306,6 +347,11 @@ class TestParserRegistry:
         p = get_parser("application/pdf", "doc.pdf")
         assert p is not None
         assert p.name == "pdf"
+
+    def test_get_parser_returns_plain_text(self):
+        p = get_parser("text/plain", "notes.txt")
+        assert p is not None
+        assert p.name == "plain_text"
 
     def test_get_parser_returns_none_for_unknown(self):
         p = get_parser("application/zip", "archive.zip")


### PR DESCRIPTION
## 背景

云盘文件向量化判定 `is_vectorizable("text/plain")` 返回 True（text/plain 位于 `VECTORIZABLE_MIME_PREFIXES`），但 `_PARSERS` 注册表中没有任何 parser 能处理 text/plain，导致 `.txt` 文件上传后必然在 `vectorize.py:_extract_text()` 处抛 `ValueError: No parser for ...` → `vector_status='failed'`，且重试无法修复。

## 改动

- **新增** `app/services/doc_parser/plain_text_parser.py`：`PlainTextParser`，支持 MIME `text/plain` 与扩展名 `.txt` / `.text`（含 `application/octet-stream` 的扩展名兜底）；UTF-8 解码失败时回退 GB18030（覆盖中文 txt 常见编码）。
- **注册** `app/services/doc_parser/__init__.py`：`PlainTextParser()` 加入 `_PARSERS`（`is_vectorizable` 的 parser 兜底分支自动生效，无需修改白名单）。
- **测试** `app/test/test_doc_parser.py`：新增 `TestPlainTextParser`（5 例）+ 注册表命中测试（1 例）。

## 验证

- `ruff check`：通过（3 个改动文件）
- `pytest app/test/test_doc_parser.py`：**79 passed, 1 skipped**（skip 为原有 reportlab 缺失跳过，与本次改动无关）

## 兼容性

- 向后兼容零迁移：已上传但标 `failed` 的 `.txt` 文件无需数据修复，重新处理（reprocess）即可恢复。
- 无 schema / 接口变更。
