### PR TITLE
[quiz] feat: 定时出题支持多题 + 判题迁移主 app + 前端交互完善

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,9 @@ app/test/rag/data/
 
 # reasonix
 reasonix.toml
+# Go test cache (sandbox can't write to user AppData; keep local & persistent)
+.gocache/
+.gopath/
+.gotmp/
+.gocache/
+.pip-tmp/

--- a/apisix/apisix.dev.yaml
+++ b/apisix/apisix.dev.yaml
@@ -230,12 +230,28 @@ routes:
         timeout: 5000
         status_code: 401
 
-  # User -> app-task task detail/answer (forward-auth, X-Uid injected)
+  # User -> app-task task detail (forward-auth, X-Uid injected)
   - id: tasks_wildcard
     uri: /tasks/*
     methods: [GET, POST]
     priority: 10
     upstream_id: upstream-app-task
+    plugins:
+      forward-auth:
+        uri: "http://192.168.138.1:8000/internal/auth/verify"
+        request_headers: [Authorization]
+        upstream_headers: [X-Uid]
+        timeout: 5000
+        status_code: 401
+
+  # User -> main app submit answer (forward-auth, X-Uid injected).
+  # 判题/入库/状态流转是业务逻辑，归主 app（app-task 只做调度+通知）。
+  # priority 100 so /tasks/{id}/answer is NOT shadowed by /tasks/* (app-task).
+  - id: tasks_answer
+    uri: /tasks/*/answer
+    methods: [POST]
+    priority: 100
+    upstream_id: upstream-backend
     plugins:
       forward-auth:
         uri: "http://192.168.138.1:8000/internal/auth/verify"

--- a/apisix/apisix.yaml
+++ b/apisix/apisix.yaml
@@ -274,12 +274,28 @@ routes:
         timeout: 5000
         status_code: 401
 
-  # User -> app-task task detail/answer (forward-auth, X-Uid injected)
+  # User -> app-task task detail (forward-auth, X-Uid injected)
   - id: tasks_wildcard
     uri: /tasks/*
     methods: [GET, POST]
     priority: 10
     upstream_id: upstream-app-task
+    plugins:
+      forward-auth:
+        uri: "http://backend:8000/internal/auth/verify"
+        request_headers: [Authorization]
+        upstream_headers: [X-Uid]
+        timeout: 5000
+        status_code: 401
+
+  # User -> main app submit answer (forward-auth, X-Uid injected).
+  # 判题/入库/状态流转是业务逻辑，归主 app（app-task 只做调度+通知）。
+  # priority 100 so /tasks/{id}/answer is NOT shadowed by /tasks/* (app-task).
+  - id: tasks_answer
+    uri: /tasks/*/answer
+    methods: [POST]
+    priority: 100
+    upstream_id: upstream-backend
     plugins:
       forward-auth:
         uri: "http://backend:8000/internal/auth/verify"

--- a/app-task/README.md
+++ b/app-task/README.md
@@ -23,7 +23,8 @@ MindBase **定时出题任务执行器**(Go,自写 DB 轮询调度,无 xxl-job/p
 app-task --HTTP /internal/quiz/generate-llm (经 APISIX)--> 主 app (纯 LLM 出题)
 app-task --渲染 HTML + 入队--> notification worker --Resend--> 用户+抄送人
 app-task --设 deadline + mark sent--> scheduler 轮询 deadline 到期
-用户登录 --> /tasks/{id}/answer --> app-task 判定完成 / 超时发未完成语录
+用户登录 --> /tasks/{id}/answer --> 主 app (判题/入库/状态流转 sent->completed)
+app-task --scheduler 轮询 deadline--> 超时 mark overdue + 未完成语录
 ```
 
 ## 目录结构
@@ -42,11 +43,11 @@ app-task/
 │   ├── model/model.go         # GORM 模型(task_quiz_task/answer/notification)
 │   ├── repo/
 │   │   ├── task.go            # CRUD + conditional_update 状态机 + list_due/list_overdue
-│   │   ├── answer.go
+│   │   ├── answer.go            # 读 task_quiz_answer（主 app 写入；app-task 只读供详情）
 │   │   ├── notification.go    # queue scan + mark_sent/failed
 │   │   └── quiz.go            # Mongo task_quiz_questions
 │   ├── service/
-│   │   ├── task_service.go    # register/execute/submit/timeout + judge
+│   │   ├── task_service.go    # register/execute/timeout（判题已移到主 app）
 │   │   ├── app_client.go      # 调主 app /internal/quiz/generate-llm
 │   │   ├── email.go           # html/template 渲染 + 入队
 │   │   ├── scheduler.go       # DB 轮询调度(30s tick)
@@ -100,10 +101,13 @@ APPTASK__TIMEZONE=Asia/Shanghai
 | 方法 | 路径 | 说明 |
 |------|------|------|
 | POST | `/tasks/register` | 主 app agent 调用,注册任务(uid/prompt/trigger_time/cc_emails/incomplete_message) |
-| POST | `/tasks/{task_id}/answer` | 用户答题提交(校验 uid = task.uid) |
 | GET | `/tasks/{task_id}` | 任务详情(task + quiz + answer),X-Uid 鉴权 |
 | GET | `/tasks` | 用户任务列表,X-Uid 鉴权 |
 | GET | `/health` | 健康检查 |
+
+> ⚠️ `POST /tasks/{task_id}/answer`（答题提交）已由主 app 提供（判题/入库/状态流转
+> 属业务逻辑），经 APISIX `/tasks/*/answer`（priority 100, forward-auth）转发到 backend。
+> app-task 只负责调度执行与通知，不处理答题。
 
 ## 调度模型(自写,无 xxl-job)
 

--- a/app-task/internal/model/model.go
+++ b/app-task/internal/model/model.go
@@ -22,6 +22,7 @@ type TaskQuizTask struct {
 	CCEmails          datatypes.JSON `gorm:"column:cc_emails;type:json;not null" json:"cc_emails"`
 	Prompt            string         `gorm:"column:prompt;size:500;not null" json:"prompt"`
 	Difficulty        string         `gorm:"column:difficulty;size:20;default:medium;not null" json:"difficulty"` // easy/medium/hard (考研难度: 简单/中等/压轴)
+	QuestionCount     int            `gorm:"column:question_count;default:1;not null" json:"question_count"`      // 本次任务出题数量 (1~5)
 	IncompleteMessage *string        `gorm:"column:incomplete_message;type:text" json:"incomplete_message,omitempty"`
 	TriggerTime       time.Time      `gorm:"column:trigger_time;not null" json:"trigger_time"`
 	Status            string         `gorm:"column:status;size:20;default:pending;not null" json:"status"`
@@ -34,14 +35,16 @@ type TaskQuizTask struct {
 
 func (TaskQuizTask) TableName() string { return "task_quiz_task" }
 
-// TaskQuizAnswer: user's answer to a quiz task.
+// TaskQuizAnswer: user's answer to a quiz task (one row per question when
+// question_count > 1; question_index is 0-based).
 type TaskQuizAnswer struct {
-	ID          int64     `gorm:"primaryKey;autoIncrement" json:"-"`
-	TaskID      string    `gorm:"column:task_id;index;not null" json:"task_id"`
-	UID         int64     `gorm:"column:uid;index;not null" json:"uid"`
-	Answer      string    `gorm:"column:answer;type:text;not null" json:"answer"`
-	IsCorrect   bool      `gorm:"column:is_correct;not null" json:"is_correct"`
-	SubmittedAt time.Time `gorm:"column:submitted_at;autoCreateTime" json:"submitted_at"`
+	ID            int64     `gorm:"primaryKey;autoIncrement" json:"-"`
+	TaskID        string    `gorm:"column:task_id;index;not null" json:"task_id"`
+	UID           int64     `gorm:"column:uid;index;not null" json:"uid"`
+	QuestionIndex int       `gorm:"column:question_index;default:0;not null" json:"question_index"`
+	Answer        string    `gorm:"column:answer;type:text;not null" json:"answer"`
+	IsCorrect     bool      `gorm:"column:is_correct;not null" json:"is_correct"`
+	SubmittedAt   time.Time `gorm:"column:submitted_at;autoCreateTime" json:"submitted_at"`
 }
 
 func (TaskQuizAnswer) TableName() string { return "task_quiz_answer" }

--- a/app-task/internal/repo/answer.go
+++ b/app-task/internal/repo/answer.go
@@ -3,19 +3,17 @@ package repo
 import (
 	"app-task/internal/db"
 	"app-task/internal/model"
-
-	"gorm.io/gorm"
 )
 
-func CreateAnswer(a *model.TaskQuizAnswer) error {
-	return db.DB.Create(a).Error
-}
-
-func GetAnswerByTaskID(taskID string) (*model.TaskQuizAnswer, error) {
-	var a model.TaskQuizAnswer
-	err := db.DB.Where("task_id = ?", taskID).First(&a).Error
-	if err == gorm.ErrRecordNotFound {
-		return nil, nil
+// GetAnswersByTaskID reads the user's answers for the task detail endpoint
+// (one row per question when question_count > 1, ordered by question_index).
+// Answers are WRITTEN by the main app (POST /tasks/{id}/answer); app-task only
+// reads the shared MySQL table task_quiz_answer.
+func GetAnswersByTaskID(taskID string) ([]model.TaskQuizAnswer, error) {
+	var ans []model.TaskQuizAnswer
+	err := db.DB.Where("task_id = ?", taskID).Order("question_index").Find(&ans).Error
+	if err != nil {
+		return nil, err
 	}
-	return &a, err
+	return ans, nil
 }

--- a/app-task/internal/repo/quiz.go
+++ b/app-task/internal/repo/quiz.go
@@ -10,20 +10,12 @@ import (
 	mgodriver "go.mongodb.org/mongo-driver/mongo"
 )
 
-// InsertQuiz stores generated quiz content in MongoDB.
-//
-// Package-level variable (func type) so tests can stub it without a real
-// MongoDB (ExecuteQuiz tests inject a no-op here).
-var InsertQuiz = func(ctx context.Context, doc map[string]any) error {
-	_, err := mongo.DB.Collection(model.TaskQuizCollection).InsertOne(ctx, doc)
-	return err
-}
-
 // GetQuizByTaskID returns the quiz doc for a task, or nil if not found.
 //
-// Declared as a package-level variable (func type) so tests can swap it
-// with a stub, avoiding the need for a real MongoDB in SubmitAnswer
-// full-path tests.
+// Quiz content is generated + stored by the MAIN app (mind_base Mongo,
+// collection task_quiz_questions); app-task only reads it for the detail
+// endpoint. Declared as a package-level variable (func type) so tests can
+// swap it with a stub, avoiding the need for a real MongoDB.
 var GetQuizByTaskID = func(ctx context.Context, taskID string) (map[string]any, error) {
 	sr := mongo.DB.Collection(model.TaskQuizCollection).FindOne(ctx, bson.M{"task_id": taskID})
 	var m map[string]any

--- a/app-task/internal/router/router.go
+++ b/app-task/internal/router/router.go
@@ -14,6 +14,7 @@ import (
 	"app-task/internal/service"
 
 	"github.com/gin-gonic/gin"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 // New builds the Gin engine with all routes registered.
@@ -45,7 +46,6 @@ func (r *Router) registerRoutes(e *gin.Engine) {
 
 	tasks := e.Group("/tasks")
 	tasks.POST("/register", r.register)
-	tasks.POST("/:task_id/answer", r.answer)
 	tasks.GET("/:task_id", r.detail)
 	tasks.GET("", r.list)
 }
@@ -57,12 +57,16 @@ func (r *Router) register(c *gin.Context) {
 		CCEmails          []string `json:"cc_emails"`
 		Prompt            string   `json:"prompt" binding:"required,max=500"`
 		Difficulty        string   `json:"difficulty"`
+		QuestionCount     int      `json:"question_count"`
 		TriggerTime       string   `json:"trigger_time" binding:"required"`
 		IncompleteMessage *string  `json:"incomplete_message"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"detail": "invalid request: " + err.Error()})
 		return
+	}
+	if req.QuestionCount < 1 || req.QuestionCount > 5 {
+		req.QuestionCount = 1
 	}
 	triggerTime, err := parseISO8601(req.TriggerTime)
 	if err != nil {
@@ -73,41 +77,12 @@ func (r *Router) register(c *gin.Context) {
 	if req.IncompleteMessage != nil {
 		incomplete = *req.IncompleteMessage
 	}
-	taskID, err := r.taskSvc.RegisterTask(req.UID, req.UserEmail, req.CCEmails, req.Prompt, req.Difficulty, triggerTime, incomplete)
+	taskID, err := r.taskSvc.RegisterTask(req.UID, req.UserEmail, req.CCEmails, req.Prompt, req.Difficulty, req.QuestionCount, triggerTime, incomplete)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"detail": "register failed: " + err.Error()})
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"task_id": taskID, "status": "pending"})
-}
-
-func (r *Router) answer(c *gin.Context) {
-	uid, ok := uidFromHeader(c)
-	if !ok {
-		return
-	}
-	taskID := c.Param("task_id")
-	var req struct {
-		Answer string `json:"answer" binding:"required"`
-	}
-	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"detail": "invalid request: " + err.Error()})
-		return
-	}
-	result, err := r.taskSvc.SubmitAnswer(taskID, uid, req.Answer)
-	if err == service.ErrNotFound {
-		c.JSON(http.StatusNotFound, gin.H{"detail": "task not found"})
-		return
-	}
-	if err == service.ErrForbidden {
-		c.JSON(http.StatusForbidden, gin.H{"detail": "not the task owner"})
-		return
-	}
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"detail": err.Error()})
-		return
-	}
-	c.JSON(http.StatusOK, result)
 }
 
 func (r *Router) detail(c *gin.Context) {
@@ -130,25 +105,61 @@ func (r *Router) detail(c *gin.Context) {
 		return
 	}
 	quiz, _ := repo.GetQuizByTaskID(c.Request.Context(), taskID)
-	ans, _ := repo.GetAnswerByTaskID(taskID)
+	answers, _ := repo.GetAnswersByTaskID(taskID)
 	resp := gin.H{
-		"task_id":      task.TaskID,
-		"uid":          task.UID,
-		"prompt":       task.Prompt,
-		"status":       task.Status,
-		"trigger_time": task.TriggerTime.Format(time.RFC3339),
-		"cc_emails":    task.CCEmails,
-		"quiz":         quiz,
-		"answer":       nil,
+		"task_id":        task.TaskID,
+		"uid":            task.UID,
+		"prompt":         task.Prompt,
+		"status":         task.Status,
+		"trigger_time":   task.TriggerTime.Format(time.RFC3339),
+		"cc_emails":      task.CCEmails,
+		"question_count": task.QuestionCount,
+		"quiz":           gin.H{"questions": normalizeQuizQuestions(quiz)},
+		"answers":        []gin.H{},
 	}
-	if ans != nil {
-		resp["answer"] = gin.H{
-			"answer":       ans.Answer,
-			"is_correct":   ans.IsCorrect,
-			"submitted_at": ans.SubmittedAt.Format(time.RFC3339),
-		}
+	for _, a := range answers {
+		resp["answers"] = append(resp["answers"].([]gin.H), gin.H{
+			"question_index": a.QuestionIndex,
+			"answer":         a.Answer,
+			"is_correct":     a.IsCorrect,
+			"submitted_at":   a.SubmittedAt.Format(time.RFC3339),
+		})
 	}
 	c.JSON(http.StatusOK, resp)
+}
+
+// normalizeQuizQuestions normalizes the quiz doc to a {questions: [...]} list.
+// New docs store a questions array; legacy single-question docs keep flat
+// fields (question/question_type/options/answer/...), which we wrap here so the
+// frontend always sees the same array shape.
+//
+// NOTE: bson decode produces primitive.A (named []any), NOT []any — a plain
+// `.([]any)` assertion on it fails silently, so both shapes are handled.
+func normalizeQuizQuestions(quiz map[string]any) []any {
+	if quiz == nil {
+		return []any{}
+	}
+	if qs, ok := quiz["questions"]; ok {
+		if arr, ok := qs.([]any); ok && len(arr) > 0 {
+			return arr
+		}
+		if arr, ok := qs.(primitive.A); ok && len(arr) > 0 {
+			return []any(arr)
+		}
+	}
+	single := map[string]any{}
+	for _, k := range []string{
+		"question", "question_type", "options", "answer", "difficulty",
+		"answer_time_limit_seconds",
+	} {
+		if v, ok := quiz[k]; ok {
+			single[k] = v
+		}
+	}
+	if single["question"] == nil {
+		return []any{}
+	}
+	return []any{single}
 }
 
 func (r *Router) list(c *gin.Context) {

--- a/app-task/internal/router/router_test.go
+++ b/app-task/internal/router/router_test.go
@@ -16,6 +16,7 @@ import (
 	"app-task/internal/service"
 
 	"github.com/glebarez/sqlite"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"gorm.io/gorm"
 )
 
@@ -39,7 +40,7 @@ type stubQuizGen struct {
 	requestQuiz   *service.Quiz
 }
 
-func (s *stubQuizGen) RequestQuiz(taskID, prompt string, uid int64, difficulty string) (*service.QuizGenResponse, error) {
+func (s *stubQuizGen) RequestQuiz(taskID, prompt string, uid int64, difficulty string, questionCount int) (*service.QuizGenResponse, error) {
 	return &service.QuizGenResponse{Status: s.requestStatus, Quiz: s.requestQuiz}, nil
 }
 
@@ -50,13 +51,13 @@ func (s *stubQuizGen) GetQuizStatus(taskID string) (*service.QuizGenResponse, er
 func newTestRouter(t *testing.T) (*service.TaskService, http.Handler) {
 	t.Helper()
 	setupRouterTestDB(t)
-	// stub Mongo InsertQuiz as no-op (router tests don't touch Mongo)
-	repo.InsertQuiz = func(context.Context, map[string]any) error { return nil }
 	svc := service.NewTaskService(&stubQuizGen{
 		requestStatus: "ready",
 		requestQuiz: &service.Quiz{
-			Question: "q", QuestionType: "choice", Answer: "A",
-			AnswerTimeLimitSeconds: 600, Difficulty: "easy",
+			Questions: []service.QuizQuestion{
+				{Question: "q", QuestionType: "choice", Answer: "A",
+					AnswerTimeLimitSeconds: 600, Difficulty: "easy"},
+			},
 		},
 	})
 	cfg := &config.Config{}
@@ -100,50 +101,12 @@ func TestRegisterHandler_InvalidBody(t *testing.T) {
 	}
 }
 
-// ── POST /tasks/:id/answer ───────────────────────────────────────
-
-func TestAnswerHandler(t *testing.T) {
-	svc, h := newTestRouter(t)
-	taskID, _ := svc.RegisterTask(1, "u@x.com", nil, "p", "medium", time.Now().UTC().Add(-time.Minute), "")
-	repo.ConditionalUpdate(taskID, "pending", "sent", nil)
-	repo.GetQuizByTaskID = func(ctx context.Context, _ string) (map[string]any, error) {
-		return map[string]any{"question_type": "choice", "answer": "A"}, nil
-	}
-
-	req := httptest.NewRequest("POST", "/tasks/"+taskID+"/answer", bytes.NewBufferString(`{"answer":"A"}`))
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-Uid", "1")
-	w := httptest.NewRecorder()
-	h.ServeHTTP(w, req)
-
-	if w.Code != 200 {
-		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
-	}
-	var resp map[string]any
-	json.Unmarshal(w.Body.Bytes(), &resp)
-	if resp["is_correct"] != true {
-		t.Errorf("is_correct = %v, want true", resp["is_correct"])
-	}
-}
-
-func TestAnswerHandler_NoXUid(t *testing.T) {
-	_, h := newTestRouter(t)
-	req := httptest.NewRequest("POST", "/tasks/some-id/answer", bytes.NewBufferString(`{"answer":"A"}`))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	h.ServeHTTP(w, req)
-
-	if w.Code != 401 {
-		t.Errorf("status = %d, want 401 (no X-Uid)", w.Code)
-	}
-}
-
 // ── GET /tasks ───────────────────────────────────────────────────
 
 func TestListHandler(t *testing.T) {
 	svc, h := newTestRouter(t)
-	svc.RegisterTask(1, "u@x.com", nil, "p1", "medium", time.Now().UTC().Add(time.Hour), "")
-	svc.RegisterTask(1, "u@x.com", nil, "p2", "hard", time.Now().UTC().Add(time.Hour), "")
+	svc.RegisterTask(1, "u@x.com", nil, "p1", "medium", 1, time.Now().UTC().Add(time.Hour), "")
+	svc.RegisterTask(1, "u@x.com", nil, "p2", "hard", 1, time.Now().UTC().Add(time.Hour), "")
 
 	req := httptest.NewRequest("GET", "/tasks", nil)
 	req.Header.Set("X-Uid", "1")
@@ -176,7 +139,7 @@ func TestListHandler_NoXUid(t *testing.T) {
 
 func TestDetailHandler(t *testing.T) {
 	svc, h := newTestRouter(t)
-	taskID, _ := svc.RegisterTask(1, "u@x.com", nil, "p", "medium", time.Now().UTC().Add(time.Hour), "")
+	taskID, _ := svc.RegisterTask(1, "u@x.com", nil, "p", "medium", 1, time.Now().UTC().Add(time.Hour), "")
 	repo.GetQuizByTaskID = func(ctx context.Context, _ string) (map[string]any, error) {
 		return map[string]any{"question": "q", "answer": "A"}, nil
 	}
@@ -198,7 +161,7 @@ func TestDetailHandler(t *testing.T) {
 
 func TestDetailHandler_NotOwner(t *testing.T) {
 	svc, h := newTestRouter(t)
-	taskID, _ := svc.RegisterTask(1, "u@x.com", nil, "p", "medium", time.Now().UTC().Add(time.Hour), "")
+	taskID, _ := svc.RegisterTask(1, "u@x.com", nil, "p", "medium", 1, time.Now().UTC().Add(time.Hour), "")
 
 	req := httptest.NewRequest("GET", "/tasks/"+taskID, nil)
 	req.Header.Set("X-Uid", "999") // not owner
@@ -219,5 +182,47 @@ func TestDetailHandler_NotFound(t *testing.T) {
 
 	if w.Code != 404 {
 		t.Errorf("status = %d, want 404", w.Code)
+	}
+}
+
+// ── normalizeQuizQuestions: bson primitive.A vs []any vs legacy flat ──
+
+func TestNormalizeQuizQuestions(t *testing.T) {
+	// 新文档：mongo-driver 解码数组得到 primitive.A（命名 []any），
+	// 不能直接 `.([]any)` 断言——必须兼容（回归：多题出题后前端无内容）
+	primitiveDoc := map[string]any{
+		"questions": primitive.A{
+			primitive.M{"question": "q1", "answer": "A"},
+			primitive.M{"question": "q2", "answer": "B"},
+		},
+	}
+	qs := normalizeQuizQuestions(primitiveDoc)
+	if len(qs) != 2 {
+		t.Fatalf("primitive.A questions = %d, want 2", len(qs))
+	}
+
+	// 新文档但恰好是 []any（例如测试中手工构造）
+	plainDoc := map[string]any{
+		"questions": []any{map[string]any{"question": "q1", "answer": "A"}},
+	}
+	if qs := normalizeQuizQuestions(plainDoc); len(qs) != 1 {
+		t.Fatalf("[]any questions = %d, want 1", len(qs))
+	}
+
+	// 旧单题平铺文档（兼容）
+	legacyDoc := map[string]any{
+		"question": "q", "question_type": "choice",
+		"options": []any{"A", "B"}, "answer": "A",
+	}
+	if qs := normalizeQuizQuestions(legacyDoc); len(qs) != 1 || qs[0].(map[string]any)["question"] != "q" {
+		t.Fatalf("legacy doc normalized wrong: %+v", qs)
+	}
+
+	// 空/无题目
+	if qs := normalizeQuizQuestions(nil); len(qs) != 0 {
+		t.Fatalf("nil doc = %d, want 0", len(qs))
+	}
+	if qs := normalizeQuizQuestions(map[string]any{"task_id": "t"}); len(qs) != 0 {
+		t.Fatalf("doc without questions = %d, want 0", len(qs))
 	}
 }

--- a/app-task/internal/service/app_client.go
+++ b/app-task/internal/service/app_client.go
@@ -41,8 +41,15 @@ type QuizGenResponse struct {
 	Error  string `json:"error,omitempty"`  // present when status=failed
 }
 
-// Quiz is the generated quiz content (when status=ready).
+// Quiz is the generated quiz content (when status=ready). A task can hold
+// multiple questions (question_count 1..5); the main app always returns the
+// normalized {questions: [...]} shape.
 type Quiz struct {
+	Questions []QuizQuestion `json:"questions"`
+}
+
+// QuizQuestion is one question inside a quiz set.
+type QuizQuestion struct {
 	Question               string   `json:"question"`
 	QuestionType           string   `json:"question_type"`
 	Options                []string `json:"options"`
@@ -54,16 +61,17 @@ type Quiz struct {
 // RequestQuiz POSTs /generate-llm asynchronously. Returns immediately with
 // the status (generating/ready). Idempotent: main app checks task_id and won't
 // re-invoke the LLM if already generating/ready.
-func (c *AppClient) RequestQuiz(taskID, prompt string, uid int64, difficulty string) (*QuizGenResponse, error) {
+func (c *AppClient) RequestQuiz(taskID, prompt string, uid int64, difficulty string, questionCount int) (*QuizGenResponse, error) {
 	if c.baseURL == "" {
 		return nil, fmt.Errorf("app base_url not configured")
 	}
 	url := strings.TrimRight(c.baseURL, "/") + c.llmPath
 	body, _ := json.Marshal(map[string]any{
-		"task_id":    taskID,
-		"prompt":     prompt,
-		"uid":        uid,
-		"difficulty": difficulty,
+		"task_id":        taskID,
+		"prompt":         prompt,
+		"uid":            uid,
+		"difficulty":     difficulty,
+		"question_count": questionCount,
 	})
 	req, err := http.NewRequest("POST", url, bytes.NewReader(body))
 	if err != nil {

--- a/app-task/internal/service/app_client_test.go
+++ b/app-task/internal/service/app_client_test.go
@@ -22,13 +22,16 @@ func TestRequestQuiz_Success(t *testing.T) {
 		if body["difficulty"] != "hard" {
 			t.Errorf("difficulty = %v", body["difficulty"])
 		}
+		if body["question_count"] != float64(3) {
+			t.Errorf("question_count = %v, want 3", body["question_count"])
+		}
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]any{"status": "generating"})
 	}))
 	defer srv.Close()
 
 	c := &AppClient{baseURL: srv.URL, apiKey: "test-key", llmPath: "/internal/quiz/generate-llm", statusPath: "/internal/quiz/status/", httpClient: srv.Client()}
-	resp, err := c.RequestQuiz("t1", "prompt", 1, "hard")
+	resp, err := c.RequestQuiz("t1", "prompt", 1, "hard", 3)
 	if err != nil {
 		t.Fatalf("RequestQuiz: %v", err)
 	}
@@ -43,22 +46,24 @@ func TestRequestQuiz_Ready(t *testing.T) {
 		json.NewEncoder(w).Encode(map[string]any{
 			"status": "ready",
 			"quiz": map[string]any{
-				"question": "q", "answer": "A", "answer_time_limit_seconds": 600,
+				"questions": []any{
+					map[string]any{"question": "q", "answer": "A", "answer_time_limit_seconds": 600},
+				},
 			},
 		})
 	}))
 	defer srv.Close()
 
 	c := &AppClient{baseURL: srv.URL, apiKey: "k", llmPath: "/p", statusPath: "/s/", httpClient: srv.Client()}
-	resp, err := c.RequestQuiz("t1", "p", 1, "medium")
+	resp, err := c.RequestQuiz("t1", "p", 1, "medium", 1)
 	if err != nil {
 		t.Fatalf("RequestQuiz: %v", err)
 	}
 	if resp.Status != "ready" {
 		t.Errorf("status = %q, want ready", resp.Status)
 	}
-	if resp.Quiz == nil || resp.Quiz.Answer != "A" {
-		t.Errorf("quiz = %+v, want answer A", resp.Quiz)
+	if resp.Quiz == nil || len(resp.Quiz.Questions) != 1 || resp.Quiz.Questions[0].Answer != "A" {
+		t.Errorf("quiz = %+v, want 1 question with answer A", resp.Quiz)
 	}
 }
 
@@ -69,7 +74,7 @@ func TestRequestQuiz_Non200(t *testing.T) {
 	defer srv.Close()
 
 	c := &AppClient{baseURL: srv.URL, apiKey: "k", llmPath: "/p", statusPath: "/s/", httpClient: srv.Client()}
-	_, err := c.RequestQuiz("t1", "p", 1, "medium")
+	_, err := c.RequestQuiz("t1", "p", 1, "medium", 1)
 	if err == nil {
 		t.Fatal("want error on 500")
 	}
@@ -77,7 +82,7 @@ func TestRequestQuiz_Non200(t *testing.T) {
 
 func TestRequestQuiz_NotConfigured(t *testing.T) {
 	c := &AppClient{baseURL: "", apiKey: "k", llmPath: "/p", statusPath: "/s/", httpClient: &http.Client{}}
-	_, err := c.RequestQuiz("t1", "p", 1, "medium")
+	_, err := c.RequestQuiz("t1", "p", 1, "medium", 1)
 	if err == nil {
 		t.Fatal("want error when baseURL empty")
 	}
@@ -93,7 +98,11 @@ func TestGetQuizStatus_Ready(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]any{
 			"status": "ready",
-			"quiz":   map[string]any{"question": "q", "answer": "A"},
+			"quiz": map[string]any{
+				"questions": []any{
+					map[string]any{"question": "q", "answer": "A"},
+				},
+			},
 		})
 	}))
 	defer srv.Close()

--- a/app-task/internal/service/email.go
+++ b/app-task/internal/service/email.go
@@ -16,10 +16,18 @@ import (
 //go:embed template/*.html template/*.txt
 var templateFS embed.FS
 
+type quizEmailQuestion struct {
+	Index        int // 1-based
+	Question     string
+	QuestionType string
+	Options      []string
+}
+
 type quizEmailData struct {
-	Question       string
-	QuestionType   string
-	Options        []string
+	Count          int
+	ShowDetail     bool // 题数 <= 2 时邮件内联展示题目；否则只显示数量
+	Prompt         string
+	Questions      []quizEmailQuestion
 	AnswerDeadline string
 }
 
@@ -29,11 +37,24 @@ type overdueEmailData struct {
 }
 
 // EnqueueQuizEmail renders the quiz email HTML and enqueues a pending notification.
-func EnqueueQuizEmail(taskID, recipient string, ccEmails []string, quiz map[string]any, deadlineStr string) error {
+// 多题策略：≤2 道在邮件里内联展示具体题目；>2 道只提示"共 N 道题，请登录系统查看"，
+// 避免邮件过长。
+func EnqueueQuizEmail(taskID, recipient string, ccEmails []string, prompt string, questions []QuizQuestion, deadlineStr string) error {
+	showDetail := len(questions) <= 2
+	qs := make([]quizEmailQuestion, 0, len(questions))
+	for i, q := range questions {
+		qs = append(qs, quizEmailQuestion{
+			Index:        i + 1,
+			Question:     latexToText(q.Question),
+			QuestionType: q.QuestionType,
+			Options:      latexToTextSlice(q.Options),
+		})
+	}
 	html, err := renderTemplate("template/quiz_email.html", quizEmailData{
-		Question:       latexToText(str(quiz["question"])),
-		QuestionType:   str(quiz["question_type"]),
-		Options:        latexToTextSlice(toStringSlice(quiz["options"])),
+		Count:          len(questions),
+		ShowDetail:     showDetail,
+		Prompt:         prompt,
+		Questions:      qs,
 		AnswerDeadline: deadlineStr,
 	})
 	if err != nil {

--- a/app-task/internal/service/scheduler_test.go
+++ b/app-task/internal/service/scheduler_test.go
@@ -10,7 +10,7 @@ import (
 // registerDueTask creates a pending task whose trigger_time has already passed.
 func registerDueTask(t *testing.T, svc *TaskService, uid int64, prompt string) string {
 	t.Helper()
-	taskID, err := svc.RegisterTask(uid, "u@x.com", nil, prompt, "medium", time.Now().UTC().Add(-time.Minute), "")
+	taskID, err := svc.RegisterTask(uid, "u@x.com", nil, prompt, "medium", 1, time.Now().UTC().Add(-time.Minute), "")
 	if err != nil {
 		t.Fatalf("RegisterTask: %v", err)
 	}
@@ -37,7 +37,7 @@ func TestScheduler_TickExecutesDuePending(t *testing.T) {
 func TestScheduler_TickSkipsFutureTask(t *testing.T) {
 	setupTestDB(t)
 	svc := NewTaskService(&mockAppClient{requestStatus: "ready", requestQuiz: testQuiz})
-	taskID, _ := svc.RegisterTask(1, "u@x.com", nil, "p", "medium", time.Now().UTC().Add(time.Hour), "")
+	taskID, _ := svc.RegisterTask(1, "u@x.com", nil, "p", "medium", 1, time.Now().UTC().Add(time.Hour), "")
 
 	sched := NewScheduler(svc, 30)
 	sched.tick()

--- a/app-task/internal/service/task_service.go
+++ b/app-task/internal/service/task_service.go
@@ -1,11 +1,8 @@
 package service
 
 import (
-	"context"
-	"errors"
 	"fmt"
 	"log/slog"
-	"strings"
 	"time"
 
 	"app-task/internal/model"
@@ -14,20 +11,16 @@ import (
 	"github.com/google/uuid"
 )
 
-var (
-	ErrNotFound  = errors.New("task not found")
-	ErrForbidden = errors.New("not the task owner")
-)
-
 // QuizGenerator abstracts the async quiz generation calls to the main app.
 // *AppClient implements it in production; tests substitute a stub.
 type QuizGenerator interface {
-	RequestQuiz(taskID, prompt string, uid int64, difficulty string) (*QuizGenResponse, error)
+	RequestQuiz(taskID, prompt string, uid int64, difficulty string, questionCount int) (*QuizGenResponse, error)
 	GetQuizStatus(taskID string) (*QuizGenResponse, error)
 }
 
-// TaskService orchestrates task lifecycle: register/execute/submit/timeout.
+// TaskService orchestrates task lifecycle: register/execute/timeout.
 // State machine: pending -> sent -> completed | overdue | failed.
+// 答题提交/判题/入库由主 app 负责（POST /tasks/{id}/answer），app-task 不做业务。
 type TaskService struct {
 	appClient QuizGenerator
 }
@@ -38,7 +31,7 @@ func NewTaskService(appClient QuizGenerator) *TaskService {
 
 // RegisterTask creates a pending task. The scheduler polls trigger_time and
 // fires ExecuteQuiz when due - no explicit job registration needed.
-func (s *TaskService) RegisterTask(uid int64, userEmail string, ccEmails []string, prompt string, difficulty string, triggerTime time.Time, incompleteMessage string) (string, error) {
+func (s *TaskService) RegisterTask(uid int64, userEmail string, ccEmails []string, prompt string, difficulty string, questionCount int, triggerTime time.Time, incompleteMessage string) (string, error) {
 	taskID := uuid.NewString()
 	var incomplete *string
 	if incompleteMessage != "" {
@@ -47,6 +40,9 @@ func (s *TaskService) RegisterTask(uid int64, userEmail string, ccEmails []strin
 	if difficulty == "" {
 		difficulty = "medium"
 	}
+	if questionCount < 1 || questionCount > 5 {
+		questionCount = 1
+	}
 	task := &model.TaskQuizTask{
 		TaskID:            taskID,
 		UID:               uid,
@@ -54,6 +50,7 @@ func (s *TaskService) RegisterTask(uid int64, userEmail string, ccEmails []strin
 		CCEmails:          toJSON(ccEmails),
 		Prompt:            prompt,
 		Difficulty:        difficulty,
+		QuestionCount:     questionCount,
 		IncompleteMessage: incomplete,
 		TriggerTime:       triggerTime,
 		Status:            "pending",
@@ -85,7 +82,7 @@ func (s *TaskService) ExecuteQuiz(taskID string) {
 	}
 
 	// Async: request quiz generation (returns immediately with generating/ready)
-	resp, err := s.appClient.RequestQuiz(taskID, task.Prompt, task.UID, task.Difficulty)
+	resp, err := s.appClient.RequestQuiz(taskID, task.Prompt, task.UID, task.Difficulty, task.QuestionCount)
 	if err != nil {
 		slog.Error("[TASK] request quiz failed", "task_id", taskID, "err", err)
 		_, _ = repo.ConditionalUpdate(taskID, "pending", "failed", nil)
@@ -136,50 +133,24 @@ func (s *TaskService) ProcessGenerating(taskID string) {
 }
 
 // finalizeQuiz sends the quiz email + sets deadline + marks sent.
-// Quiz content is NOT stored here (main app already persisted it in Mongo);
-// app-task reads it back via repo.GetQuizByTaskID when judging answers.
+// Quiz content is NOT stored here: generation/入库归主 app（主 app 已把题目
+// 写进共享 Mongo mind_base.task_quiz_questions），app-task 只读它用于详情，
+// 判题也由主 app 负责（POST /tasks/{id}/answer）。
 func (s *TaskService) finalizeQuiz(taskID string, task *model.TaskQuizTask, quiz *Quiz, fromStatus string) {
-	if quiz == nil || quiz.Question == "" {
+	if quiz == nil || len(quiz.Questions) == 0 {
 		slog.Error("[TASK] finalizeQuiz: quiz empty, marking failed", "task_id", taskID)
 		_, _ = repo.ConditionalUpdate(taskID, fromStatus, "failed", nil)
 		return
 	}
-	limitSec := quiz.AnswerTimeLimitSeconds
+	// 任务级答题时限取第一题的建议值（deadline 是任务级的）
+	limitSec := quiz.Questions[0].AnswerTimeLimitSeconds
 	if limitSec <= 0 {
 		limitSec = 1200
 	}
 	deadline := time.Now().UTC().Add(time.Duration(limitSec) * time.Second)
 
-	// Store quiz to app-task's own Mongo so detail/SubmitAnswer can read it back.
-	// Main app stores its copy (for /status polling) in the main app's Mongo;
-	// app-task may use a different Mongo connection/db, so it needs its own copy.
-	quizDoc := map[string]any{
-		"task_id":                   taskID,
-		"uid":                       task.UID,
-		"question":                  quiz.Question,
-		"question_type":             quiz.QuestionType,
-		"options":                   quiz.Options,
-		"answer":                    quiz.Answer,
-		"difficulty":                quiz.Difficulty,
-		"answer_time_limit_seconds": limitSec,
-		"generated_at":              time.Now().UTC().Format(time.RFC3339),
-	}
-	if err := repo.InsertQuiz(context.Background(), quizDoc); err != nil {
-		slog.Error("[TASK] store quiz failed, marking task failed", "task_id", taskID, "err", err)
-		_, _ = repo.ConditionalUpdate(taskID, fromStatus, "failed", nil)
-		return
-	}
-
 	cc := toStringSliceJSON(task.CCEmails)
-	quizMap := map[string]any{
-		"question":                  quiz.Question,
-		"question_type":             quiz.QuestionType,
-		"options":                   quiz.Options,
-		"answer":                    quiz.Answer,
-		"difficulty":                quiz.Difficulty,
-		"answer_time_limit_seconds": limitSec,
-	}
-	if err := EnqueueQuizEmail(taskID, task.UserEmail, cc, quizMap, formatBeijing(deadline)); err != nil {
+	if err := EnqueueQuizEmail(taskID, task.UserEmail, cc, task.Prompt, quiz.Questions, formatBeijing(deadline)); err != nil {
 		slog.Error("[TASK] enqueue quiz email failed, marking task failed", "task_id", taskID, "err", err)
 		_, _ = repo.ConditionalUpdate(taskID, fromStatus, "failed", nil)
 		return
@@ -189,56 +160,7 @@ func (s *TaskService) finalizeQuiz(taskID string, task *model.TaskQuizTask, quiz
 		slog.Error("[TASK] mark sent failed", "task_id", taskID, "err", err)
 		return
 	}
-	slog.Info("[TASK] executed", "task_id", taskID, "deadline", formatBeijing(deadline), "question_len", len(quiz.Question), "answer_len", len(quiz.Answer))
-}
-
-// SubmitAnswer records answer, judges, marks completed.
-// No job cancellation needed: scheduler's CheckTimeout skips non-sent tasks.
-func (s *TaskService) SubmitAnswer(taskID string, uid int64, answer string) (map[string]any, error) {
-	task, err := repo.GetTaskByID(taskID)
-	if err != nil {
-		return nil, fmt.Errorf("get task: %w", err)
-	}
-	if task == nil {
-		return nil, ErrNotFound
-	}
-	if task.UID != uid {
-		return nil, ErrForbidden
-	}
-
-	existing, err := repo.GetAnswerByTaskID(taskID)
-	if err != nil {
-		return nil, err
-	}
-	if existing != nil {
-		return map[string]any{"status": task.Status, "is_correct": existing.IsCorrect}, nil
-	}
-
-	quiz, err := repo.GetQuizByTaskID(context.Background(), taskID)
-	if err != nil {
-		return nil, err
-	}
-	isCorrect := judge(quiz, answer)
-
-	if err := repo.CreateAnswer(&model.TaskQuizAnswer{
-		TaskID: taskID, UID: uid, Answer: answer, IsCorrect: isCorrect,
-	}); err != nil {
-		return nil, fmt.Errorf("create answer: %w", err)
-	}
-
-	updated, err := repo.ConditionalUpdate(taskID, "sent", "completed", nil)
-	if err != nil {
-		return nil, err
-	}
-	if !updated {
-		slog.Warn("[TASK] answer for task but status not sent (race lost)", "task_id", taskID, "status", task.Status)
-	}
-
-	status := task.Status
-	if updated {
-		status = "completed"
-	}
-	return map[string]any{"status": status, "is_correct": isCorrect}, nil
+	slog.Info("[TASK] executed", "task_id", taskID, "deadline", formatBeijing(deadline), "question_count", len(quiz.Questions))
 }
 
 // CheckTimeout marks overdue + enqueues incomplete email.
@@ -264,19 +186,4 @@ func (s *TaskService) CheckTimeout(taskID string) {
 		slog.Error("[TASK] enqueue overdue email failed", "task_id", taskID, "err", err)
 	}
 	slog.Info("[TASK] overdue", "task_id", taskID)
-}
-
-func judge(quiz map[string]any, answer string) bool {
-	if quiz == nil {
-		return false
-	}
-	correct := strings.TrimSpace(str(quiz["answer"]))
-	given := strings.TrimSpace(answer)
-	if correct == "" {
-		return false
-	}
-	if str(quiz["question_type"]) == "short_answer" {
-		return strings.Contains(strings.ToLower(given), strings.ToLower(correct))
-	}
-	return correct == given
 }

--- a/app-task/internal/service/task_service_test.go
+++ b/app-task/internal/service/task_service_test.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"context"
 	"errors"
 	"testing"
 	"time"
@@ -37,45 +36,6 @@ func setupTestDB(t *testing.T) {
 		t.Fatalf("migrate: %v", err)
 	}
 	db.DB = gdb
-	// Stub Mongo InsertQuiz: finalizeQuiz stores quiz to app-task Mongo; tests
-	// don't have real Mongo, so no-op (router_test.go does the same).
-	repo.InsertQuiz = func(context.Context, map[string]any) error { return nil }
-}
-
-// ── judge: pure function, no DB ──────────────────────────────────
-
-func TestJudge(t *testing.T) {
-	tests := []struct {
-		name   string
-		quiz   map[string]any
-		answer string
-		want   bool
-	}{
-		// choice / fill_blank: exact match after TrimSpace (case-sensitive)
-		{"choice correct", map[string]any{"question_type": "choice", "answer": "A"}, "A", true},
-		{"choice trim whitespace", map[string]any{"question_type": "choice", "answer": "A"}, "  A  ", true},
-		{"choice wrong option", map[string]any{"question_type": "choice", "answer": "A"}, "B", false},
-		{"choice case sensitive", map[string]any{"question_type": "choice", "answer": "A"}, "a", false},
-		{"fill_blank correct", map[string]any{"question_type": "fill_blank", "answer": "42"}, "42", true},
-		{"fill_blank trim", map[string]any{"question_type": "fill_blank", "answer": "42"}, " 42 ", true},
-		{"fill_blank wrong", map[string]any{"question_type": "fill_blank", "answer": "42"}, "43", false},
-		// short_answer: case-insensitive contains
-		{"short_answer contains", map[string]any{"question_type": "short_answer", "answer": "牛顿"}, "牛顿发现万有引力", true},
-		{"short_answer case insensitive", map[string]any{"question_type": "short_answer", "answer": "Newton"}, "isaac newton was here", true},
-		{"short_answer not contains", map[string]any{"question_type": "short_answer", "answer": "牛顿"}, "爱因斯坦", false},
-		// edge cases
-		{"nil quiz", nil, "A", false},
-		{"empty answer", map[string]any{"question_type": "choice", "answer": "A"}, "", false},
-		{"empty correct", map[string]any{"question_type": "choice", "answer": ""}, "A", false},
-		{"unknown type falls back to exact", map[string]any{"question_type": "unknown", "answer": "X"}, "X", true},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := judge(tt.quiz, tt.answer); got != tt.want {
-				t.Errorf("judge() = %v, want %v", got, tt.want)
-			}
-		})
-	}
 }
 
 // ── RegisterTask: persists task with difficulty + state ──────────
@@ -85,7 +45,7 @@ func TestRegisterTask(t *testing.T) {
 	svc := NewTaskService(nil) // appClient nil — RegisterTask never calls it
 
 	trigger := time.Now().UTC().Add(time.Hour)
-	taskID, err := svc.RegisterTask(1, "u@x.com", []string{"c@x.com"}, "数学1填空题", "hard", trigger, "加油")
+	taskID, err := svc.RegisterTask(1, "u@x.com", []string{"c@x.com"}, "数学1填空题", "hard", 1, trigger, "加油")
 	if err != nil {
 		t.Fatalf("RegisterTask: %v", err)
 	}
@@ -124,7 +84,7 @@ func TestRegisterTask_DefaultDifficulty(t *testing.T) {
 	setupTestDB(t)
 	svc := NewTaskService(nil)
 	// empty difficulty -> should default to "medium"
-	taskID, err := svc.RegisterTask(1, "u@x.com", nil, "prompt", "", time.Now().UTC().Add(time.Hour), "")
+	taskID, err := svc.RegisterTask(1, "u@x.com", nil, "prompt", "", 1, time.Now().UTC().Add(time.Hour), "")
 	if err != nil {
 		t.Fatalf("RegisterTask: %v", err)
 	}
@@ -140,7 +100,7 @@ func TestRegisterTask_DefaultDifficulty(t *testing.T) {
 func TestRegisterTask_EmptyIncomplete(t *testing.T) {
 	setupTestDB(t)
 	svc := NewTaskService(nil)
-	taskID, _ := svc.RegisterTask(1, "u@x.com", nil, "prompt", "medium", time.Now().UTC().Add(time.Hour), "")
+	taskID, _ := svc.RegisterTask(1, "u@x.com", nil, "prompt", "medium", 1, time.Now().UTC().Add(time.Hour), "")
 	task, _ := repo.GetTaskByID(taskID)
 	if task == nil {
 		t.Fatal("task not persisted")
@@ -150,58 +110,12 @@ func TestRegisterTask_EmptyIncomplete(t *testing.T) {
 	}
 }
 
-// ── SubmitAnswer: ownership + idempotency (no Mongo needed) ──────
-
-func TestSubmitAnswer_TaskNotFound(t *testing.T) {
-	setupTestDB(t)
-	svc := NewTaskService(nil)
-	_, err := svc.SubmitAnswer("nonexistent-task", 1, "A")
-	if err != ErrNotFound {
-		t.Errorf("want ErrNotFound, got %v", err)
-	}
-}
-
-func TestSubmitAnswer_NotOwner(t *testing.T) {
-	setupTestDB(t)
-	svc := NewTaskService(nil)
-	taskID, _ := svc.RegisterTask(1, "u@x.com", nil, "prompt", "medium", time.Now().UTC().Add(time.Hour), "")
-	// uid 999 != owner 1
-	_, err := svc.SubmitAnswer(taskID, 999, "A")
-	if err != ErrForbidden {
-		t.Errorf("want ErrForbidden, got %v", err)
-	}
-}
-
-func TestSubmitAnswer_AlreadyAnswered(t *testing.T) {
-	setupTestDB(t)
-	svc := NewTaskService(nil)
-	taskID, _ := svc.RegisterTask(1, "u@x.com", nil, "prompt", "medium", time.Now().UTC().Add(time.Hour), "")
-	// simulate: task already sent + an answer row already exists
-	if ok, _ := repo.ConditionalUpdate(taskID, "pending", "sent", nil); !ok {
-		t.Fatal("ConditionalUpdate pending->sent failed")
-	}
-	if err := repo.CreateAnswer(&model.TaskQuizAnswer{
-		TaskID: taskID, UID: 1, Answer: "A", IsCorrect: true,
-	}); err != nil {
-		t.Fatalf("CreateAnswer: %v", err)
-	}
-
-	// second submit should short-circuit and return the existing answer
-	res, err := svc.SubmitAnswer(taskID, 1, "B")
-	if err != nil {
-		t.Fatalf("SubmitAnswer: %v", err)
-	}
-	if res["is_correct"] != true {
-		t.Errorf("want existing is_correct=true, got %v", res["is_correct"])
-	}
-}
-
 // ── State machine: ConditionalUpdate semantics ───────────────────
 
 func TestConditionalUpdate_GuardsStateTransition(t *testing.T) {
 	setupTestDB(t)
 	svc := NewTaskService(nil)
-	taskID, _ := svc.RegisterTask(1, "u@x.com", nil, "prompt", "medium", time.Now().UTC().Add(time.Hour), "")
+	taskID, _ := svc.RegisterTask(1, "u@x.com", nil, "prompt", "medium", 1, time.Now().UTC().Add(time.Hour), "")
 
 	// pending -> sent: ok
 	ok, err := repo.ConditionalUpdate(taskID, "pending", "sent", nil)
@@ -225,140 +139,6 @@ func TestConditionalUpdate_GuardsStateTransition(t *testing.T) {
 	}
 }
 
-// ── SubmitAnswer full path: judge + CreateAnswer + state transition ──
-// These stub repo.GetQuizByTaskID (Mongo) so the whole chain runs against
-// SQLite for the MySQL side, exercising judge + CreateAnswer + ConditionalUpdate.
-
-// withQuiz stubs repo.GetQuizByTaskID to return the given quiz doc, and
-// restores the original on test cleanup.
-func withQuiz(t *testing.T, quiz map[string]any) {
-	t.Helper()
-	orig := repo.GetQuizByTaskID
-	repo.GetQuizByTaskID = func(ctx context.Context, _ string) (map[string]any, error) {
-		return quiz, nil
-	}
-	t.Cleanup(func() { repo.GetQuizByTaskID = orig })
-}
-
-// registerSentTask creates a task and advances it to the "sent" state,
-// ready for answering.
-func registerSentTask(t *testing.T, svc *TaskService, uid int64) string {
-	t.Helper()
-	taskID, err := svc.RegisterTask(uid, "u@x.com", nil, "prompt", "medium", time.Now().UTC().Add(time.Hour), "")
-	if err != nil {
-		t.Fatalf("RegisterTask: %v", err)
-	}
-	if ok, _ := repo.ConditionalUpdate(taskID, "pending", "sent", nil); !ok {
-		t.Fatal("ConditionalUpdate pending->sent failed")
-	}
-	return taskID
-}
-
-func TestSubmitAnswer_CorrectChoice(t *testing.T) {
-	setupTestDB(t)
-	svc := NewTaskService(nil)
-	taskID := registerSentTask(t, svc, 1)
-	withQuiz(t, map[string]any{"question_type": "choice", "answer": "A", "options": []any{"A", "B", "C"}})
-
-	res, err := svc.SubmitAnswer(taskID, 1, "A")
-	if err != nil {
-		t.Fatalf("SubmitAnswer: %v", err)
-	}
-	if res["is_correct"] != true {
-		t.Errorf("is_correct = %v, want true", res["is_correct"])
-	}
-	if res["status"] != "completed" {
-		t.Errorf("status = %v, want completed", res["status"])
-	}
-	// answer persisted with is_correct=true
-	ans, _ := repo.GetAnswerByTaskID(taskID)
-	if ans == nil || !ans.IsCorrect {
-		t.Errorf("answer not persisted / is_correct wrong: %+v", ans)
-	}
-	// task moved to completed
-	task, _ := repo.GetTaskByID(taskID)
-	if task.Status != "completed" {
-		t.Errorf("task status = %q, want completed", task.Status)
-	}
-}
-
-func TestSubmitAnswer_WrongChoice(t *testing.T) {
-	setupTestDB(t)
-	svc := NewTaskService(nil)
-	taskID := registerSentTask(t, svc, 1)
-	withQuiz(t, map[string]any{"question_type": "choice", "answer": "A", "options": []any{"A", "B", "C"}})
-
-	res, err := svc.SubmitAnswer(taskID, 1, "B")
-	if err != nil {
-		t.Fatalf("SubmitAnswer: %v", err)
-	}
-	if res["is_correct"] != false {
-		t.Errorf("is_correct = %v, want false", res["is_correct"])
-	}
-	// wrong answer still completes the task (status -> completed)
-	if res["status"] != "completed" {
-		t.Errorf("status = %v, want completed (wrong answer still completes)", res["status"])
-	}
-}
-
-func TestSubmitAnswer_ShortAnswerContains(t *testing.T) {
-	setupTestDB(t)
-	svc := NewTaskService(nil)
-	taskID := registerSentTask(t, svc, 1)
-	withQuiz(t, map[string]any{"question_type": "short_answer", "answer": "牛顿"})
-
-	res, err := svc.SubmitAnswer(taskID, 1, "牛顿发现了万有引力定律")
-	if err != nil {
-		t.Fatalf("SubmitAnswer: %v", err)
-	}
-	if res["is_correct"] != true {
-		t.Errorf("is_correct = %v, want true (short_answer uses contains match)", res["is_correct"])
-	}
-}
-
-func TestSubmitAnswer_QuizNotFound(t *testing.T) {
-	setupTestDB(t)
-	svc := NewTaskService(nil)
-	taskID := registerSentTask(t, svc, 1)
-	// quiz doc missing (e.g. ExecuteQuiz crashed before InsertQuiz)
-	withQuiz(t, nil)
-
-	res, err := svc.SubmitAnswer(taskID, 1, "A")
-	if err != nil {
-		t.Fatalf("SubmitAnswer: %v", err)
-	}
-	// nil quiz -> judge returns false; answer still recorded, task still completes
-	if res["is_correct"] != false {
-		t.Errorf("is_correct = %v, want false (nil quiz -> judge false)", res["is_correct"])
-	}
-}
-
-func TestSubmitAnswer_RaceLostToTimeout(t *testing.T) {
-	setupTestDB(t)
-	svc := NewTaskService(nil)
-	taskID := registerSentTask(t, svc, 1)
-	withQuiz(t, map[string]any{"question_type": "choice", "answer": "A"})
-
-	// simulate: timeout already moved the task to "overdue" before this submit
-	if ok, _ := repo.ConditionalUpdate(taskID, "sent", "overdue", nil); !ok {
-		t.Fatal("ConditionalUpdate sent->overdue failed")
-	}
-
-	res, err := svc.SubmitAnswer(taskID, 1, "A")
-	if err != nil {
-		t.Fatalf("SubmitAnswer: %v", err)
-	}
-	// answer is correct and persisted...
-	if res["is_correct"] != true {
-		t.Errorf("is_correct = %v, want true", res["is_correct"])
-	}
-	// ...but status is NOT "completed" (ConditionalUpdate sent->completed lost
-	// the race to the timeout's sent->overdue)
-	if res["status"] == "completed" {
-		t.Errorf("status = completed, but race should have been lost to overdue")
-	}
-}
-
 // ── ExecuteQuiz: generate + store + notify + state transition ──
 
 type mockAppClient struct {
@@ -369,7 +149,7 @@ type mockAppClient struct {
 	statusErr     error
 }
 
-func (m *mockAppClient) RequestQuiz(taskID, prompt string, uid int64, difficulty string) (*QuizGenResponse, error) {
+func (m *mockAppClient) RequestQuiz(taskID, prompt string, uid int64, difficulty string, questionCount int) (*QuizGenResponse, error) {
 	if m.requestErr != nil {
 		return nil, m.requestErr
 	}
@@ -388,18 +168,22 @@ func (m *mockAppClient) GetQuizStatus(taskID string) (*QuizGenResponse, error) {
 
 // testQuiz is a ready Quiz returned by mockAppClient when requestStatus=ready.
 var testQuiz = &Quiz{
-	Question:               "1+1=?",
-	QuestionType:           "choice",
-	Options:                []string{"1", "2", "3"},
-	Answer:                 "2",
-	Difficulty:             "easy",
-	AnswerTimeLimitSeconds: 600,
+	Questions: []QuizQuestion{
+		{
+			Question:               "1+1=?",
+			QuestionType:           "choice",
+			Options:                []string{"1", "2", "3"},
+			Answer:                 "2",
+			Difficulty:             "easy",
+			AnswerTimeLimitSeconds: 600,
+		},
+	},
 }
 
 func TestExecuteQuiz_Generating(t *testing.T) {
 	setupTestDB(t)
 	svc := NewTaskService(&mockAppClient{requestStatus: "generating"})
-	taskID, _ := svc.RegisterTask(1, "u@x.com", nil, "prompt", "medium", time.Now().UTC().Add(-time.Minute), "")
+	taskID, _ := svc.RegisterTask(1, "u@x.com", nil, "prompt", "medium", 1, time.Now().UTC().Add(-time.Minute), "")
 
 	svc.ExecuteQuiz(taskID)
 
@@ -417,7 +201,7 @@ func TestExecuteQuiz_Generating(t *testing.T) {
 func TestExecuteQuiz_Ready(t *testing.T) {
 	setupTestDB(t)
 	svc := NewTaskService(&mockAppClient{requestStatus: "ready", requestQuiz: testQuiz})
-	taskID, _ := svc.RegisterTask(1, "u@x.com", []string{"c@x.com"}, "prompt", "easy", time.Now().UTC().Add(-time.Minute), "")
+	taskID, _ := svc.RegisterTask(1, "u@x.com", []string{"c@x.com"}, "prompt", "easy", 1, time.Now().UTC().Add(-time.Minute), "")
 
 	svc.ExecuteQuiz(taskID)
 
@@ -438,7 +222,7 @@ func TestExecuteQuiz_Ready(t *testing.T) {
 func TestExecuteQuiz_RequestFails(t *testing.T) {
 	setupTestDB(t)
 	svc := NewTaskService(&mockAppClient{requestErr: errors.New("connection refused")})
-	taskID, _ := svc.RegisterTask(1, "u@x.com", nil, "prompt", "medium", time.Now().UTC().Add(-time.Minute), "")
+	taskID, _ := svc.RegisterTask(1, "u@x.com", nil, "prompt", "medium", 1, time.Now().UTC().Add(-time.Minute), "")
 
 	svc.ExecuteQuiz(taskID)
 
@@ -451,7 +235,7 @@ func TestExecuteQuiz_RequestFails(t *testing.T) {
 func TestExecuteQuiz_SkipIfNotPending(t *testing.T) {
 	setupTestDB(t)
 	svc := NewTaskService(&mockAppClient{requestStatus: "ready", requestQuiz: testQuiz})
-	taskID, _ := svc.RegisterTask(1, "u@x.com", nil, "prompt", "medium", time.Now().UTC().Add(-time.Minute), "")
+	taskID, _ := svc.RegisterTask(1, "u@x.com", nil, "prompt", "medium", 1, time.Now().UTC().Add(-time.Minute), "")
 	repo.ConditionalUpdate(taskID, "pending", "sent", nil)
 
 	svc.ExecuteQuiz(taskID)
@@ -480,7 +264,7 @@ func TestProcessGenerating_Ready(t *testing.T) {
 	svc := NewTaskService(&mockAppClient{
 		statusResp: &QuizGenResponse{Status: "ready", Quiz: testQuiz},
 	})
-	taskID, _ := svc.RegisterTask(1, "u@x.com", nil, "prompt", "medium", time.Now().UTC().Add(-time.Hour), "")
+	taskID, _ := svc.RegisterTask(1, "u@x.com", nil, "prompt", "medium", 1, time.Now().UTC().Add(-time.Hour), "")
 	repo.ConditionalUpdate(taskID, "pending", "generating", nil)
 
 	svc.ProcessGenerating(taskID)
@@ -496,7 +280,7 @@ func TestProcessGenerating_Failed(t *testing.T) {
 	svc := NewTaskService(&mockAppClient{
 		statusResp: &QuizGenResponse{Status: "failed", Error: "LLM error"},
 	})
-	taskID, _ := svc.RegisterTask(1, "u@x.com", nil, "prompt", "medium", time.Now().UTC().Add(-time.Hour), "")
+	taskID, _ := svc.RegisterTask(1, "u@x.com", nil, "prompt", "medium", 1, time.Now().UTC().Add(-time.Hour), "")
 	repo.ConditionalUpdate(taskID, "pending", "generating", nil)
 
 	svc.ProcessGenerating(taskID)
@@ -510,7 +294,7 @@ func TestProcessGenerating_Failed(t *testing.T) {
 func TestProcessGenerating_StillGenerating(t *testing.T) {
 	setupTestDB(t)
 	svc := NewTaskService(&mockAppClient{statusResp: &QuizGenResponse{Status: "generating"}})
-	taskID, _ := svc.RegisterTask(1, "u@x.com", nil, "prompt", "medium", time.Now().UTC().Add(-time.Hour), "")
+	taskID, _ := svc.RegisterTask(1, "u@x.com", nil, "prompt", "medium", 1, time.Now().UTC().Add(-time.Hour), "")
 	repo.ConditionalUpdate(taskID, "pending", "generating", nil)
 
 	svc.ProcessGenerating(taskID)
@@ -524,7 +308,7 @@ func TestProcessGenerating_StillGenerating(t *testing.T) {
 func TestProcessGenerating_SkipIfNotGenerating(t *testing.T) {
 	setupTestDB(t)
 	svc := NewTaskService(&mockAppClient{statusResp: &QuizGenResponse{Status: "ready", Quiz: testQuiz}})
-	taskID, _ := svc.RegisterTask(1, "u@x.com", nil, "prompt", "medium", time.Now().UTC().Add(-time.Hour), "")
+	taskID, _ := svc.RegisterTask(1, "u@x.com", nil, "prompt", "medium", 1, time.Now().UTC().Add(-time.Hour), "")
 	repo.ConditionalUpdate(taskID, "pending", "sent", nil)
 
 	svc.ProcessGenerating(taskID)
@@ -543,7 +327,7 @@ func TestProcessGenerating_SkipIfNotGenerating(t *testing.T) {
 func TestCheckTimeout_Success(t *testing.T) {
 	setupTestDB(t)
 	svc := NewTaskService(nil) // CheckTimeout never calls appClient
-	taskID, _ := svc.RegisterTask(1, "u@x.com", []string{"c@x.com"}, "数学1", "medium", time.Now().UTC().Add(-time.Hour), "加油快做")
+	taskID, _ := svc.RegisterTask(1, "u@x.com", []string{"c@x.com"}, "数学1", "medium", 1, time.Now().UTC().Add(-time.Hour), "加油快做")
 	// advance to sent (quiz delivered, waiting for answer)
 	repo.ConditionalUpdate(taskID, "pending", "sent", nil)
 
@@ -568,7 +352,7 @@ func TestCheckTimeout_SkipIfNotSent(t *testing.T) {
 	setupTestDB(t)
 	svc := NewTaskService(nil)
 	// task still pending (not yet sent) -> CheckTimeout should skip
-	taskID, _ := svc.RegisterTask(1, "u@x.com", nil, "prompt", "medium", time.Now().UTC().Add(-time.Hour), "")
+	taskID, _ := svc.RegisterTask(1, "u@x.com", nil, "prompt", "medium", 1, time.Now().UTC().Add(-time.Hour), "")
 
 	svc.CheckTimeout(taskID)
 
@@ -593,7 +377,7 @@ func TestCheckTimeout_TaskNotFound(t *testing.T) {
 func TestCheckTimeout_RaceLostToAnswer(t *testing.T) {
 	setupTestDB(t)
 	svc := NewTaskService(nil)
-	taskID, _ := svc.RegisterTask(1, "u@x.com", nil, "prompt", "medium", time.Now().UTC().Add(-time.Hour), "")
+	taskID, _ := svc.RegisterTask(1, "u@x.com", nil, "prompt", "medium", 1, time.Now().UTC().Add(-time.Hour), "")
 	// user answered just before timeout: sent -> completed
 	repo.ConditionalUpdate(taskID, "pending", "sent", nil)
 	repo.ConditionalUpdate(taskID, "sent", "completed", nil)
@@ -612,32 +396,7 @@ func TestCheckTimeout_RaceLostToAnswer(t *testing.T) {
 	}
 }
 
-// ── finalizeQuiz: store/enqueue failures must NOT silently advance to sent ──
-
-func TestFinalizeQuiz_StoreQuizFails(t *testing.T) {
-	setupTestDB(t)
-	// stub InsertQuiz to fail (e.g. Mongo down) -> finalizeQuiz must abort
-	orig := repo.InsertQuiz
-	repo.InsertQuiz = func(context.Context, map[string]any) error {
-		return errors.New("mongo connection refused")
-	}
-	t.Cleanup(func() { repo.InsertQuiz = orig })
-
-	svc := NewTaskService(&mockAppClient{requestStatus: "ready", requestQuiz: testQuiz})
-	taskID, _ := svc.RegisterTask(1, "u@x.com", nil, "prompt", "medium", time.Now().UTC().Add(-time.Minute), "")
-
-	svc.ExecuteQuiz(taskID)
-
-	task, _ := repo.GetTaskByID(taskID)
-	if task.Status != "failed" {
-		t.Errorf("status = %q, want failed (store quiz failed must not advance to sent)", task.Status)
-	}
-	var notifs []model.TaskQuizNotification
-	db.DB.Find(&notifs)
-	if len(notifs) != 0 {
-		t.Errorf("notifications = %d, want 0 (finalize aborted before enqueue)", len(notifs))
-	}
-}
+// ── finalizeQuiz: enqueue failures must NOT silently advance to sent ──
 
 func TestFinalizeQuiz_EnqueueFails(t *testing.T) {
 	setupTestDB(t)
@@ -649,7 +408,7 @@ func TestFinalizeQuiz_EnqueueFails(t *testing.T) {
 	t.Cleanup(func() { repo.CreateNotification = orig })
 
 	svc := NewTaskService(&mockAppClient{requestStatus: "ready", requestQuiz: testQuiz})
-	taskID, _ := svc.RegisterTask(1, "u@x.com", nil, "prompt", "medium", time.Now().UTC().Add(-time.Minute), "")
+	taskID, _ := svc.RegisterTask(1, "u@x.com", nil, "prompt", "medium", 1, time.Now().UTC().Add(-time.Minute), "")
 
 	svc.ExecuteQuiz(taskID)
 

--- a/app-task/internal/service/template/quiz_email.html
+++ b/app-task/internal/service/template/quiz_email.html
@@ -11,14 +11,16 @@
     </tr>
     <tr>
       <td style="padding: 24px 0 8px;">
-        <p style="margin: 0 0 16px; font-size: 15px; line-height: 1.7;">您预约的定时出题任务已生成，请在答题时限内登录系统完成作答。</p>
+        <p style="margin: 0 0 16px; font-size: 15px; line-height: 1.7;">您预约的定时出题任务已生成，共 <strong>{{.Count}}</strong> 道题，请在答题时限内登录系统完成作答。</p>
       </td>
     </tr>
+    {{if .ShowDetail}}
+    {{range .Questions}}
     <tr>
       <td style="padding: 0 0 16px;">
         <table width="100%" cellpadding="0" cellspacing="0" style="background: #f7f8fa; border-radius: 8px; border: 1px solid #e5e6eb;">
           <tr><td style="padding: 20px;">
-            <p style="margin: 0 0 12px; font-size: 12px; font-weight: 600; color: #86909c; letter-spacing: 1px;">题目</p>
+            <p style="margin: 0 0 12px; font-size: 12px; font-weight: 600; color: #86909c; letter-spacing: 1px;">第 {{.Index}} 题</p>
             <p style="margin: 0 0 16px; font-size: 16px; font-weight: 600; line-height: 1.6;">{{.Question}}</p>
             {{if and (eq .QuestionType "choice") .Options}}
             <ol type="A" style="margin: 0 0 0 20px; padding: 0; line-height: 2; font-size: 15px;">
@@ -33,6 +35,20 @@
         </table>
       </td>
     </tr>
+    {{end}}
+    {{else}}
+    <tr>
+      <td style="padding: 0 0 16px;">
+        <table width="100%" cellpadding="0" cellspacing="0" style="background: #f7f8fa; border-radius: 8px; border: 1px solid #e5e6eb;">
+          <tr><td style="padding: 20px;">
+            <p style="margin: 0 0 8px; font-size: 12px; font-weight: 600; color: #86909c; letter-spacing: 1px;">出题方向</p>
+            <p style="margin: 0; font-size: 15px; line-height: 1.6;">{{.Prompt}}</p>
+            <p style="margin: 14px 0 0; font-size: 14px; color: #4e5969; line-height: 1.7;">本次共生成 <strong>{{.Count}}</strong> 道题，具体题目请在登录 MindBase 后查看。</p>
+          </td></tr>
+        </table>
+      </td>
+    </tr>
+    {{end}}
     <tr>
       <td style="padding: 8px 0 24px;">
         <table width="100%" cellpadding="0" cellspacing="0" style="background: #e8f3ff; border-radius: 6px; border-left: 3px solid #3370ff;">

--- a/app-task/internal/service/util.go
+++ b/app-task/internal/service/util.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"encoding/json"
-	"fmt"
 	"time"
 
 	"gorm.io/datatypes"
@@ -19,49 +18,9 @@ func init() {
 	beijingLoc = loc
 }
 
-// str coerces an any (from JSON/map) to string.
-func str(v any) string {
-	if v == nil {
-		return ""
-	}
-	if s, ok := v.(string); ok {
-		return s
-	}
-	return fmt.Sprint(v)
-}
-
-// toInt coerces an any (JSON numbers decode as float64) to int.
-func toInt(v any) int {
-	switch n := v.(type) {
-	case float64:
-		return int(n)
-	case int:
-		return n
-	case int64:
-		return int(n)
-	default:
-		return 0
-	}
-}
-
 func toJSON(ss []string) datatypes.JSON {
 	b, _ := json.Marshal(ss)
 	return datatypes.JSON(b)
-}
-
-func toStringSlice(v any) []string {
-	if v == nil {
-		return nil
-	}
-	arr, ok := v.([]any)
-	if !ok {
-		return nil
-	}
-	out := make([]string, 0, len(arr))
-	for _, x := range arr {
-		out = append(out, fmt.Sprint(x))
-	}
-	return out
 }
 
 func toStringSliceJSON(j datatypes.JSON) []string {

--- a/app/agent/task_quiz/prompts.py
+++ b/app/agent/task_quiz/prompts.py
@@ -34,7 +34,11 @@ QUIZ_GEN_SYS_PROMPT = (
     "【格式要求】\n"
     "1. question_type 只能是 fill_blank / choice / short_answer 之一；\n"
     "2. difficulty 必须等于用户指定的难度值，不要自行更改；\n"
-    "3. 选择题必须给出 options（2-4 个）并确保 answer 是其中一项；填空题/简答题 options 留空；\n"
+    "3. 必须输出恰好“出题数量”道题（questions 数组长度等于出题数量），每题都是独立对象，且：\n"
+    "   - 选择题必须给出 4 个选项，且 answer 必须填写正确选项的完整文本，与 options 中某一项逐字完全一致，禁止只填字母编号（如 'B'）或简写；\n"
+    "   - 每个选择题的四个选项中必须恰好只有一个是正确答案，其余为明显错误或干扰项，绝不允许出现两个及以上正确选项（可用数值代入或反例检验）；\n"
+    "   - 多道题之间不得重复或雷同，覆盖不同知识点；\n"
+    "   填空题/简答题 options 留空；\n"
     "4. answer_time_limit_seconds 按难度给：easy≈600、medium≈1200、hard≈1800。\n"
     "返回结构化结果。"
 )

--- a/app/database.py
+++ b/app/database.py
@@ -115,6 +115,9 @@ async def _migrate_add_columns():
         ("credential_usage", "cost_estimate", "NUMERIC(12, 6) DEFAULT 0.0"),
         # task-quiz: difficulty column (easy/medium/hard, default medium)
         ("task_quiz_task", "difficulty", "VARCHAR(20) DEFAULT 'medium'"),
+        # task-quiz: multi-question support (one task can generate N questions)
+        ("task_quiz_task", "question_count", "INTEGER DEFAULT 1"),
+        ("task_quiz_answer", "question_index", "INTEGER DEFAULT 0"),
     ]
 
     # Column type modifications (widening VARCHAR, etc.)

--- a/app/main.py
+++ b/app/main.py
@@ -44,6 +44,7 @@ from app.routers.admin_code_executions import router as admin_code_executions_ro
 from app.routers.internal_quiz import router as internal_quiz_router
 from app.routers.internal_auth import router as internal_auth_router
 from app.routers.task_quiz import router as task_quiz_router
+from app.routers.task_answer import router as task_answer_router
 
 
 # ---------------------------------------------------------------------------
@@ -468,6 +469,8 @@ app.include_router(admin_code_executions_router)
 app.include_router(internal_quiz_router)
 app.include_router(internal_auth_router)
 app.include_router(task_quiz_router)
+# 定时出题答题提交（判题/入库业务在主 app；app-task 只做调度+通知）
+app.include_router(task_answer_router)
 
 # Preferences - extensible KV (wallpaper/theme/language)
 from app.routers.preferences import router as preferences_router  # noqa: E402

--- a/app/models.py
+++ b/app/models.py
@@ -1007,6 +1007,7 @@ class TaskQuizTask(Base):
     cc_emails = Column(JSON, nullable=False)  # ["a@x.com", "b@y.com"]
     prompt = Column(String(500), nullable=False)  # 出题方向（粗粒度，如"数学1填空题"）
     difficulty = Column(String(20), default="medium", nullable=False)  # easy/medium/hard（考研难度：简单/中等/压轴）
+    question_count = Column(Integer, default=1, nullable=False)  # 本次任务出题数量（1~5）
     incomplete_message = Column(Text, nullable=True)  # 自定义未完成语录；null=用默认模板
     trigger_time = Column(DateTime, nullable=False)  # 出题触发时间（UTC aware）
     status = Column(
@@ -1031,6 +1032,7 @@ class TaskQuizAnswer(Base):
     id = Column(Integer, primary_key=True, autoincrement=True)
     task_id = Column(String(64), nullable=False, index=True)
     uid = Column(BigInteger, ForeignKey("users.uid"), nullable=False, index=True)
+    question_index = Column(Integer, default=0, nullable=False)  # 0-based；一道任务多题时每题一行
     answer = Column(Text, nullable=False)
     is_correct = Column(Boolean, nullable=False)
     submitted_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))

--- a/app/routers/internal_quiz.py
+++ b/app/routers/internal_quiz.py
@@ -21,6 +21,7 @@ class QuizGenerateRequest(BaseModel):
     prompt: str  # 出题方向（粗粒度，如"数学1填空题"）
     uid: int | None = None
     difficulty: str = "medium"  # easy/medium/hard（考研难度：简单/中等/压轴）
+    question_count: int = 1  # 本次任务出题数量（1~5）
     task_id: str  # app-task passes this for idempotency + status polling
 
 
@@ -28,7 +29,9 @@ class QuizGenerateRequest(BaseModel):
 async def generate_llm(req: QuizGenerateRequest):
     """Async + idempotent quiz generation. Returns generating/ready immediately."""
     try:
-        return await QuizGenService.generate(req.task_id, req.prompt, req.difficulty, req.uid)
+        return await QuizGenService.generate(
+            req.task_id, req.prompt, req.difficulty, req.uid, req.question_count
+        )
     except ValueError as e:
         raise HTTPException(400, str(e))
     except RuntimeError as e:

--- a/app/routers/task_answer.py
+++ b/app/routers/task_answer.py
@@ -1,0 +1,58 @@
+"""用户答题提交端点：POST /tasks/{task_id}/answer（主 app 负责判题/入库）。
+
+Auth: APISIX forward-auth 校验 bili_session 后注入 X-Uid，本端点信任 X-Uid。
+APISIX 的 /tasks/*/answer 路由（priority 100）将请求转发到主 app，其余
+/tasks/* 仍由 app-task 提供（列表/详情）。
+"""
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel, Field
+
+from app.services.task_quiz_answer import (
+    TaskQuizForbidden,
+    TaskQuizNotFound,
+    submit_task_quiz_answer,
+)
+
+router = APIRouter(prefix="/tasks", tags=["task-quiz"])
+
+
+class TaskAnswerItem(BaseModel):
+    question_index: int = 0
+    answer: str = Field(..., min_length=1, max_length=2000)
+
+
+class TaskAnswerRequest(BaseModel):
+    """多题答题：answers 数组；answer 为单题旧格式（兼容，等价于 question_index=0）。"""
+
+    answers: list[TaskAnswerItem] | None = None
+    answer: str | None = Field(None, max_length=2000)
+
+
+@router.post("/{task_id}/answer")
+async def submit_answer(request: Request, task_id: str, req: TaskAnswerRequest):
+    """提交答案：逐题判题 + 入库 + 状态流转（sent -> completed）。"""
+    uid_header = request.headers.get("X-Uid")
+    if not uid_header:
+        raise HTTPException(401, "unauthorized (X-Uid missing)")
+    try:
+        uid = int(uid_header)
+    except ValueError:
+        raise HTTPException(401, "invalid X-Uid")
+
+    if req.answers:
+        answers = [
+            {"question_index": a.question_index, "answer": a.answer}
+            for a in req.answers
+        ]
+    elif req.answer is not None:
+        answers = [{"question_index": 0, "answer": req.answer}]
+    else:
+        raise HTTPException(400, "answer or answers required")
+
+    try:
+        return await submit_task_quiz_answer(task_id, uid, answers)
+    except TaskQuizNotFound:
+        raise HTTPException(404, "task not found")
+    except TaskQuizForbidden:
+        raise HTTPException(403, "not the task owner")

--- a/app/routers/task_quiz.py
+++ b/app/routers/task_quiz.py
@@ -80,6 +80,7 @@ class TaskRegisterRequest(BaseModel):
     """User-facing task registration form (APISIX forward-auth injects X-Uid)."""
     prompt: str = Field(..., max_length=500)
     difficulty: str = Field("medium", pattern="^(easy|medium|hard)$")  # 考研难度：简单/中等/压轴
+    question_count: int = Field(1, ge=1, le=5)  # 本次任务出题数量（1~5）
     trigger_time: str  # ISO8601 UTC
     cc_emails: list[str] = Field(default_factory=list)
     incomplete_message: str | None = None
@@ -113,6 +114,7 @@ async def register(request: Request, req: TaskRegisterRequest):
         "cc_emails": req.cc_emails,
         "prompt": req.prompt,
         "difficulty": req.difficulty,
+        "question_count": req.question_count,
         "trigger_time": req.trigger_time,
         "incomplete_message": req.incomplete_message,
     }

--- a/app/services/quiz_gen/service.py
+++ b/app/services/quiz_gen/service.py
@@ -27,7 +27,7 @@ _background_tasks: set = set()
 
 
 class QuizGenerateResult(BaseModel):
-    """Structured output schema enforced on the LLM."""
+    """单题结构化输出 schema（一道任务可含多题）。"""
 
     question: str = Field(..., description="题干")
     question_type: str = Field(..., description="fill_blank / choice / short_answer")
@@ -35,6 +35,33 @@ class QuizGenerateResult(BaseModel):
     answer: str = Field(..., description="正确答案")
     difficulty: str = Field(..., description="easy / medium / hard")
     answer_time_limit_seconds: int = Field(..., description="建议答题时限（秒）")
+
+
+class QuizSetGenerateResult(BaseModel):
+    """一道任务多题的结构化输出（LLM 一次返回 N 道题）。"""
+
+    questions: list[QuizGenerateResult] = Field(..., min_length=1, max_length=5)
+
+
+_QUESTION_FIELDS = (
+    "question",
+    "question_type",
+    "options",
+    "answer",
+    "difficulty",
+    "answer_time_limit_seconds",
+)
+
+
+def _quiz_from_doc(doc: dict) -> dict:
+    """把题库文档归一化为 {questions: [...]}。
+
+    新文档存 questions 数组；兼容历史单题文档（question 等平铺字段）。
+    """
+    qs = doc.get("questions")
+    if isinstance(qs, list) and qs:
+        return {"questions": qs}
+    return {"questions": [{k: doc.get(k) for k in _QUESTION_FIELDS}]}
 
 
 def _quiz_coll():
@@ -51,24 +78,28 @@ async def _get_quiz_doc(task_id: str) -> dict | None:
 
 
 def _quiz_from_doc(doc: dict) -> dict:
-    return {
-        "question": doc.get("question"),
-        "question_type": doc.get("question_type"),
-        "options": doc.get("options"),
-        "answer": doc.get("answer"),
-        "difficulty": doc.get("difficulty"),
-        "answer_time_limit_seconds": doc.get("answer_time_limit_seconds"),
-    }
+    """把题库文档归一化为 {questions: [...]}。
+
+    新文档存 questions 数组；兼容历史单题文档（question 等平铺字段）。
+    """
+    qs = doc.get("questions")
+    if isinstance(qs, list) and qs:
+        return {"questions": qs}
+    return {"questions": [{k: doc.get(k) for k in _QUESTION_FIELDS}]}
 
 
 class QuizGenService:
     """Async + idempotent quiz generation. Called by the internal_quiz router."""
 
     @staticmethod
-    async def generate(task_id: str, prompt: str, difficulty: str, uid: int | None) -> dict:
+    async def generate(
+        task_id: str, prompt: str, difficulty: str, uid: int | None, question_count: int = 1
+    ) -> dict:
         """Returns {status: generating|ready, quiz?}. Launches background LLM if needed."""
         if not prompt.strip():
             raise ValueError("prompt required")
+        if not 1 <= question_count <= 5:
+            raise ValueError("question_count must be 1..5")
         if not settings.openai_api_key:
             raise RuntimeError("LLM not configured (openai_api_key empty)")
 
@@ -89,10 +120,10 @@ class QuizGenService:
             "task_id": task_id, "uid": uid,
             "status": "generating", "created_at": time.time(),
         })
-        task = asyncio.create_task(_generate_quiz_bg(task_id, prompt, difficulty, uid))
+        task = asyncio.create_task(_generate_quiz_bg(task_id, prompt, difficulty, uid, question_count))
         _background_tasks.add(task)
         task.add_done_callback(_background_tasks.discard)
-        logger.info("[INTERNAL_QUIZ] started generation task_id={} difficulty={}", task_id, difficulty)
+        logger.info("[INTERNAL_QUIZ] started generation task_id={} difficulty={} count={}", task_id, difficulty, question_count)
         return {"status": "generating"}
 
     @staticmethod
@@ -110,7 +141,9 @@ class QuizGenService:
         return {"status": "generating"}
 
 
-async def _generate_quiz_bg(task_id: str, prompt: str, difficulty: str, uid: int | None):
+async def _generate_quiz_bg(
+    task_id: str, prompt: str, difficulty: str, uid: int | None, question_count: int
+):
     """Background coroutine: invoke LLM and store result in Mongo."""
     try:
         llm = ChatOpenAI(
@@ -119,34 +152,36 @@ async def _generate_quiz_bg(task_id: str, prompt: str, difficulty: str, uid: int
             model=settings.llm_model,
             temperature=0.7,
         )
-        structured_llm = llm.with_structured_output(QuizGenerateResult)
+        structured_llm = llm.with_structured_output(QuizSetGenerateResult)
 
         last_err: Exception | None = None
         for attempt in range(1, MAX_RETRIES + 1):
             try:
-                result: QuizGenerateResult = await structured_llm.ainvoke(
+                result: QuizSetGenerateResult = await structured_llm.ainvoke(
                     [
                         {"role": "system", "content": QUIZ_GEN_SYS_PROMPT},
-                        {"role": "user", "content": f"出题方向：{prompt}\n难度：{difficulty}"},
+                        {
+                            "role": "user",
+                            "content": f"出题方向：{prompt}\n难度：{difficulty}\n出题数量：{question_count}",
+                        },
                     ]
                 )
-                limit = int(result.answer_time_limit_seconds)
+                if not result.questions:
+                    raise ValueError("LLM returned empty questions")
+                # 任务级答题时限取第一题的建议值（各题可能不同，deadline 是任务级的）
+                limit = int(result.questions[0].answer_time_limit_seconds)
                 if limit <= 0:
-                    limit = _DIFFICULTY_LIMITS.get(result.difficulty, 1200)
+                    limit = _DIFFICULTY_LIMITS.get(result.questions[0].difficulty, 1200)
                 logger.info(
-                    "[INTERNAL_QUIZ] generated task_id={} type={} difficulty={} (attempt={})",
-                    task_id, result.question_type, result.difficulty, attempt,
+                    "[INTERNAL_QUIZ] generated task_id={} count={} difficulty={} (attempt={})",
+                    task_id, len(result.questions), result.questions[0].difficulty, attempt,
                 )
                 await _quiz_coll().update_one(
                     {"task_id": task_id},
                     {"$set": {
                         "status": "ready",
-                        "question": result.question,
-                        "question_type": result.question_type,
-                        "options": result.options,
-                        "answer": result.answer,
-                        "difficulty": result.difficulty,
-                        "answer_time_limit_seconds": limit,
+                        "questions": [q.model_dump() for q in result.questions],
+                        "difficulty": result.questions[0].difficulty,
                         "generated_at": time.time(),
                     }},
                 )

--- a/app/services/task_quiz_answer.py
+++ b/app/services/task_quiz_answer.py
@@ -1,0 +1,209 @@
+"""定时出题 - 答题提交 + 判题（业务逻辑归主 app）。
+
+架构定位（CLAUDE.md §2.7）：app-task 是纯调度执行器，负责到点触发生成、
+轮询状态、发通知、超时检测；答题判题/入库/状态流转属于业务逻辑，必须在
+主 app。本模块被 app/routers/task_answer.py 调用。
+
+判题规则：
+- choice（选择题）：兼容 LLM 两种存法——answer 为完整选项文本（"B. 收敛"）
+  或仅字母（"B"），而前端提交的是用户所点选项的完整文本。统一把正确答案
+  和用户答案解析为选项字母后比较，避免"答对却被判错"。
+- fill_blank（填空）：去除首尾空白后精确比较。
+- short_answer（简答）：不区分大小写，包含匹配。
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import text
+
+from app.database import get_db_context
+from app.infra.mongo import coll
+
+TASK_QUIZ_QUESTIONS = "task_quiz_questions"
+
+
+class TaskQuizNotFound(Exception):
+    """任务不存在。"""
+
+
+class TaskQuizForbidden(Exception):
+    """不是任务所有者。"""
+
+
+def judge_task_quiz_answer(quiz: dict | None, user_answer: str) -> bool:
+    """判定单题答案是否正确。quiz 是 questions 数组中的某一题。"""
+    if not quiz:
+        return False
+    correct = (quiz.get("answer") or "").strip()
+    given = (user_answer or "").strip()
+    if not correct:
+        return False
+    if quiz.get("question_type") == "short_answer":
+        return correct.lower() in given.lower()
+    options = quiz.get("options") or []
+    if options:
+        c_letter = _choice_letter(options, correct)
+        g_letter = _choice_letter(options, given)
+        if c_letter and g_letter:
+            return c_letter == g_letter
+    # 无 options（填空等）或解析失败：回退精确比较
+    return correct == given
+
+
+def _choice_letter(options: list, answer: str) -> str:
+    """把答案解析成选项字母 A/B/C/...；解析不了返回空串。
+
+    兼容三种形态：裸字母（"B"）、完整选项文本（"B. 收敛"）、去掉字母前缀的
+    文本（"收敛"）。裸字母比较区分大小写（与历史精确比较语义一致）。
+    """
+    a = answer.strip()
+    if not a:
+        return ""
+    if len(a) == 1 and "A" <= a <= "Z":
+        return a
+    for i, opt in enumerate(options):
+        t = (opt or "").strip()
+        if t == a:
+            return chr(ord("A") + i)
+        if _strip_option_label(t) == a:
+            return chr(ord("A") + i)
+    return ""
+
+
+def _strip_option_label(s: str) -> str:
+    """去掉选项开头的字母标签（"A. "、"B、"、"C) "、"D "），无标签则原样返回。"""
+    t = s.strip()
+    if not t:
+        return s
+    first = t[0]
+    is_letter = ("A" <= first <= "Z") or ("a" <= first <= "z")
+    if not is_letter:
+        return s
+    for sep in (".", "、", ")", "）", ":", "：", " ", "\t"):
+        if t[1:].startswith(sep):
+            return t[1 + len(sep):].strip()
+    return s
+
+
+def _quiz_questions(quiz_doc: dict | None) -> list:
+    """把题库文档归一化为题目列表（新文档 questions 数组；兼容旧单题平铺）。"""
+    if not quiz_doc:
+        return []
+    qs = quiz_doc.get("questions")
+    if isinstance(qs, list) and qs:
+        return qs
+    single = {
+        "question": quiz_doc.get("question"),
+        "question_type": quiz_doc.get("question_type"),
+        "options": quiz_doc.get("options"),
+        "answer": quiz_doc.get("answer"),
+        "difficulty": quiz_doc.get("difficulty"),
+        "answer_time_limit_seconds": quiz_doc.get("answer_time_limit_seconds"),
+    }
+    return [single] if single.get("question") else []
+
+
+async def submit_task_quiz_answer(
+    task_id: str, uid: int, answers: list[dict]
+) -> dict:
+    """用户答题：归属校验 -> 幂等 -> 逐题判题 -> 入库 -> 状态流转。
+
+    answers: [{"question_index": 0, "answer": "..."}, ...]
+    返回 {"status": ..., "results": [{"question_index", "answer", "is_correct"}],
+          "is_correct": 全部正确}，与前端 task-quiz-api 契约一致。
+    """
+    async with get_db_context() as db:
+        # 1. 任务存在性 + 归属（X-Uid 由 APISIX forward-auth 注入）
+        row = (
+            await db.execute(
+                text(
+                    "SELECT task_id, uid, status FROM task_quiz_task "
+                    "WHERE task_id = :tid"
+                ),
+                {"tid": task_id},
+            )
+        ).mappings().first()
+        if row is None:
+            raise TaskQuizNotFound()
+        if int(row["uid"]) != uid:
+            raise TaskQuizForbidden()
+
+        # 2. 幂等：已答过直接返回既有结果（按题号）
+        existing = (
+            await db.execute(
+                text(
+                    "SELECT question_index, answer, is_correct "
+                    "FROM task_quiz_answer WHERE task_id = :tid "
+                    "ORDER BY question_index"
+                ),
+                {"tid": task_id},
+            )
+        ).mappings().all()
+        if existing:
+            return {
+                "status": row["status"],
+                "is_correct": all(bool(e["is_correct"]) for e in existing),
+                "results": [
+                    {
+                        "question_index": int(e["question_index"]),
+                        "answer": e["answer"],
+                        "is_correct": bool(e["is_correct"]),
+                    }
+                    for e in existing
+                ],
+            }
+
+        # 3. 取题目（主 app 的 Mongo 权威数据）并逐题判题
+        quiz_doc = await coll(TASK_QUIZ_QUESTIONS).find_one({"task_id": task_id})
+        questions = _quiz_questions(quiz_doc)
+        now = datetime.now(timezone.utc)
+
+        results: list[dict] = []
+        for item in answers:
+            idx = int(item.get("question_index", 0))
+            ans = (item.get("answer") or "").strip()
+            q = questions[idx] if 0 <= idx < len(questions) else None
+            is_correct = judge_task_quiz_answer(q, ans)
+            results.append(
+                {"question_index": idx, "answer": ans, "is_correct": is_correct}
+            )
+
+        # 4. 写答案记录（每题一行）
+        for r in results:
+            await db.execute(
+                text(
+                    "INSERT INTO task_quiz_answer "
+                    "(task_id, uid, question_index, answer, is_correct, submitted_at) "
+                    "VALUES (:tid, :uid, :qidx, :ans, :correct, :ts)"
+                ),
+                {
+                    "tid": task_id,
+                    "uid": uid,
+                    "qidx": r["question_index"],
+                    "ans": r["answer"],
+                    "correct": r["is_correct"],
+                    "ts": now,
+                },
+            )
+
+        # 5. 状态流转 sent -> completed（条件更新防与超时检测竞态）
+        updated = (
+            await db.execute(
+                text(
+                    "UPDATE task_quiz_task SET status = 'completed', updated_at = :ts "
+                    "WHERE task_id = :tid AND status = 'sent'"
+                ),
+                {"tid": task_id, "ts": now},
+            )
+        ).rowcount
+
+        await db.commit()
+
+        status = "completed" if updated else row["status"]
+        return {
+            "status": status,
+            "is_correct": all(r["is_correct"] for r in results),
+            "results": results,
+        }

--- a/app/system.sql
+++ b/app/system.sql
@@ -771,6 +771,7 @@ create table task_quiz_task
     cc_emails          json         not null,
     prompt             varchar(500) not null,
     difficulty         varchar(20)  default 'medium' not null,
+    question_count     int          default 1 not null,
     incomplete_message text         null,
     trigger_time       datetime     not null,
     status             varchar(20)  default 'pending' not null,
@@ -793,12 +794,14 @@ create index ix_task_quiz_task_status_deadline on task_quiz_task (status, deadli
 
 create table task_quiz_answer
 (
-    id           int auto_increment primary key,
-    task_id      varchar(64) not null,
-    uid          bigint      not null,
-    answer       text        not null,
-    is_correct   tinyint(1)  not null,
-    submitted_at datetime    null
+    id             int auto_increment primary key,
+    task_id        varchar(64) not null,
+    uid            bigint      not null,
+    question_index int         default 0 not null,
+    answer         text        not null,
+    is_correct     tinyint(1)  not null,
+    submitted_at   datetime    null,
+    constraint uq_task_quiz_answer_task_question unique (task_id, question_index)
 );
 
 create index ix_task_quiz_answer_task_id on task_quiz_answer (task_id);

--- a/app/test/test_task_quiz.py
+++ b/app/test/test_task_quiz.py
@@ -97,6 +97,8 @@ async def test_register_forwards_to_app_task(monkeypatch):
     assert fake_client.captured_json["user_email"] == "u@x.com"
     assert fake_client.captured_json["difficulty"] == "hard"
     assert fake_client.captured_json["cc_emails"] == ["a@x.com"]
+    # 题目数量默认 1（一次任务可出多题 1~5）
+    assert fake_client.captured_json["question_count"] == 1
     # apikey header set (APISIX key-auth)
     assert "apikey" in fake_client.captured_headers
 

--- a/app/test/test_task_quiz_answer.py
+++ b/app/test/test_task_quiz_answer.py
@@ -1,0 +1,99 @@
+"""Tests for 定时出题答题判题（业务逻辑在主 app）。
+
+覆盖 judge_task_quiz_answer 的字母/全文容错 + 填空/简答 + 路由鉴权。
+"""
+
+import pytest
+from fastapi import HTTPException
+
+from app.routers.task_answer import TaskAnswerRequest, submit_answer
+from app.services.task_quiz_answer import judge_task_quiz_answer
+
+
+class FakeRequest:
+    """Minimal stand-in for starlette.Request (only .headers used)."""
+
+    def __init__(self, headers=None):
+        self.headers = headers or {}
+
+
+CHOICE_OPTIONS = ["A. 发散", "B. 收敛", "C. 振荡", "D. 不确定"]
+
+
+# ── choice：字母/全文容错 ──────────────────────────────────────────
+
+def test_choice_letter_answer_matches_full_text():
+    quiz = {"question_type": "choice", "answer": "B", "options": CHOICE_OPTIONS}
+    assert judge_task_quiz_answer(quiz, "B. 收敛") is True
+
+
+def test_choice_letter_answer_matches_bare_text():
+    quiz = {"question_type": "choice", "answer": "B", "options": CHOICE_OPTIONS}
+    assert judge_task_quiz_answer(quiz, "收敛") is True
+
+
+def test_choice_letter_answer_matches_letter():
+    quiz = {"question_type": "choice", "answer": "B", "options": CHOICE_OPTIONS}
+    assert judge_task_quiz_answer(quiz, "B") is True
+
+
+def test_choice_full_text_answer_matches_full_text():
+    quiz = {"question_type": "choice", "answer": "B. 收敛", "options": CHOICE_OPTIONS}
+    assert judge_task_quiz_answer(quiz, "B. 收敛") is True
+
+
+def test_choice_wrong_option():
+    quiz = {"question_type": "choice", "answer": "B", "options": CHOICE_OPTIONS}
+    assert judge_task_quiz_answer(quiz, "A. 发散") is False
+
+
+def test_choice_wrong_bare_text():
+    quiz = {"question_type": "choice", "answer": "B", "options": CHOICE_OPTIONS}
+    assert judge_task_quiz_answer(quiz, "发散") is False
+
+
+def test_choice_lowercase_letter_still_case_sensitive():
+    quiz = {"question_type": "choice", "answer": "B", "options": CHOICE_OPTIONS}
+    assert judge_task_quiz_answer(quiz, "b") is False
+
+
+def test_choice_no_options_falls_back_exact():
+    # 无 options（历史数据）回退精确比较
+    assert judge_task_quiz_answer({"question_type": "choice", "answer": "A"}, "A") is True
+    assert judge_task_quiz_answer({"question_type": "choice", "answer": "A"}, "B") is False
+
+
+# ── fill_blank / short_answer ─────────────────────────────────────
+
+def test_fill_blank_exact_trimmed():
+    assert judge_task_quiz_answer({"question_type": "fill_blank", "answer": "42"}, " 42 ") is True
+    assert judge_task_quiz_answer({"question_type": "fill_blank", "answer": "42"}, "43") is False
+
+
+def test_short_answer_contains_case_insensitive():
+    quiz = {"question_type": "short_answer", "answer": "Newton"}
+    assert judge_task_quiz_answer(quiz, "isaac newton was here") is True
+    assert judge_task_quiz_answer({"question_type": "short_answer", "answer": "牛顿"}, "爱因斯坦") is False
+
+
+# ── edge cases ────────────────────────────────────────────────────
+
+def test_empty_correct_answer_false():
+    assert judge_task_quiz_answer({"question_type": "choice", "answer": ""}, "A") is False
+
+
+def test_nil_quiz_false():
+    assert judge_task_quiz_answer(None, "A") is False
+
+
+# ── 路由鉴权 ──────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_submit_answer_401_without_x_uid():
+    with pytest.raises(HTTPException) as exc:
+        await submit_answer(
+            FakeRequest(),
+            "some-task",
+            TaskAnswerRequest(answer="A"),
+        )
+    assert exc.value.status_code == 401

--- a/frontendv2/components/chat/chat-view.tsx
+++ b/frontendv2/components/chat/chat-view.tsx
@@ -406,7 +406,14 @@ export function ChatView() {
 
   const handleSessionSelect = useCallback((sessionId: string) => {
     setActiveSessionId(sessionId);
-    setSidebarOpen(false); // collapse on mobile after pick
+    // 桌面端（md+，≥768px）侧边栏常驻，选中会话不能把它收起变窄；
+    // 仅移动端覆盖式抽屉需要选中后自动关闭。
+    if (
+      typeof window !== "undefined" &&
+      window.matchMedia("(max-width: 767px)").matches
+    ) {
+      setSidebarOpen(false);
+    }
   }, []);
 
   const handleDeleteSession = useCallback(

--- a/frontendv2/components/task-quiz/new-task-dialog.tsx
+++ b/frontendv2/components/task-quiz/new-task-dialog.tsx
@@ -82,6 +82,7 @@ function DialogBody({
 }) {
     const [prompt, setPrompt] = useState("");
     const [difficulty, setDifficulty] = useState<string>("medium");
+    const [questionCount, setQuestionCount] = useState(1);
     const [triggerTime, setTriggerTime] = useState("");
     const [ccEmails, setCcEmails] = useState("");
     const [incomplete, setIncomplete] = useState("");
@@ -113,6 +114,7 @@ function DialogBody({
                 ccEmails: ccs,
                 incompleteMessage: incomplete.trim() || null,
                 difficulty,
+                questionCount,
             });
             onCreated();
             onClose();
@@ -190,6 +192,33 @@ function DialogBody({
                                 </button>
                             );
                         })}
+                    </div>
+                </div>
+
+                {/* Question count */}
+                <div className="mb-4">
+                    <label className="mb-1.5 block text-[13px] font-medium text-secondary">
+                        题目数量
+                        <span className="ml-1.5 font-normal text-tertiary">
+                            （一次生成多道题，最多 5 道）
+                        </span>
+                    </label>
+                    <div className="grid grid-cols-5 gap-2">
+                        {[1, 2, 3, 4, 5].map((c) => (
+                            <button
+                                key={c}
+                                type="button"
+                                onClick={() => setQuestionCount(c)}
+                                className={cn(
+                                    "h-10 rounded-lg border text-[13px] font-medium transition-all",
+                                    questionCount === c
+                                        ? "border-accent bg-accent-soft text-accent"
+                                        : "border-border bg-surface text-foreground hover:border-tertiary",
+                                )}
+                            >
+                                {c}
+                            </button>
+                        ))}
                     </div>
                 </div>
 

--- a/frontendv2/components/task-quiz/task-detail.tsx
+++ b/frontendv2/components/task-quiz/task-detail.tsx
@@ -18,7 +18,6 @@
 import { useEffect, useState } from "react";
 import { motion } from "framer-motion";
 import {
-    ArrowLeft,
     CalendarClock,
     Clock,
     CheckCircle2,
@@ -27,11 +26,12 @@ import {
     Loader2,
     Mail,
     Hourglass,
-    Sparkles,
 } from "lucide-react";
 import {
     taskQuizApi,
+    type TaskQuizAnswerItem,
     type TaskQuizDetail as TaskQuizDetailData,
+    type TaskQuizQuestion,
     type TaskQuizStatus,
 } from "@/lib/api";
 import { cn } from "@/lib/utils";
@@ -41,7 +41,6 @@ interface TaskQuizDetailProps {
     detail: TaskQuizDetailData | null;
     loading: boolean;
     onAnswered: () => void;
-    onBack: () => void;
 }
 
 const STATUS_BADGE: Record<TaskQuizStatus, { label: string; cls: string }> = {
@@ -72,17 +71,31 @@ function formatCountdown(ms: number): string {
     return h > 0 ? `${h}:${mm}:${ss}` : `${mm}:${ss}`;
 }
 
+/**
+ * Whether an option matches a quiz answer. The LLM may output the answer as
+ * the full option text ("马原") or just its letter ("A"); options may carry a
+ * letter prefix ("A. 马原"). Tolerate both shapes so reveal-highlighting works.
+ */
+function matchesAnswer(opt: string, answer: string): boolean {
+    const o = opt.trim();
+    const a = answer.trim();
+    if (!o || !a) return false;
+    if (o === a) return true;
+    const letter = a.toUpperCase();
+    if (/^[A-F]$/.test(letter)) {
+        return new RegExp(`^${letter}[.、)）:\\s]`, "i").test(o);
+    }
+    return false;
+}
+
 export function TaskQuizDetail({
     detail,
     loading,
     onAnswered,
-    onBack,
 }: TaskQuizDetailProps) {
     if (loading && !detail) return <DetailSkeleton />;
     if (!detail) return <EmptyDetail />;
-    return (
-        <DetailBody detail={detail} onAnswered={onAnswered} onBack={onBack} />
-    );
+    return <DetailBody detail={detail} onAnswered={onAnswered} />;
 }
 
 /* ─── Empty / loading ─── */
@@ -121,11 +134,9 @@ function DetailSkeleton() {
 function DetailBody({
     detail,
     onAnswered,
-    onBack,
 }: {
     detail: TaskQuizDetailData;
     onAnswered: () => void;
-    onBack: () => void;
 }) {
     const badge = STATUS_BADGE[detail.status];
     const quiz = detail.quiz;
@@ -134,14 +145,6 @@ function DetailBody({
         <div className="flex h-full flex-col">
             {/* Header */}
             <div className="flex items-start gap-3 border-b border-border-subtle px-5 py-4 md:px-8">
-                <button
-                    type="button"
-                    onClick={onBack}
-                    aria-label="返回列表"
-                    className="mt-0.5 grid h-8 w-8 shrink-0 place-items-center rounded-full text-secondary transition-colors hover:bg-border-subtle hover:text-foreground md:hidden"
-                >
-                    <ArrowLeft className="h-4 w-4" />
-                </button>
                 <div className="min-w-0 flex-1">
                     <div className="flex flex-wrap items-center gap-2">
                         <span
@@ -243,7 +246,7 @@ function FailedState() {
     );
 }
 
-/* ─── Quiz card + answer form ─── */
+/* ─── Quiz card + answer form (multi-question) ─── */
 
 function QuizCard({
     detail,
@@ -252,16 +255,12 @@ function QuizCard({
     detail: TaskQuizDetailData;
     onAnswered: () => void;
 }) {
-    const quiz = detail.quiz!;
-    const answered = detail.answer != null;
-    const isChoice = !!quiz.options && quiz.options.length > 0;
-    const isMultiple = quiz.questionType.toLowerCase().includes("multiple");
+    const questions = detail.quiz?.questions ?? [];
+    const submitted = detail.answers ?? []; // 防御：旧后端可能缺字段
+    const answered = submitted.length > 0;
 
-    const [selectedOption, setSelectedOption] = useState<string | null>(null);
-    const [selectedOptions, setSelectedOptions] = useState<Set<string>>(
-        new Set(),
-    );
-    const [textAnswer, setTextAnswer] = useState("");
+    // 每题一个答案字符串（选择题=选项文本，填空/简答=输入文本），按下标存
+    const [answers, setAnswers] = useState<Record<number, string>>({});
     const [submitting, setSubmitting] = useState(false);
     const [error, setError] = useState<string | null>(null);
 
@@ -282,29 +281,20 @@ function QuizCard({
         return () => clearInterval(t);
     }, [detail.deadline, answered]);
 
-    function toggleOption(opt: string) {
-        setSelectedOptions((prev) => {
-            const next = new Set(prev);
-            if (next.has(opt)) next.delete(opt);
-            else next.add(opt);
-            return next;
-        });
+    function setAnswer(idx: number, val: string) {
+        setAnswers((prev) => ({ ...prev, [idx]: val }));
     }
 
     async function submit() {
-        let answerStr = "";
-        if (isChoice) {
-            answerStr = isMultiple
-                ? Array.from(selectedOptions).join(", ")
-                : selectedOption ?? "";
-        } else {
-            answerStr = textAnswer.trim();
-        }
-        if (!answerStr) return;
+        const items = questions.map((_, i) => ({
+            question_index: i,
+            answer: (answers[i] ?? "").trim(),
+        }));
+        if (items.some((it) => !it.answer)) return;
         setSubmitting(true);
         setError(null);
         try {
-            await taskQuizApi.submitAnswer(detail.taskId, answerStr);
+            await taskQuizApi.submitAnswer(detail.taskId, items);
             onAnswered();
         } catch (e) {
             setError(e instanceof Error ? e.message : "提交失败");
@@ -312,12 +302,11 @@ function QuizCard({
         setSubmitting(false);
     }
 
-    const canSubmit = isChoice
-        ? isMultiple
-            ? selectedOptions.size > 0
-            : selectedOption != null
-        : textAnswer.trim().length > 0;
-
+    const answeredCount = questions.filter((_, i) =>
+        (answers[i] ?? "").trim(),
+    ).length;
+    const canSubmit =
+        questions.length > 0 && answeredCount === questions.length;
     const inputLocked = submitting || detail.status === "overdue";
 
     return (
@@ -347,94 +336,136 @@ function QuizCard({
                 </div>
             )}
 
-            {/* Question card */}
-            <div className="rounded-2xl border border-border bg-surface p-5 md:p-6">
-                <div className="mb-3 flex items-center gap-2">
-                    <span className="rounded-md bg-border-subtle px-2 py-0.5 text-[11px] font-medium text-secondary">
-                        {quiz.difficulty}
-                    </span>
-                    <span className="text-[11px] text-tertiary">
-                        {quiz.questionType}
-                    </span>
-                    {isMultiple && (
-                        <span className="text-[11px] text-tertiary">· 多选</span>
-                    )}
-                </div>
-                <div className="md-body text-[15px] leading-relaxed text-foreground">
-                    <Markdown>{quiz.question}</Markdown>
-                </div>
+            {/* Question list */}
+            <div className="space-y-5">
+                {questions.map((q, i) => {
+                    const myAns = answered
+                        ? submitted.find((a) => a.questionIndex === i)
+                        : undefined;
+                    return (
+                        <div
+                            key={i}
+                            className="rounded-2xl border border-border bg-surface p-5 md:p-6"
+                        >
+                            <div className="mb-3 flex flex-wrap items-center gap-2">
+                                <span className="rounded-md bg-border-subtle px-2 py-0.5 text-[11px] font-medium text-secondary">
+                                    第 {i + 1} 题
+                                </span>
+                                <span className="rounded-md bg-border-subtle px-2 py-0.5 text-[11px] font-medium text-secondary">
+                                    {q.difficulty}
+                                </span>
+                                <span className="text-[11px] text-tertiary">
+                                    {q.questionType}
+                                </span>
+                            </div>
+                            <div className="md-body text-[15px] leading-relaxed text-foreground">
+                                <Markdown>{q.question}</Markdown>
+                            </div>
 
-                {/* Choice options (input mode) */}
-                {isChoice && !answered && (
-                    <div className="mt-4 space-y-2">
-                        {quiz.options!.map((opt, i) => {
-                            const active = isMultiple
-                                ? selectedOptions.has(opt)
-                                : selectedOption === opt;
-                            return (
-                                <button
-                                    key={i}
-                                    type="button"
+                            {/* Choice options — always visible; interactive before
+                                answering, read-only reveal (correct/wrong) after */}
+                            {q.options && q.options.length > 0 ? (
+                                <div className="mt-4 grid gap-2 sm:grid-cols-2">
+                                    {q.options.map((opt, oi) => {
+                                        const letter = String.fromCharCode(65 + oi);
+                                        const isUserPick = answered
+                                            ? matchesAnswer(opt, myAns?.answer ?? "")
+                                            : answers[i] === opt;
+                                        const isCorrectOpt =
+                                            answered && matchesAnswer(opt, q.answer);
+
+                                        const optState:
+                                            | "idle"
+                                            | "selected"
+                                            | "correct"
+                                            | "wrong" = answered
+                                            ? isCorrectOpt
+                                                ? "correct"
+                                                : isUserPick
+                                                  ? "wrong"
+                                                  : "idle"
+                                            : isUserPick
+                                              ? "selected"
+                                              : "idle";
+
+                                        return (
+                                            <button
+                                                key={oi}
+                                                type="button"
+                                                disabled={inputLocked || answered}
+                                                onClick={() => setAnswer(i, opt)}
+                                                className={cn(
+                                                    "flex w-full items-center gap-3 rounded-xl border px-4 py-3 text-left text-[14px] transition-all",
+                                                    optState === "correct" &&
+                                                        "border-success/40 bg-success/10",
+                                                    optState === "wrong" &&
+                                                        "border-danger/40 bg-danger/10",
+                                                    optState === "selected" &&
+                                                        "border-foreground bg-surface text-foreground",
+                                                    optState === "idle" &&
+                                                        (answered
+                                                            ? "border-border bg-surface text-foreground/70"
+                                                            : "border-border bg-surface text-foreground/90 hover:border-tertiary"),
+                                                    inputLocked && "opacity-60",
+                                                )}
+                                            >
+                                                <span
+                                                    className={cn(
+                                                        "grid h-5 w-5 shrink-0 place-items-center border text-[11px] font-medium",
+                                                        "rounded-full",
+                                                        optState === "correct" &&
+                                                            "border-success bg-success text-surface",
+                                                        optState === "wrong" &&
+                                                            "border-danger bg-danger text-surface",
+                                                        optState === "selected" &&
+                                                            "border-foreground bg-foreground text-surface",
+                                                        optState === "idle" &&
+                                                            (answered
+                                                                ? "border-tertiary/50 text-tertiary"
+                                                                : "border-tertiary text-tertiary"),
+                                                    )}
+                                                >
+                                                    {letter}
+                                                </span>
+                                                <span className="min-w-0 flex-1">
+                                                    <Markdown inline>{opt}</Markdown>
+                                                </span>
+                                                {optState === "correct" && (
+                                                    <span className="ml-auto shrink-0 text-[11px] font-medium text-success">
+                                                        ✓ 正确答案
+                                                    </span>
+                                                )}
+                                                {optState === "wrong" && (
+                                                    <span className="ml-auto shrink-0 text-[11px] font-medium text-danger">
+                                                        你的答案
+                                                    </span>
+                                                )}
+                                            </button>
+                                        );
+                                    })}
+                                </div>
+                            ) : !answered ? (
+                                /* Fill-in / short answer input (input mode) */
+                                <textarea
+                                    value={answers[i] ?? ""}
+                                    onChange={(e) => setAnswer(i, e.target.value)}
                                     disabled={inputLocked}
-                                    onClick={() =>
-                                        isMultiple
-                                            ? toggleOption(opt)
-                                            : setSelectedOption(opt)
-                                    }
-                                    className={cn(
-                                        "flex w-full items-center gap-3 rounded-xl border px-4 py-3 text-left text-[14px] transition-all",
-                                        active
-                                            ? "border-foreground bg-surface text-foreground"
-                                            : "border-border bg-surface text-foreground/90 hover:border-tertiary",
-                                        inputLocked && "opacity-60",
-                                    )}
-                                >
-                                    <span
-                                        className={cn(
-                                            "grid h-5 w-5 shrink-0 place-items-center border text-[11px] font-medium",
-                                            isMultiple ? "rounded-[6px]" : "rounded-full",
-                                            active
-                                                ? "border-foreground bg-foreground text-surface"
-                                                : "border-tertiary text-tertiary",
-                                        )}
-                                    >
-                                        {active && <CheckCircle2 className="h-3.5 w-3.5" />}
-                                    </span>
-                                    <span className="min-w-0 flex-1">
-                                        <Markdown inline>{opt}</Markdown>
-                                    </span>
-                                </button>
-                            );
-                        })}
-                    </div>
-                )}
-
-                {/* Fill-in input (input mode) */}
-                {!isChoice && !answered && (
-                    <textarea
-                        value={textAnswer}
-                        onChange={(e) => setTextAnswer(e.target.value)}
-                        disabled={inputLocked}
-                        className="field mt-4 resize-none"
-                        rows={4}
-                        placeholder="输入你的答案…"
-                    />
-                )}
+                                    className="field mt-4 resize-none"
+                                    rows={3}
+                                    placeholder="输入你的答案…"
+                                />
+                            ) : null}
+                        </div>
+                    );
+                })}
             </div>
 
-            {/* Result (answered) */}
-            {answered && detail.answer && (
-                <ResultCard
-                    answer={detail.answer.answer}
-                    isCorrect={detail.answer.isCorrect}
-                    correctAnswer={quiz.answer}
-                    submittedAt={detail.answer.submittedAt}
-                />
-            )}
+            {/* Result summary (answered) */}
+            {answered && <ResultSummary answers={submitted} questions={questions} />}
 
             {/* Submit */}
             {!answered && detail.status === "sent" && (
-                <div className="mt-4">
+                <div className="mt-5">
                     {error && (
                         <div className="mb-3 flex items-center gap-2 rounded-lg border-l-2 border-foreground bg-border-subtle px-3.5 py-2.5 text-[13px] text-foreground">
                             <AlertCircle className="h-4 w-4 shrink-0" />
@@ -448,7 +479,7 @@ function QuizCard({
                         className="btn-pill btn-primary h-10 px-6 text-[14px]"
                     >
                         {submitting && <Loader2 className="h-4 w-4 animate-spin" />}
-                        提交答案
+                        提交答案 · {answeredCount}/{questions.length}
                     </button>
                 </div>
             )}
@@ -456,19 +487,18 @@ function QuizCard({
     );
 }
 
-/* ─── Result card ─── */
+/* ─── Result summary (per-question verdicts) ─── */
 
-function ResultCard({
-    answer,
-    isCorrect,
-    correctAnswer,
-    submittedAt,
+function ResultSummary({
+    answers,
+    questions,
 }: {
-    answer: string;
-    isCorrect: boolean;
-    correctAnswer: string;
-    submittedAt: string;
+    answers: TaskQuizAnswerItem[];
+    questions: TaskQuizQuestion[];
 }) {
+    const allCorrect = answers.length > 0 && answers.every((a) => a.isCorrect);
+    const correctCount = answers.filter((a) => a.isCorrect).length;
+
     return (
         <motion.div
             initial={{ opacity: 0, y: 8 }}
@@ -478,41 +508,58 @@ function ResultCard({
         >
             {/* Verdict - flat monochrome row, no color box */}
             <div className="flex items-center gap-2.5 border-b border-border-subtle pb-3">
-                {isCorrect ? (
+                {allCorrect ? (
                     <CheckCircle2 className="h-5 w-5 text-foreground" />
                 ) : (
                     <XCircle className="h-5 w-5 text-foreground" />
                 )}
                 <span className="text-[15px] font-semibold tracking-tight text-foreground">
-                    {isCorrect ? "回答正确" : "回答错误"}
+                    {allCorrect
+                        ? "全部回答正确"
+                        : `答对 ${correctCount}/${questions.length}`}
                 </span>
-                <span className="ml-auto text-[11px] text-tertiary">
-                    {formatDateTime(submittedAt)} 提交
-                </span>
+                {answers[0] && (
+                    <span className="ml-auto text-[11px] text-tertiary">
+                        {formatDateTime(answers[0].submittedAt)} 提交
+                    </span>
+                )}
             </div>
 
-            {/* My answer */}
-            <div className="mt-4">
-                <div className="mb-1.5 text-[11px] font-medium uppercase tracking-wider text-tertiary">
-                    我的答案
-                </div>
-                <div className="md-body text-[14px] leading-relaxed text-foreground">
-                    <Markdown>{answer || "（空）"}</Markdown>
-                </div>
+            {/* Per-question my/correct answers */}
+            <div className="mt-4 space-y-4">
+                {questions.map((q, i) => {
+                    const r = answers.find((a) => a.questionIndex === i);
+                    if (!r) return null;
+                    return (
+                        <div key={i} className="rounded-xl border border-border bg-surface p-4">
+                            <div className="flex items-center gap-2">
+                                {r.isCorrect ? (
+                                    <CheckCircle2 className="h-4 w-4 text-success" />
+                                ) : (
+                                    <XCircle className="h-4 w-4 text-danger" />
+                                )}
+                                <span className="text-[13px] font-medium tracking-tight text-foreground">
+                                    第 {i + 1} 题
+                                </span>
+                            </div>
+                            <div className="mt-2 text-[14px] leading-relaxed">
+                                <span className="text-tertiary">我的答案：</span>
+                                <span className="text-foreground">
+                                    <Markdown inline>{r.answer || "（空）"}</Markdown>
+                                </span>
+                            </div>
+                            {!r.isCorrect && (
+                                <div className="mt-1 text-[14px] leading-relaxed">
+                                    <span className="text-tertiary">正确答案：</span>
+                                    <span className="font-medium text-foreground">
+                                        <Markdown inline>{q.answer}</Markdown>
+                                    </span>
+                                </div>
+                            )}
+                        </div>
+                    );
+                })}
             </div>
-
-            {/* Correct answer */}
-            {!isCorrect && (
-                <div className="mt-4">
-                    <div className="mb-1.5 flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-wider text-tertiary">
-                        <Sparkles className="h-3 w-3" />
-                        正确答案
-                    </div>
-                    <div className="md-body text-[14px] leading-relaxed text-foreground">
-                        <Markdown>{correctAnswer}</Markdown>
-                    </div>
-                </div>
-            )}
         </motion.div>
     );
 }

--- a/frontendv2/components/task-quiz/task-quiz-view.tsx
+++ b/frontendv2/components/task-quiz/task-quiz-view.tsx
@@ -22,27 +22,25 @@ export function TaskQuizView() {
     const [detail, setDetail] = useState<TaskQuizDetail | null>(null);
     const [loadingDetail, setLoadingDetail] = useState(false);
     const [dialogOpen, setDialogOpen] = useState(false);
-    const [mobileDetail, setMobileDetail] = useState(false);
 
-    const refreshList = useCallback(
-        async (autoSelect: boolean) => {
-            setLoading(true);
-            try {
-                const list = await taskQuizApi.listTasks();
-                // Newest trigger first.
-                list.sort((a, b) => b.triggerTime.localeCompare(a.triggerTime));
-                setTasks(list);
-                if (autoSelect && list.length > 0 && !selectedTaskId) {
-                    setSelectedTaskId(list[0].taskId);
-                }
-            } catch {
-                // Empty list is a valid state.
-            } finally {
-                setLoading(false);
+    const refreshList = useCallback(async (autoSelect: boolean) => {
+        setLoading(true);
+        try {
+            const list = await taskQuizApi.listTasks();
+            // Newest trigger first.
+            list.sort((a, b) => b.triggerTime.localeCompare(a.triggerTime));
+            setTasks(list);
+            if (autoSelect && list.length > 0) {
+                // 只在尚未选中任何任务时自动选中第一个（函数式更新，
+                // 不依赖 selectedTaskId，避免点击任务时列表被整表重拉）。
+                setSelectedTaskId((prev) => prev ?? list[0].taskId);
             }
-        },
-        [selectedTaskId],
-    );
+        } catch {
+            // Empty list is a valid state.
+        } finally {
+            setLoading(false);
+        }
+    }, []);
 
     const refreshDetail = useCallback(async (taskId: string) => {
         setLoadingDetail(true);
@@ -79,11 +77,20 @@ export function TaskQuizView() {
         return () => clearInterval(t);
     }, [selectedTaskId, refreshDetail]);
 
-    const handleSelect = useCallback((taskId: string) => {
-        setSelectedTaskId(taskId);
-        setDetail(null); // clear stale so loader shows
-        setMobileDetail(true);
-    }, []);
+    const handleSelect = useCallback(
+        (taskId: string) => {
+            if (selectedTaskId === taskId) {
+                // 重复点击当前选中的任务：不清空详情，直接重新拉取，
+                // 否则详情被置空后 selectedTaskId 不变、fetch effect 不触发，
+                // 右侧面板会永远停留在空状态。
+                void refreshDetail(taskId);
+                return;
+            }
+            setSelectedTaskId(taskId);
+            setDetail(null); // clear stale so loader shows
+        },
+        [selectedTaskId, refreshDetail],
+    );
 
     const handleNew = useCallback(() => setDialogOpen(true), []);
 
@@ -93,17 +100,18 @@ export function TaskQuizView() {
 
     const handleAnswered = useCallback(() => {
         if (selectedTaskId) void refreshDetail(selectedTaskId);
-    }, [selectedTaskId, refreshDetail]);
-
-    const handleBack = useCallback(() => setMobileDetail(false), []);
+        // 答题后任务状态变为 completed，同步刷新侧边栏列表的状态与分组。
+        void refreshList(false);
+    }, [selectedTaskId, refreshDetail, refreshList]);
 
     return (
         <div className="flex h-[calc(100dvh-3rem)]">
-            {/* Left list */}
+            {/* Left list — 任何宽度下都常驻显示，点击任务绝不收起/变窄；
+                窄屏(<sm)只把宽度收窄到 240px，而不是隐藏 */}
             <aside
                 className={cn(
                     "w-[320px] shrink-0 border-r border-border-subtle",
-                    mobileDetail && "hidden md:flex",
+                    "max-sm:w-[240px]",
                 )}
             >
                 <TaskQuizList
@@ -115,18 +123,12 @@ export function TaskQuizView() {
                 />
             </aside>
 
-            {/* Right detail */}
-            <section
-                className={cn(
-                    "min-w-0 flex-1",
-                    !mobileDetail && "hidden md:block",
-                )}
-            >
+            {/* Right detail — 始终与侧边栏并排 */}
+            <section className="min-w-0 flex-1">
                 <TaskQuizDetailPanel
                     detail={detail}
                     loading={loadingDetail}
                     onAnswered={handleAnswered}
-                    onBack={handleBack}
                 />
             </section>
 

--- a/frontendv2/lib/api/task-quiz.ts
+++ b/frontendv2/lib/api/task-quiz.ts
@@ -27,14 +27,15 @@ export interface TaskQuizListItem {
 
 export interface TaskQuizQuestion {
     question: string;
-    questionType: string;            // single_choice / multiple_choice / fill_blank / short_answer ...
+    questionType: string;            // choice / fill_blank / short_answer
     options: string[] | null;        // choice types only
-    answer: string;                  // correct answer (choice index/text, or fill-in text)
+    answer: string;                  // correct answer (choice text/letter, or fill-in text)
     difficulty: string;              // easy / medium / hard
     answerTimeLimitSeconds: number;
 }
 
-export interface TaskQuizAnswer {
+export interface TaskQuizAnswerItem {
+    questionIndex: number;           // 0-based, 与 questions 数组下标对应
     answer: string;
     isCorrect: boolean;
     submittedAt: string;
@@ -47,9 +48,10 @@ export interface TaskQuizDetail {
     status: TaskQuizStatus;
     triggerTime: string;
     ccEmails: string[];
+    questionCount: number;           // 本次任务出题数量（1~5）
     deadline?: string | null;        // armed on send; used for the answer countdown
-    quiz: TaskQuizQuestion | null;
-    answer: TaskQuizAnswer | null;
+    quiz: { questions: TaskQuizQuestion[] } | null;
+    answers: TaskQuizAnswerItem[];   // 空数组 = 未作答
 }
 
 export interface RegisterTaskParams {
@@ -58,6 +60,7 @@ export interface RegisterTaskParams {
     ccEmails: string[];
     incompleteMessage?: string | null;
     difficulty: string;              // easy / medium / hard
+    questionCount: number;           // 1~5
 }
 
 export interface RegisterTaskResponse {
@@ -65,9 +68,15 @@ export interface RegisterTaskResponse {
     status: string;
 }
 
+export interface SubmitAnswerItem {
+    question_index: number; // wire format (snake_case)
+    answer: string;
+}
+
 export interface SubmitAnswerResponse {
     status: string;
     isCorrect: boolean;
+    results: { questionIndex: number; answer: string; isCorrect: boolean }[];
 }
 
 export interface TaskQuizStreamHandlers {
@@ -88,6 +97,7 @@ export const taskQuizApi = {
                 cc_emails: params.ccEmails,
                 incomplete_message: params.incompleteMessage ?? null,
                 difficulty: params.difficulty,
+                question_count: params.questionCount,
             }),
         }),
 
@@ -101,11 +111,11 @@ export const taskQuizApi = {
     getTask: (taskId: string) =>
         requestCamel<TaskQuizDetail>(`/tasks/${taskId}`),
 
-    /** Submit answer for a sent task. */
-    submitAnswer: (taskId: string, answer: string) =>
+    /** Submit answers for a sent task (one entry per question, index 0-based). */
+    submitAnswer: (taskId: string, answers: SubmitAnswerItem[]) =>
         requestCamel<SubmitAnswerResponse>(`/tasks/${taskId}/answer`, {
             method: "POST",
-            body: JSON.stringify({ answer }),
+            body: JSON.stringify({ answers }),
         }),
 
     /**


### PR DESCRIPTION
## 背景

完善「定时出题」功能：修复答题/出题链路多处问题，并支持一次任务生成多道题。

## 变更内容

### 前端（frontendv2）
- 定时出题答题页：答题后选项常驻展示 + 批改高亮（正确绿/错误红/你的答案）；多题渲染与逐题提交/结果
- 左侧任务列表侧边栏**任何宽度都不再收起/缩小**（删除了收起机制）
- 新建任务对话框：新增「题目数量」选择（1~5）
- 聊天页：桌面端选中会话不再收起历史会话侧边栏（仅移动端抽屉自动关闭）

### 主 app（backend）
- 出题支持多题：LLM 结构化输出改为 questions 数组（1~5 题），/internal/quiz/generate-llm 接受 question_count
- 答题/判题/入库迁移到主 app：新增 `POST /tasks/{id}/answer`（forward-auth），逐题判题/入库/状态流转；判题兼容「字母 vs 全文」两种答案格式（修复答对却判错的 bug）
- 出题 prompt 加固：answer 必须为选项完整文本、每题恰好一个正确答案、多题不重复
- DB 迁移：`task_quiz_task.question_count`、`task_quiz_answer.question_index`（启动自动执行）

### app-task
- 纯调度化：移除答题端点/判题/本地题目副本（生成/判题/入库归主 app），保留调度执行 + 邮件通知 + 超时检测 + 详情/列表
- 详情归一化兼容 bson primitive.A（修复多题出题后详情无内容的 bug）
- 邮件策略：≤2 道内联展示题目，>2 道只显示数量并引导登录系统查看

### 基础设施
- APISIX：新增 `/tasks/{id}/answer` 路由（priority 100，forward-auth）指向主 app

## 验证

- app-task：`go build` + `go test ./...` 全部通过（含 primitive.A 回归测试、question_count 断言）
- 主 app：所有改动文件 py_compile 通过；判题/归一化逻辑独立验证通过；ruff 规则集（E4/E7/E9+F）手动检查无问题
- 前端：`tsc` + `eslint` 通过

## 部署注意

1. MySQL 迁移由主 app 启动自动执行（question_count / question_index 两列），无需手工 DDL
2. 需重建三个服务并清 nginx 缓存：
   `docker compose build backend app-task frontend && docker compose up -d backend app-task frontend && docker compose up -d --force-recreate nginx`
3. APISIX 需重建加载新路由（/tasks/{id}/answer → backend）
4. 历史单题任务兼容（详情自动归一化展示，可正常作答）
