### PR TITLE
[skills/chat] feat: 技能代码沙箱执行 + 聊天产物持久化与对外地址访问

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,8 @@ reasonix.toml
 .gotmp/
 .gocache/
 .pip-tmp/
+# Local test scratch dirs (sandbox temp artifacts)
+_tmp/
+_uvcache/
+_uvtools/
+_tmp2/

--- a/app/agent/code/prompts.py
+++ b/app/agent/code/prompts.py
@@ -42,6 +42,16 @@ with open("heart.png", "rb") as f:
 5. 可输出多个产物（多个标记段）
 6. 纯文本结果（无文件产物）无需此标记，正常 print 即可
 
+## 绘图规范（用 matplotlib 等绘图库生成图表时必须遵守）
+1. **图表内文字一律使用英文**：title（标题）、xlabel/ylabel（坐标轴标签）、
+   legend（图例）、刻度标签（tick labels）、annotate/text 注释等全部使用英文，
+   例如 "Normal Distribution"、"Probability Density"、"Value"、"Frequency"。
+2. **禁止使用中文作为图表文字**：matplotlib 默认字体不包含中文字符集，
+   沙箱环境也未配置中文字体，中文会渲染成方块（豆腐块），导致图表不可读。
+3. **文件名建议用英文或拼音**：如 normal_distribution.png，避免中文文件名
+   在对象存储/URL 中产生编码问题。
+4. 图内其他可见文本（数据标签、图注、坐标刻度值等）同样优先使用英文。
+
 ## run_code 工具
 - code: 代码字符串
 - language: "python"（默认）/ "javascript" / "typescript"

--- a/app/infra/config.py
+++ b/app/infra/config.py
@@ -224,7 +224,8 @@ class MinioSection(_Section):
     presign_expire: int = 3600
     access_key: SecretStr = SecretStr("")
     secret_key: SecretStr = SecretStr("")
-    public_endpoint: str = ""  # e.g. https://example.com/minio-proxy
+    public_endpoint: str = ""  # full public base, e.g. https://example.com/minio-proxy
+    public_host: str = ""  # host only (domain or IP); auto-prefixed with /minio-proxy
 
 
 class DaytonaSection(_Section):

--- a/app/infra/minio.py
+++ b/app/infra/minio.py
@@ -126,6 +126,31 @@ def _endpoint_host(endpoint: str) -> str:
     return parsed.netloc or endpoint
 
 
+def _resolve_public_base() -> str:
+    """Resolve the browser-reachable MinIO base (via nginx /minio-proxy).
+
+    Fallback chain:
+      1. ``config.minio.public_endpoint`` — full URL (domain scenario),
+         e.g. ``https://mindbase.example.com/minio-proxy``
+      2. ``config.minio.public_host`` — host only (public/private IP or
+         domain); auto-prefixed: ``{scheme}://{host}/minio-proxy``
+      3. local development default: ``http://localhost/minio-proxy``
+
+    The resolved base is the nginx prefix that proxies to the MinIO
+    container. Presigned signatures only cover the host header, which
+    nginx rewrites back to ``minio:9000``, so signatures stay valid
+    regardless of which host the browser actually uses.
+    """
+    public = config.minio.public_endpoint.strip().rstrip("/")
+    if public:
+        return public
+    host = config.minio.public_host.strip().strip("/")
+    if host:
+        scheme = "https" if config.minio.secure else "http"
+        return f"{scheme}://{host}/minio-proxy"
+    return "http://localhost/minio-proxy"
+
+
 # ---------------------------------------------------------------------------
 # MinioClient
 # ---------------------------------------------------------------------------
@@ -165,7 +190,7 @@ class MinioClient:
         return self._client
 
     def _public_url(self, internal_url: str) -> str:
-        public = config.minio.public_endpoint.rstrip("/")
+        public = _resolve_public_base()
         if not public:
             return internal_url
         internal = config.minio.endpoint.rstrip("/")

--- a/app/repository/mongo_chat_repository.py
+++ b/app/repository/mongo_chat_repository.py
@@ -14,6 +14,8 @@ Document:
         "content":          str,
         "status":           "pending" | "completed" | "failed",
         "sources":          [dict] | null,
+        "artifacts":        [dict] | null,  // binary outputs (e.g. images from run_code);
+        //                            stored with minio_key; url is refreshed on read
         "tokens_used":      int | null,
         "model":            str | null,
         "latency_ms":        int | null,

--- a/app/response/chat.py
+++ b/app/response/chat.py
@@ -107,6 +107,7 @@ class ChatMessageResponse(BaseModel):
     content: str
     status: str = "completed"
     sources: Optional[list[dict]] = None
+    artifacts: Optional[list[dict]] = None  # binary outputs (run_code images); url is a fresh presigned link
     tokens_used: Optional[int] = None
     model: Optional[str] = None
     latency_ms: Optional[int] = None

--- a/app/services/chat/lifecycle.py
+++ b/app/services/chat/lifecycle.py
@@ -70,6 +70,7 @@ async def finalize_turn(
     assistant_msg_id: str,
     content: str,
     sources: list[dict],
+    artifacts: Optional[list[dict]] = None,
     tokens_used: Optional[int],
     latency_ms: int,
 ) -> None:
@@ -78,6 +79,7 @@ async def finalize_turn(
         msg_id=assistant_msg_id,
         content=content,
         sources=sources[:5],
+        artifacts=artifacts,
         tokens_used=tokens_used,
         latency_ms=latency_ms,
     )

--- a/app/services/chat/orchestrator.py
+++ b/app/services/chat/orchestrator.py
@@ -511,6 +511,7 @@ async def _stream_agent_events(
             assistant_msg_id=ctx.assistant_msg_id,
             content=streamer.full_content,
             sources=streamer.sources[:5],
+            artifacts=streamer.artifacts,
             tokens_used=total_tokens or None,
             latency_ms=latency_ms,
         )

--- a/app/services/chat_history.py
+++ b/app/services/chat_history.py
@@ -311,6 +311,7 @@ def _messages_from_rows(rows: list[dict]) -> list[ChatMessageResponse]:
             content=r.get("content", ""),
             status=r.get("status", "completed"),
             sources=r.get("sources"),
+            artifacts=r.get("artifacts"),
             tokens_used=r.get("tokens_used"),
             model=r.get("model"),
             latency_ms=r.get("latency_ms"),
@@ -319,6 +320,40 @@ def _messages_from_rows(rows: list[dict]) -> list[ChatMessageResponse]:
         )
         for r in rows
     ]
+
+
+async def _refresh_artifact_urls(
+    messages: list[ChatMessageResponse],
+) -> None:
+    """Refresh presigned URLs for persisted artifacts in-place.
+
+    Artifacts are stored with their authoritative ``minio_key``; the
+    originally-generated presigned ``url`` expires after
+    ``config.minio.presign_expire`` seconds, so every history read mints a
+    fresh URL.  Best-effort: MinIO disabled or a presign failure keeps the
+    stored url (graceful degradation, never raised).
+    """
+    from app.infra.minio import get_minio_client, is_enabled as minio_enabled
+
+    if not minio_enabled() or not messages:
+        return
+    client = get_minio_client()
+    for msg in messages:
+        arts = msg.artifacts
+        if not isinstance(arts, list) or not arts:
+            continue
+        for art in arts:
+            if not isinstance(art, dict):
+                continue
+            key = art.get("minio_key")
+            if not key:
+                continue
+            try:
+                art["url"] = await client.presigned_get(key)
+            except Exception as exc:
+                logger.warning(
+                    "[CHAT_HISTORY] artifact url refresh failed key=%s: %s", key, exc
+                )
 
 
 async def save_user_message(
@@ -386,18 +421,22 @@ async def complete_assistant_message(
     msg_id: str,
     content: str,
     sources: Optional[list[dict]] = None,
+    artifacts: Optional[list[dict]] = None,
     tokens_used: Optional[int] = None,
     latency_ms: Optional[int] = None,
 ) -> None:
     """Finalise a pending assistant message after the LLM response arrives.
 
     Updates the MongoDB document in-place: sets status=completed, fills
-    content / sources / tokens_used / latency_ms.
+    content / sources / tokens_used / latency_ms.  *artifacts* (binary
+    outputs such as run_code images) are persisted as-is - the stored
+    ``minio_key`` is authoritative and the ``url`` is refreshed on read.
     """
     await mongo_chat.update_message_content(
         msg_id,
         content=content,
         sources=sources,
+        artifacts=artifacts,
         tokens_used=tokens_used,
         latency_ms=latency_ms,
     )
@@ -447,6 +486,7 @@ async def _unsafe_get_history(
         chat_session_id, page=page, page_size=page_size
     )
     messages = _messages_from_rows(rows)
+    await _refresh_artifact_urls(messages)
     return messages, total
 
 
@@ -487,7 +527,9 @@ async def get_history_for_user(
     rows, total = await mongo_chat.get_messages_for_user(
         chat_session_id, uid, page=page, page_size=page_size
     )
-    return _messages_from_rows(rows), total
+    messages = _messages_from_rows(rows)
+    await _refresh_artifact_urls(messages)
+    return messages, total
 
 
 async def _unsafe_clear_history(

--- a/app/skills/__init__.py
+++ b/app/skills/__init__.py
@@ -3,8 +3,8 @@
 Skills are downloaded from an external skill store into MinIO as zips; their
 metadata lives in the ``installed_skills`` MySQL table. ``SkillManager``
 lazily loads a skill's instructions from MinIO when the agent calls
-``load_skill``. Code tools inside a skill are not executed yet (sandbox
-pending).
+``load_skill``. Code tools inside a skill are executed in a Daytona sandbox
+by the ``run_skill_code`` tool when ``DAYTONA__ENABLED`` is on.
 """
 
 from .manager import SkillManager

--- a/app/skills/manager.py
+++ b/app/skills/manager.py
@@ -6,8 +6,10 @@ in the ``installed_skills`` MySQL table. When an agent calls
 ``load_skill(name)``, the manager fetches the zip from MinIO, parses it in
 memory, caches it (LRU, per uid+skill_id), and returns the instructions.
 
-Skill code tools (``manifest.has_code_tools``) are **not executed** yet -
-sandbox support is pending.
+Skill code tools (``manifest.has_code_tools`` + a ``tools/`` dir in the zip)
+are executed in a Daytona sandbox by the ``run_skill_code`` tool when
+``DAYTONA__ENABLED`` is on; otherwise ``load_skill`` reports them as
+unavailable.
 """
 
 from __future__ import annotations
@@ -139,6 +141,8 @@ class SkillManager:
             "body": info["body"],
             "manifest": manifest,
             "files": info["files"],
+            "code_tools": info["code_tools"],  # list of runnable tools/ files
+            "entry": info["entry"],  # default entrypoint (tools/ relpath)
         }
 
     # ── install / uninstall ────────────────────────────────────────────

--- a/app/skills/zip_parser.py
+++ b/app/skills/zip_parser.py
@@ -1,12 +1,16 @@
 """Parse a skill zip (from MinIO) into a Skill in-memory.
 
 A skill zip contains:
-    manifest.json   - {name, description, version, has_code_tools, resources[]}
+    manifest.json   - {name, description, version, has_code_tools, entry, resources[]}
     SKILL.md        - instruction body (frontmatter optional; manifest wins)
     resources/      - optional reference resources
-    tools/          - optional code tools (NOT executed yet - sandbox pending)
+    tools/          - optional code tools, executed in the Daytona sandbox
+                      (each file becomes a runnable script; manifest.entry
+                      names the default entrypoint, default "main.py").
 
-Nothing is written to disk. The zip is read entirely in memory.
+Code tools are parsed into Skill.code_tools (relpath -> source text) and
+executed remotely by the run_skill_code tool - this module never writes
+anything to disk, the zip is read entirely in memory.
 """
 
 from __future__ import annotations
@@ -22,7 +26,13 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True)
 class Skill:
-    """One parsed skill - instructions + metadata, no code execution."""
+    """One parsed skill - instructions + metadata (+ code tool sources).
+
+    code_tools maps each file under tools/ to its source text
+    (relpath without the tools/ prefix, e.g. {"main.py": "...",
+    "utils.py": "..."}). entry is the default entrypoint filename
+    (manifest entry or "main.py").
+    """
 
     skill_id: str
     name: str
@@ -31,21 +41,26 @@ class Skill:
     has_code_tools: bool
     resources: list[str] = field(default_factory=list)
     manifest: dict = field(default_factory=dict)
+    code_tools: dict[str, str] = field(default_factory=dict)
+    entry: str | None = None
 
 
 def parse_skill_zip(
     zip_bytes: bytes, *, skill_id: str, name: str, description: str = ""
 ) -> Skill:
-    """Parse a skill zip archive into a :class:`Skill`.
+    """Parse a skill zip archive into a Skill.
 
-    ``skill_id`` / ``name`` / ``description`` come from the installed_skills
-    row (manifest is source of truth for metadata); the zip's own
-    ``manifest.json`` provides ``has_code_tools`` / ``resources``.
+    skill_id / name / description come from the installed_skills row
+    (manifest is source of truth for metadata); the zip own manifest.json
+    provides has_code_tools / entry / resources. Files under tools/ are
+    decoded as text into Skill.code_tools.
     """
     has_code_tools = False
     resources: list[str] = []
     manifest: dict = {}
     body = ""
+    code_tools: dict[str, str] = {}
+    entry: str | None = None
 
     with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
         names = zf.namelist()
@@ -55,12 +70,16 @@ def parse_skill_zip(
                 manifest = json.loads(zf.read(m_entry).decode("utf-8"))
                 has_code_tools = bool(manifest.get("has_code_tools", False))
                 resources = list(manifest.get("resources", []))
+                entry = manifest.get("entry") or None
             except Exception:
                 logger.exception("[SKILLS] bad manifest.json in %s", skill_id)
         s_entry = _find_entry(names, "SKILL.md")
         if s_entry is not None:
             text = zf.read(s_entry).decode("utf-8")
             body = _strip_frontmatter(text)
+        code_tools = _extract_code_tools(names, zf)
+        if code_tools:
+            has_code_tools = True
 
     return Skill(
         skill_id=skill_id,
@@ -70,24 +89,49 @@ def parse_skill_zip(
         has_code_tools=has_code_tools,
         resources=resources,
         manifest=manifest,
+        code_tools=code_tools,
+        entry=entry,
     )
+
+
+def _extract_code_tools(names: list[str], zf: zipfile.ZipFile) -> dict[str, str]:
+    """Extract tools/ files as text: relpath (no tools/ prefix) -> source.
+
+    Supports both flat zips (tools/main.py) and GitHub zipballs
+    (owner-repo-sha/tools/main.py under a top-level prefix dir). Only
+    text files are decoded; un-decodable entries are skipped with a warning.
+    """
+    code_tools: dict[str, str] = {}
+    for n in names:
+        if n.endswith("/"):
+            continue  # directory entry
+        if "/tools/" not in n and not n.startswith("tools/"):
+            continue
+        rel = n.split("/tools/", 1)[1] if "/tools/" in n else n[len("tools/") :]
+        if not rel:
+            continue
+        try:
+            code_tools[rel] = zf.read(n).decode("utf-8")
+        except Exception:
+            logger.warning("[SKILLS] skip non-text code tool %s", n)
+    return code_tools
 
 
 def _find_entry(names: list[str], target: str) -> str | None:
     """Find the zip entry closest to the root matching *target* filename.
 
-    Supports both flat zips (``SKILL.md`` at root) and GitHub zipballs
-    (``owner-repo-sha/SKILL.md`` under a top-level prefix dir). When several
+    Supports both flat zips (SKILL.md at root) and GitHub zipballs
+    (owner-repo-sha/SKILL.md under a top-level prefix dir). When several
     entries match, the shortest path wins (root preferred over nested).
     """
-    matches = [n for n in names if n == target or n.endswith(f"/{target}")]
+    matches = [n for n in names if n == target or n.endswith("/" + target)]
     if not matches:
         return None
     return min(matches, key=len)
 
 
 def _strip_frontmatter(text: str) -> str:
-    """Drop a leading ``---\\n...\\n---`` YAML frontmatter block."""
+    """Drop a leading ---\n...\n--- YAML frontmatter block."""
     if text.startswith("---"):
         parts = text.split("---", 2)
         if len(parts) >= 3:
@@ -96,12 +140,12 @@ def _strip_frontmatter(text: str) -> str:
 
 
 def read_manifest(zip_bytes: bytes) -> dict:
-    """Read just ``manifest.json`` from a skill zip (for the install endpoint).
+    """Read just manifest.json from a skill zip (for the install endpoint).
 
-    Returns ``{}`` when the archive has no manifest. Used to extract
-    ``skill_id`` / ``name`` / ``description`` / ``version`` / ``has_code_tools``
-    before persisting the row. Supports GitHub zipball layout (manifest under
-    a top-level prefix dir).
+    Returns {} when the archive has no manifest. Used to extract
+    skill_id / name / description / version / has_code_tools
+    before persisting the row. Supports GitHub zipball layout (manifest
+    under a top-level prefix dir).
     """
     with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
         m_entry = _find_entry(zf.namelist(), "manifest.json")
@@ -117,9 +161,10 @@ def read_manifest(zip_bytes: bytes) -> dict:
 def inspect_zip(zip_bytes: bytes) -> dict:
     """Inspect an installed skill zip without writing to disk.
 
-    Returns ``{"files": [{name, path, size}], "manifest": dict, "body": str}``
-    where ``body`` is the SKILL.md content (frontmatter stripped) and
-    ``files`` lists every file in the archive. Used by the preview endpoint.
+    Returns {"files": [...], "manifest": dict, "body": str,
+    "code_tools": [relpath...], "entry": str|None} where body is the
+    SKILL.md content (frontmatter stripped) and code_tools lists the
+    runnable files under tools/. Used by the preview endpoint.
     """
     files: list[dict] = []
     manifest: dict = {}
@@ -142,11 +187,22 @@ def inspect_zip(zip_bytes: bytes) -> dict:
         s_entry = _find_entry(names, "SKILL.md")
         if s_entry is not None:
             body = _strip_frontmatter(zf.read(s_entry).decode("utf-8"))
-    return {"files": files, "manifest": manifest, "body": body}
+        code_tools = _extract_code_tools(names, zf)
+    return {
+        "files": files,
+        "manifest": manifest,
+        "body": body,
+        "code_tools": sorted(code_tools.keys()),
+        "entry": manifest.get("entry") or None,
+    }
 
 
 def build_skill_zip(
-    *, skill_md: str, manifest: dict, resources: dict[str, bytes] | None = None
+    *,
+    skill_md: str,
+    manifest: dict,
+    resources: dict[str, bytes] | None = None,
+    code_tools: dict[str, str] | None = None,
 ) -> bytes:
     """Build a skill zip in memory (used by tests and the upload endpoint)."""
     buf = io.BytesIO()
@@ -154,5 +210,7 @@ def build_skill_zip(
         zf.writestr("SKILL.md", skill_md)
         zf.writestr("manifest.json", json.dumps(manifest, ensure_ascii=False))
         for fname, data in (resources or {}).items():
-            zf.writestr(f"resources/{fname}", data)
+            zf.writestr("resources/" + fname, data)
+        for rel, src in (code_tools or {}).items():
+            zf.writestr("tools/" + rel, src)
     return buf.getvalue()

--- a/app/test/test_agent_sse_streamer.py
+++ b/app/test/test_agent_sse_streamer.py
@@ -106,28 +106,28 @@ class TestPrimaryQuery:
 
 class TestParseToolOutput:
     def test_dict_with_sources_field(self) -> None:
-        sources, preview = _parse_tool_output(
+        sources, preview, _ = _parse_tool_output(
             {"content": "x", "sources": [{"bvid": "BV1"}]}
         )
         assert sources == [{"bvid": "BV1"}]
         assert preview  # any truthy preview
 
     def test_dict_with_results_field(self) -> None:
-        sources, _ = _parse_tool_output({"results": [{"bvid": "BV1"}]})
+        sources, _, _ = _parse_tool_output({"results": [{"bvid": "BV1"}]})
         assert sources == [{"bvid": "BV1"}]
 
     def test_json_string_parsed(self) -> None:
         payload = json.dumps({"sources": [{"bvid": "BV1"}]})
-        sources, _ = _parse_tool_output(payload)
+        sources, _, _ = _parse_tool_output(payload)
         assert sources == [{"bvid": "BV1"}]
 
     def test_invalid_json_string_yields_empty_sources(self) -> None:
-        sources, preview = _parse_tool_output("not json")
+        sources, preview, _ = _parse_tool_output("not json")
         assert sources == []
         assert preview == "not json"
 
     def test_non_dict_in_sources_filtered(self) -> None:
-        sources, _ = _parse_tool_output(
+        sources, _, _ = _parse_tool_output(
             {"sources": [{"bvid": "BV1"}, "garbage", 42]}
         )
         assert sources == [{"bvid": "BV1"}]

--- a/app/test/test_chat_history_artifacts.py
+++ b/app/test/test_chat_history_artifacts.py
@@ -1,0 +1,144 @@
+"""Tests for chat-history artifact persistence + presigned URL refresh.
+
+Covers the Plan-A fix: artifacts (e.g. run_code images) are persisted on
+the assistant message and every history read mints a fresh presigned URL
+from the stored minio_key so the images survive session reloads.
+"""
+
+from contextlib import ExitStack
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services import chat_history as chat_history_service
+
+pytestmark = pytest.mark.asyncio
+
+ART = {
+    "name": "chart.png",
+    "minio_key": "code-artifacts/1/abc-123/chart.png",
+    "url": "http://old/presigned",  # originally-generated URL (may be expired)
+    "content_type": "image/png",
+    "size": 1234,
+}
+
+
+def _row(artifacts=None) -> dict:
+    return {
+        "msg_id": "m1",
+        "chat_session_id": "s1",
+        "role": "assistant",
+        "content": "答案",
+        "status": "completed",
+        "sources": None,
+        "artifacts": artifacts if artifacts is not None else [dict(ART)],
+        "tokens_used": None,
+        "model": None,
+        "latency_ms": None,
+        "error": None,
+        "created_at": datetime.now(timezone.utc),
+    }
+
+
+def _history_ctx(rows, presigned=None, minio_enabled=True):
+    """Enter all patches via ExitStack; returns (messages, total, mocks)."""
+    stack = ExitStack()
+    stack.enter_context(
+        patch.object(
+            chat_history_service,
+            "get_chat_session_for_user",
+            new=AsyncMock(return_value=object()),  # non-None session
+        )
+    )
+    mock_get = stack.enter_context(
+        patch(
+            "app.repository.mongo_chat_repository.get_messages_for_user",
+            new_callable=AsyncMock,
+        )
+    )
+    stack.enter_context(patch("app.infra.minio.is_enabled", return_value=minio_enabled))
+    mock_client = stack.enter_context(patch("app.infra.minio.get_minio_client"))
+    client = MagicMock()
+    if presigned is not None:
+        client.presigned_get = AsyncMock(return_value=presigned)
+    else:
+        client.presigned_get = AsyncMock()
+    mock_client.return_value = client
+    mock_get.return_value = (rows, len(rows))
+    return stack, client
+
+
+class TestPersistArtifacts:
+    async def test_complete_assistant_message_persists_artifacts(self) -> None:
+        db = MagicMock()
+        with patch(
+            "app.repository.mongo_chat_repository.update_message_content",
+            new_callable=AsyncMock,
+        ) as mock_update:
+            await chat_history_service.complete_assistant_message(
+                db, msg_id="m1", content="答案", artifacts=[dict(ART)], sources=None,
+            )
+        kwargs = mock_update.call_args.kwargs
+        assert kwargs["artifacts"] == [ART]
+
+    async def test_no_artifacts_keeps_old_behavior(self) -> None:
+        db = MagicMock()
+        with patch(
+            "app.repository.mongo_chat_repository.update_message_content",
+            new_callable=AsyncMock,
+        ) as mock_update:
+            await chat_history_service.complete_assistant_message(
+                db, msg_id="m1", content="x", sources=None,
+            )
+        kwargs = mock_update.call_args.kwargs
+        assert kwargs.get("artifacts") is None
+
+
+class TestHistoryReads:
+    async def test_history_returns_artifacts_with_fresh_url(self) -> None:
+        stack, client = _history_ctx([_row()], presigned="http://fresh/presigned")
+        with stack:
+            messages, total = await chat_history_service.get_history_for_user(
+                MagicMock(), uid=1, chat_session_id="s1",
+            )
+
+        assert total == 1
+        msg = messages[0]
+        assert msg.artifacts is not None
+        assert msg.artifacts[0]["minio_key"] == ART["minio_key"]
+        assert msg.artifacts[0]["url"] == "http://fresh/presigned"
+        client.presigned_get.assert_awaited_once_with(ART["minio_key"])
+
+    async def test_history_keeps_stored_url_when_minio_disabled(self) -> None:
+        stack, client = _history_ctx([_row()], presigned=None, minio_enabled=False)
+        with stack:
+            messages, total = await chat_history_service.get_history_for_user(
+                MagicMock(), uid=1, chat_session_id="s1",
+            )
+
+        # minio disabled -> stored url kept, no presign call
+        assert messages[0].artifacts[0]["url"] == ART["url"]
+        client.presigned_get.assert_not_awaited()
+
+    async def test_history_without_artifacts_unchanged(self) -> None:
+        row = _row(None)
+        row["artifacts"] = None
+        stack, _ = _history_ctx([row], presigned="x")
+        with stack:
+            messages, total = await chat_history_service.get_history_for_user(
+                MagicMock(), uid=1, chat_session_id="s1",
+            )
+
+        assert messages[0].artifacts is None
+
+    async def test_presign_failure_keeps_stored_url(self) -> None:
+        stack, client = _history_ctx([_row()], presigned="http://fresh/presigned")
+        client.presigned_get = AsyncMock(side_effect=RuntimeError("minio down"))
+        with stack:
+            messages, _ = await chat_history_service.get_history_for_user(
+                MagicMock(), uid=1, chat_session_id="s1",
+            )
+
+        # graceful degradation: old url survives
+        assert messages[0].artifacts[0]["url"] == ART["url"]

--- a/app/test/test_minio_public_url.py
+++ b/app/test/test_minio_public_url.py
@@ -1,0 +1,77 @@
+"""Tests for the MinIO public URL resolution fallback chain.
+
+Covers _resolve_public_base(): explicit MINIO__PUBLIC_ENDPOINT >
+MINIO__PUBLIC_HOST (auto /minio-proxy prefix) > localhost default, and
+that _public_url rewrites only internal-endpoint URLs (so presigned
+signatures stay valid through the nginx /minio-proxy rewrite).
+"""
+
+from app.infra import minio as minio_mod
+from app.infra.config import config
+
+
+def _patch_minio(monkeypatch, **kwargs):
+    # build a section-like object overriding the fields we care about
+    import types
+
+    class _Section:
+        pass
+
+    sec = _Section()
+    sec.enabled = True
+    sec.endpoint = "http://minio:9000"
+    sec.region = "us-east-1"
+    sec.bucket = "drive-videos"
+    sec.secure = False
+    sec.presign_expire = 3600
+    sec.access_key = ""
+    sec.secret_key = ""
+    sec.public_endpoint = kwargs.get("public_endpoint", "")
+    sec.public_host = kwargs.get("public_host", "")
+    monkeypatch.setattr(config, "minio", sec)
+    return sec
+
+
+class TestResolvePublicBase:
+    def test_public_endpoint_wins(self, monkeypatch):
+        _patch_minio(
+            monkeypatch, public_endpoint="https://mindbase.example.com/minio-proxy",
+            public_host="192.168.1.100",
+        )
+        assert minio_mod._resolve_public_base() == "https://mindbase.example.com/minio-proxy"
+
+    def test_public_host_gets_minio_proxy_prefix(self, monkeypatch):
+        _patch_minio(monkeypatch, public_host="192.168.1.100")
+        assert minio_mod._resolve_public_base() == "http://192.168.1.100/minio-proxy"
+
+    def test_public_host_domain_uses_https_when_secure(self, monkeypatch):
+        sec = _patch_minio(monkeypatch, public_host="mindbase.example.com")
+        sec.secure = True
+        assert minio_mod._resolve_public_base() == "https://mindbase.example.com/minio-proxy"
+
+    def test_localhost_default_when_nothing_configured(self, monkeypatch):
+        _patch_minio(monkeypatch)
+        assert minio_mod._resolve_public_base() == "http://localhost/minio-proxy"
+
+
+class TestPublicUrl:
+    def _client(self, monkeypatch, **kw):
+        _patch_minio(monkeypatch, **kw)
+        client = minio_mod.MinioClient.__new__(minio_mod.MinioClient)
+        return client
+
+    def test_internal_url_rewritten_to_public_base(self, monkeypatch):
+        client = self._client(monkeypatch, public_host="10.0.0.5")
+        internal = "http://minio:9000/drive-videos/code-artifacts/1/x/a.png?sig=abc"
+        public = client._public_url(internal)
+        assert public == "http://10.0.0.5/minio-proxy/drive-videos/code-artifacts/1/x/a.png?sig=abc"
+
+    def test_other_urls_left_untouched(self, monkeypatch):
+        client = self._client(monkeypatch, public_host="10.0.0.5")
+        other = "https://cdn.example.com/some/file.bin"
+        assert client._public_url(other) == other
+
+    def test_localhost_default_rewrite(self, monkeypatch):
+        client = self._client(monkeypatch)
+        internal = "http://minio:9000/bucket/obj"
+        assert client._public_url(internal) == "http://localhost/minio-proxy/bucket/obj"

--- a/app/test/test_run_skill_code.py
+++ b/app/test/test_run_skill_code.py
@@ -1,0 +1,244 @@
+"""Tests for RunSkillCodeTool (app/tools/skill/run_skill_code.py).
+
+Verifies registration gating (skill_manager + DAYTONA__ENABLED), the
+sandbox lifecycle (create -> upload tools/ -> exec entry -> always delete),
+and friendly error paths. The Daytona SDK is fully mocked - no network.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.infra.config import config
+from app.models import Base
+from app.skills.manager import SkillManager
+from app.skills.zip_parser import build_skill_zip
+from app.tools import ToolDeps
+from app.tools.skill.run_skill_code import RunSkillCodeTool
+
+UID = 1
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    yield factory
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def mock_minio():
+    """In-memory MinIO stand-in (same as test_skills)."""
+    m = AsyncMock()
+    store: dict[str, bytes] = {}
+
+    async def put(key, data, ct="application/octet-stream"):
+        store[key] = data
+
+    async def get(key):
+        if key not in store:
+            raise FileNotFoundError(key)
+        return store[key]
+
+    async def delete(key):
+        store.pop(key, None)
+
+    m.put_object = AsyncMock(side_effect=put)
+    m.get_object = AsyncMock(side_effect=get)
+    m.delete_object = AsyncMock(side_effect=delete)
+    m._store = store
+    return m
+
+
+def _make_zip() -> bytes:
+    return build_skill_zip(
+        skill_md="# Skill\nrun it",
+        manifest={
+            "skill_id": "analyzer",
+            "name": "analyzer",
+            "has_code_tools": True,
+            "entry": "main.py",
+        },
+        code_tools={"main.py": "print(\"hello\")", "utils.py": "def f(): return 1"},
+    )
+
+
+async def _install(mgr: SkillManager, zip_bytes: bytes | None = None) -> None:
+    await mgr.install(
+        uid=UID,
+        skill_id="analyzer",
+        name="analyzer",
+        description="",
+        version=None,
+        source_store="upload",
+        zip_bytes=zip_bytes or _make_zip(),
+        manifest={"has_code_tools": True, "entry": "main.py"},
+    )
+
+
+def _make_tool(mgr: SkillManager) -> RunSkillCodeTool:
+    """Build a tool with a mocked Daytona client (bypasses __init__)."""
+    tool = RunSkillCodeTool.__new__(RunSkillCodeTool)
+    tool._skill_manager = mgr
+    tool._daytona = MagicMock()
+    tool._network_block_all = True
+    tool._domain_allow_list = ""
+    return tool
+
+
+def _sandbox(exec_result: dict | None = None) -> MagicMock:
+    """A mocked sandbox: workdir + fs.upload_file + process.exec."""
+    sb = MagicMock()
+    sb.get_work_dir.return_value = "/workspace"
+    resp = MagicMock()
+    if exec_result is not None:
+        resp.result = exec_result.get("result", "")
+        resp.exit_code = exec_result.get("exit_code", 0)
+    else:
+        resp.result = "exitCode=0\nhello from sandbox"
+        resp.exit_code = 0
+    sb.process.exec.return_value = resp
+    return sb
+
+
+class TestFromDeps:
+    def test_none_without_skill_manager(self) -> None:
+        assert RunSkillCodeTool.from_deps(ToolDeps()) is None
+
+    def test_none_when_daytona_disabled(self, session_factory, monkeypatch) -> None:
+        monkeypatch.setattr(config.daytona, "enabled", False)
+        mgr = SkillManager(session_factory, None)
+        assert RunSkillCodeTool.from_deps(ToolDeps(skill_manager=mgr)) is None
+
+    def test_registers_when_daytona_enabled(self, session_factory, monkeypatch) -> None:
+        monkeypatch.setattr(config.daytona, "enabled", True)
+        mgr = SkillManager(session_factory, None)
+        tool = RunSkillCodeTool.from_deps(ToolDeps(skill_manager=mgr))
+        # daytona-sdk is not installed in the test env - from_deps catches it
+        # and returns None; that is still a valid gating result.
+        assert tool is None or isinstance(tool, RunSkillCodeTool)
+
+    def test_metadata(self) -> None:
+        tool = RunSkillCodeTool.__new__(RunSkillCodeTool)  # property access, no init
+        assert tool.name == "run_skill_code"
+        params = tool.parameters()
+        assert params["required"] == ["skill_id"]
+
+
+class TestRun:
+    @pytest.mark.asyncio
+    async def test_missing_uid(self, session_factory) -> None:
+        mgr = SkillManager(session_factory, None)
+        tool = _make_tool(mgr)
+        result = await tool.run(skill_id="analyzer")
+        assert "_uid" in result["content"]
+
+    @pytest.mark.asyncio
+    async def test_unknown_skill(self, session_factory, mock_minio) -> None:
+        mgr = SkillManager(session_factory, mock_minio)
+        tool = _make_tool(mgr)
+        result = await tool.run(skill_id="nope", _uid=UID)
+        assert "未知技能" in result["content"]
+
+    @pytest.mark.asyncio
+    async def test_skill_without_code_tools(self, session_factory, mock_minio) -> None:
+        mgr = SkillManager(session_factory, mock_minio)
+        zip_bytes = build_skill_zip(
+            skill_md="# Skill", manifest={"skill_id": "plain", "name": "plain"},
+        )
+        await mgr.install(
+            uid=UID, skill_id="plain", name="plain", description="", version=None,
+            source_store="upload", zip_bytes=zip_bytes, manifest={},
+        )
+        tool = _make_tool(mgr)
+        result = await tool.run(skill_id="plain", _uid=UID)
+        assert "不含可执行的代码工具" in result["content"]
+
+    @pytest.mark.asyncio
+    async def test_unknown_entry(self, session_factory, mock_minio) -> None:
+        mgr = SkillManager(session_factory, mock_minio)
+        await _install(mgr)
+        tool = _make_tool(mgr)
+        result = await tool.run(skill_id="analyzer", entry="nope.py", _uid=UID)
+        assert "入口" in result["content"]
+        assert "不存在" in result["content"]
+
+    @pytest.mark.asyncio
+    async def test_runs_entry_in_sandbox(self, session_factory, mock_minio) -> None:
+        mgr = SkillManager(session_factory, mock_minio)
+        await _install(mgr)
+        tool = _make_tool(mgr)
+        sb = _sandbox()
+        tool._daytona.create.return_value = sb
+
+        result = await tool.run(skill_id="analyzer", _uid=UID)
+
+        assert result["exit_code"] == 0
+        assert "hello from sandbox" in result["content"]
+        # both tools/ files uploaded to the sandbox workdir
+        assert sb.fs.upload_file.call_count == 2
+        uploads = [c.args for c in sb.fs.upload_file.call_args_list]
+        assert any(a[1] == "/workspace/tools/main.py" for a in uploads)
+        assert any(a[1] == "/workspace/tools/utils.py" for a in uploads)
+        # entry executed with cwd=workdir
+        cmd = sb.process.exec.call_args.args[0]
+        assert cmd == "python tools/main.py"
+        assert sb.process.exec.call_args.kwargs.get("cwd") == "/workspace"
+        # sandbox deleted
+        tool._daytona.delete.assert_called_once_with(sb)
+
+    @pytest.mark.asyncio
+    async def test_passes_args_and_entry_override(self, session_factory, mock_minio) -> None:
+        mgr = SkillManager(session_factory, mock_minio)
+        await _install(mgr)
+        tool = _make_tool(mgr)
+        sb = _sandbox()
+        tool._daytona.create.return_value = sb
+
+        await tool.run(
+            skill_id="analyzer", entry="utils.py", args="--verbose 2", _uid=UID
+        )
+
+        cmd = sb.process.exec.call_args.args[0]
+        assert cmd == "python tools/utils.py --verbose 2"
+        tool._daytona.delete.assert_called_once_with(sb)
+
+    @pytest.mark.asyncio
+    async def test_sandbox_deleted_on_exec_error(self, session_factory, mock_minio) -> None:
+        mgr = SkillManager(session_factory, mock_minio)
+        await _install(mgr)
+        tool = _make_tool(mgr)
+        sb = _sandbox()
+        sb.process.exec.side_effect = RuntimeError("boom")
+        tool._daytona.create.return_value = sb
+
+        result = await tool.run(skill_id="analyzer", _uid=UID)
+
+        assert result["exit_code"] == -1
+        assert "运行失败" in result["content"]
+        tool._daytona.delete.assert_called_once_with(sb)
+
+    @pytest.mark.asyncio
+    async def test_sandbox_deleted_on_create_failure(self, session_factory, mock_minio) -> None:
+        mgr = SkillManager(session_factory, mock_minio)
+        await _install(mgr)
+        tool = _make_tool(mgr)
+        tool._daytona.create.side_effect = RuntimeError("no quota")
+
+        result = await tool.run(skill_id="analyzer", _uid=UID)
+
+        assert result["exit_code"] == -1
+        assert "沙箱创建失败" in result["content"]
+        tool._daytona.delete.assert_not_called()

--- a/app/test/test_skills.py
+++ b/app/test/test_skills.py
@@ -15,11 +15,13 @@ import pytest_asyncio
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.pool import StaticPool
 
+from app.infra.config import config
 from app.models import Base
 from app.skills.manager import SkillManager
 from app.skills.zip_parser import (
     Skill,
     build_skill_zip,
+    inspect_zip,
     parse_skill_zip,
     read_manifest,
 )
@@ -72,16 +74,20 @@ async def mock_minio():
     return m
 
 
-def _make_zip(*, body: str = "# Skill\n步骤1\n", has_code_tools: bool = False, name: str = "demo") -> bytes:
+def _make_zip(*, body: str = "# Skill\n步骤1\n", has_code_tools: bool = False, name: str = "demo", code_tools: dict | None = None, entry: str | None = None) -> bytes:
+    manifest: dict = {
+        "skill_id": name,
+        "name": name,
+        "description": f"{name} description",
+        "version": "1.0",
+        "has_code_tools": has_code_tools,
+    }
+    if entry:
+        manifest["entry"] = entry
     return build_skill_zip(
         skill_md=body,
-        manifest={
-            "skill_id": name,
-            "name": name,
-            "description": f"{name} description",
-            "version": "1.0",
-            "has_code_tools": has_code_tools,
-        },
+        manifest=manifest,
+        code_tools=code_tools,
     )
 
 
@@ -109,6 +115,38 @@ class TestZipParser:
         )
         skill = parse_skill_zip(zip_bytes, skill_id="x", name="X")
         assert skill.body == "正文"
+
+    def test_parse_skill_zip_extracts_code_tools(self) -> None:
+        zip_bytes = build_skill_zip(
+            skill_md="# Skill\nbody",
+            manifest={"has_code_tools": True, "entry": "main.py"},
+            code_tools={"main.py": "print(1)", "utils.py": "def f(): return 1"},
+        )
+        skill = parse_skill_zip(zip_bytes, skill_id="x", name="X")
+        assert skill.has_code_tools is True
+        assert skill.code_tools == {"main.py": "print(1)", "utils.py": "def f(): return 1"}
+        assert skill.entry == "main.py"
+
+    def test_parse_skill_zip_code_tools_imply_flag(self) -> None:
+        # tools/ present but manifest does not claim has_code_tools
+        zip_bytes = build_skill_zip(
+            skill_md="# Skill\nbody",
+            manifest={},
+            code_tools={"main.py": "print(1)"},
+        )
+        skill = parse_skill_zip(zip_bytes, skill_id="x", name="X")
+        assert skill.has_code_tools is True
+        assert "main.py" in skill.code_tools
+
+    def test_inspect_zip_lists_code_tools(self) -> None:
+        zip_bytes = build_skill_zip(
+            skill_md="# Skill\nbody",
+            manifest={"entry": "main.py"},
+            code_tools={"main.py": "print(1)", "helper.py": "x = 1"},
+        )
+        info = inspect_zip(zip_bytes)
+        assert info["code_tools"] == ["helper.py", "main.py"]
+        assert info["entry"] == "main.py"
 
     def test_read_manifest_returns_dict(self) -> None:
         zip_bytes = _make_zip(name="abc")
@@ -339,18 +377,49 @@ class TestLoadSkillTool:
         assert "video-summary" in result
 
     @pytest.mark.asyncio
-    async def test_code_tools_warning(self, session_factory, mock_minio) -> None:
+    async def test_code_tools_unavailable_when_daytona_off(
+        self, session_factory, mock_minio, monkeypatch
+    ) -> None:
+        # Force DAYTONA__ENABLED=false (repo .env may set it true) -> code
+        # tools reported unavailable.
+        monkeypatch.setattr(config.daytona, "enabled", False)
         mgr = SkillManager(session_factory, mock_minio)
         await mgr.install(
             uid=UID, skill_id="code", name="code", description="", version=None,
             source_store="upload",
-            zip_bytes=_make_zip(body="body", has_code_tools=True),
+            zip_bytes=_make_zip(
+                body="body", has_code_tools=True, code_tools={"main.py": "print(1)"}
+            ),
             manifest={"has_code_tools": True},
         )
         tool = LoadSkillTool(mgr)
         result = await tool.run(name="code", _uid=UID)
         assert "代码工具" in result
-        assert "沙箱" in result
+        assert "暂不可执行" in result
+
+    @pytest.mark.asyncio
+    async def test_code_tools_executable_when_daytona_on(
+        self, session_factory, mock_minio, monkeypatch
+    ) -> None:
+        # DAYTONA__ENABLED=true -> agent is told to use run_skill_code.
+        monkeypatch.setattr(config.daytona, "enabled", True)
+        mgr = SkillManager(session_factory, mock_minio)
+        await mgr.install(
+            uid=UID, skill_id="code", name="code", description="", version=None,
+            source_store="upload",
+            zip_bytes=_make_zip(
+                body="body", has_code_tools=True,
+                code_tools={"main.py": "print(1)", "helper.py": "x = 1"},
+                entry="main.py",
+            ),
+            manifest={"has_code_tools": True, "entry": "main.py"},
+        )
+        tool = LoadSkillTool(mgr)
+        result = await tool.run(name="code", _uid=UID)
+        assert "run_skill_code" in result
+        assert "main.py" in result
+        assert "helper.py" in result
+        assert "暂不可执行" not in result
 
     def test_from_deps_returns_none_when_no_skill_manager(self) -> None:
         assert LoadSkillTool.from_deps(ToolDeps()) is None

--- a/app/tools/skill/__init__.py
+++ b/app/tools/skill/__init__.py
@@ -1,5 +1,6 @@
 """Skill tools - tools that serve the Skills system (e.g. load_skill)."""
 
 from .load_skill import LoadSkillTool
+from .run_skill_code import RunSkillCodeTool
 
-__all__ = ["LoadSkillTool"]
+__all__ = ["LoadSkillTool", "RunSkillCodeTool"]

--- a/app/tools/skill/load_skill.py
+++ b/app/tools/skill/load_skill.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from app.infra.config import config
 from app.skills.manager import SkillManager
 from app.tools import ToolDeps, register_tool
 
@@ -67,8 +68,28 @@ class LoadSkillTool:
         logger.info("[LOAD_SKILL] uid=%s loaded skill='%s'", uid, name)
         msg = f"# 技能: {skill.name}\n\n{skill.body}"
         if skill.has_code_tools:
-            msg += (
-                "\n\n⚠️ 该技能含代码工具，需沙箱支持，当前暂不可执行。"
-                "请仅按上述指令使用已有工具完成任务。"
-            )
+            msg += self._code_tools_section(skill)
         return msg
+
+    @staticmethod
+    def _code_tools_section(skill: Any) -> str:
+        """Describe the skill code tools and how to execute them.
+
+        When Daytona is enabled (``DAYTONA__ENABLED``) the agent is told to
+        use ``run_skill_code`` to run the tools in a sandbox; otherwise it
+        gets the old "unavailable" notice so it does not fabricate results.
+        """
+        files = ", ".join(sorted(skill.code_tools)) if skill.code_tools else "(无)"
+        entry = skill.entry or "main.py"
+        if config.daytona.enabled:
+            return (
+                "\n\n## 代码工具\n该技能含以下可执行脚本（tools/ 目录）: " + files + "\n"
+                "默认入口: " + entry + "（可用 run_skill_code 的 entry 参数覆盖）\n"
+                "执行方式: 调用 run_skill_code 工具，传入 skill_id、entry、args\n"
+                "代码将在 Daytona 沙箱中运行，返回 stdout 与 exitCode。"
+            )
+        return (
+            "\n\n⚠️ 该技能含代码工具，需 Daytona 沙箱支持（DAYTONA__ENABLED=true 时启用），"
+            "当前暂不可执行。请仅按上述指令使用已有工具完成任务。"
+        )
+

--- a/app/tools/skill/run_skill_code.py
+++ b/app/tools/skill/run_skill_code.py
@@ -1,0 +1,225 @@
+"""RunSkillCodeTool - execute a skill code tool in an isolated Daytona sandbox.
+
+Skills whose manifest declares ``has_code_tools`` (and carry a ``tools/``
+directory in their zip) expose runnable scripts. This tool loads the skill,
+uploads its ``tools/`` files into a short-lived Daytona sandbox, runs the
+entrypoint (``manifest.entry`` or ``main.py`` by default), and returns
+stdout + exit code. The sandbox is always deleted (even on timeout/failure).
+
+Registered only when BOTH conditions hold:
+  * ``config.daytona.enabled`` (``DAYTONA__ENABLED=true``)
+  * a ``SkillManager`` is available in ``ToolDeps``
+Otherwise ``from_deps`` returns ``None`` and the tool is not exposed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from app.infra.config import config
+from app.skills import Skill, SkillManager
+from app.tools import ToolDeps, register_tool
+
+logger = logging.getLogger(__name__)
+
+# Total per-call timeout (sandbox creation alone can take 10-40s on the
+# cloud, plus execution). Must stay under the chat request budget; the
+# sandbox is force-deleted when this fires.
+RUN_SKILL_CODE_TIMEOUT = 90.0
+
+
+@register_tool
+class RunSkillCodeTool:
+    """Run one of a skill code tools in a Daytona sandbox."""
+
+    def __init__(
+        self,
+        skill_manager: SkillManager,
+        api_key: str,
+        api_url: str,
+        org_id: str = "",
+        network_block_all: bool = True,
+        domain_allow_list: str = "",
+    ) -> None:
+        from daytona_sdk import Daytona, DaytonaConfig
+
+        self._skill_manager = skill_manager
+        cfg_kwargs: dict[str, Any] = {"api_key": api_key, "api_url": api_url}
+        if org_id:
+            cfg_kwargs["organization_id"] = org_id
+        self._daytona = Daytona(DaytonaConfig(**cfg_kwargs))
+        self._network_block_all = network_block_all
+        self._domain_allow_list = domain_allow_list
+
+    @classmethod
+    def from_deps(cls, deps: ToolDeps) -> "RunSkillCodeTool | None":
+        # Both the skills system and the Daytona sandbox must be available.
+        if deps.skill_manager is None:
+            return None
+        if not config.daytona.enabled:
+            logger.info("[RUN_SKILL_CODE] daytona disabled - tool not registered")
+            return None
+        try:
+            return cls(
+                skill_manager=deps.skill_manager,
+                api_key=config.daytona.api_key.get_secret_value(),
+                api_url=config.daytona.api_url,
+                org_id=config.daytona.org_id,
+                network_block_all=config.daytona.network_block_all,
+                domain_allow_list=config.daytona.domain_allow_list,
+            )
+        except Exception as exc:
+            logger.warning("[RUN_SKILL_CODE] daytona-sdk init failed: %s", exc)
+            return None
+
+    @property
+    def name(self) -> str:
+        return "run_skill_code"
+
+    @property
+    def description(self) -> str:
+        return (
+            "在 Daytona 沙箱中执行已安装技能(skill)的代码工具，返回 stdout 和 exitCode。"
+            "用于执行带代码工具的技能。entry 为 tools/ 下入口文件名（默认 main.py），"
+            "args 为可选命令行参数。"
+        )
+
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "skill_id": {"type": "string", "description": "技能 ID（见技能索引）"},
+                "entry": {
+                    "type": "string",
+                    "description": "tools/ 下要执行的入口文件名，默认 main.py",
+                },
+                "args": {
+                    "type": "string",
+                    "description": "传给入口脚本的可选命令行参数",
+                },
+            },
+            "required": ["skill_id"],
+        }
+
+    async def run(
+        self,
+        *,
+        skill_id: str,
+        entry: str = "",
+        args: str = "",
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        uid = kwargs.get("_uid")
+        if uid is None:
+            return {"content": "无法执行技能代码：缺少用户上下文（_uid）。", "exit_code": -1}
+
+        skill = await self._skill_manager.load_skill(uid, skill_id)
+        if skill is None:
+            return {"content": f"未知技能 '{skill_id}'，或技能加载失败。", "exit_code": -1}
+        if not skill.has_code_tools or not skill.code_tools:
+            return {
+                "content": f"技能 '{skill_id}' 不含可执行的代码工具（tools/ 为空）。",
+                "exit_code": -1,
+            }
+
+        entry = entry.strip() or (skill.entry or "main.py")
+        entry = entry.removeprefix("tools/")
+        if entry not in skill.code_tools:
+            available = ", ".join(sorted(skill.code_tools)) or "无"
+            return {
+                "content": f"入口 '{entry}' 不存在。可用代码工具: {available}",
+                "exit_code": -1,
+            }
+
+        logger.info(
+            "[RUN_SKILL_CODE] uid=%s skill='%s' entry='%s' args='%s'",
+            uid, skill_id, entry, args[:100],
+        )
+        try:
+            sandbox = await asyncio.to_thread(self._create_sandbox)
+        except Exception as exc:
+            logger.warning("[RUN_SKILL_CODE] sandbox creation failed: %s", exc)
+            return {"content": f"沙箱创建失败: {exc}", "exit_code": -1}
+
+        try:
+            try:
+                result = await asyncio.wait_for(
+                    asyncio.to_thread(
+                        self._run_skill_sync, sandbox, skill, entry, args
+                    ),
+                    timeout=RUN_SKILL_CODE_TIMEOUT,
+                )
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "[RUN_SKILL_CODE] timed out after %ss, deleting sandbox",
+                    RUN_SKILL_CODE_TIMEOUT,
+                )
+                return {
+                    "content": f"技能代码运行超时(>{RUN_SKILL_CODE_TIMEOUT}s),已终止",
+                    "exit_code": -1,
+                    "timeout": True,
+                }
+            return {
+                "content": result.get("content", ""),
+                "exit_code": result.get("exit_code", 0),
+            }
+        finally:
+            await asyncio.to_thread(self._delete_sandbox, sandbox)
+
+    def _create_sandbox(self) -> Any:
+        # Python runtime + the same network policy as run_code (block-all
+        # by default; allow-list opens specific domains).
+        from daytona_sdk import CreateSandboxFromSnapshotParams
+
+        params_kwargs: dict[str, Any] = {"language": "python"}
+        if self._domain_allow_list:
+            params_kwargs["domain_allow_list"] = self._domain_allow_list
+        elif self._network_block_all:
+            params_kwargs["network_block_all"] = True
+        try:
+            return self._daytona.create(
+                CreateSandboxFromSnapshotParams(**params_kwargs)
+            )
+        except Exception as exc:
+            logger.warning(
+                "[RUN_SKILL_CODE] create() rejected structured params (%s); "
+                "falling back to default sandbox (network restrictions dropped)",
+                exc,
+            )
+            return self._daytona.create()
+
+    def _run_skill_sync(
+        self, sandbox: Any, skill: Skill, entry: str, args: str
+    ) -> dict[str, Any]:
+        try:
+            # Upload every tools/ file (entry + any helpers it imports),
+            # then run the entrypoint from the sandbox working directory.
+            wd = sandbox.get_work_dir() or ""
+            for rel, src in skill.code_tools.items():
+                dst = f"tools/{rel}" if not wd else f"{wd}/tools/{rel}"
+                sandbox.fs.upload_file(src.encode("utf-8"), dst)
+            cmd = f"python tools/{entry}"
+            if args.strip():
+                cmd = f"{cmd} {args.strip()}"
+            resp = sandbox.process.exec(cmd, cwd=wd or None)
+            output = getattr(resp, "result", None) or ""
+            if not output and getattr(resp, "artifacts", None):
+                output = getattr(resp.artifacts, "stdout", None) or ""
+            exit_code = getattr(resp, "exit_code", None)
+            if exit_code is None:
+                exit_code = 0
+            return {
+                "content": f"exitCode={exit_code}\n{output}",
+                "exit_code": exit_code,
+            }
+        except Exception as exc:
+            logger.warning("[RUN_SKILL_CODE] execution failed: %s", exc)
+            return {"content": f"运行失败: {exc}", "exit_code": -1}
+
+    def _delete_sandbox(self, sandbox: Any) -> None:
+        try:
+            self._daytona.delete(sandbox)
+        except Exception:
+            pass

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,6 +77,7 @@ services:
       - MINIO__REGION=${MINIO_REGION:-us-east-1}
       - MINIO__SECURE=${MINIO_SECURE:-false}
       - MINIO__PUBLIC_ENDPOINT=${MINIO__PUBLIC_ENDPOINT:-}
+      - MINIO__PUBLIC_HOST=${MINIO__PUBLIC_HOST:-}
       # Task-quiz agent (main app) -> app-task via APISIX
       - APPTASK_BASE_URL=http://apisix:9080
       - APISIX_CONSUMER_KEY=${APISIX_CONSUMER_KEY:-mindbase-internal-key-change-me}

--- a/frontendv2/components/chat/chat-view.tsx
+++ b/frontendv2/components/chat/chat-view.tsx
@@ -30,6 +30,9 @@ function toUIMessage(m: ApiChatMessage): ChatMessageData {
     content: m.content,
     // Backend may return null; normalize to array.
     sources: Array.isArray(m.sources) ? m.sources : undefined,
+    // Binary outputs (run_code images) persisted on the message; without
+    // this mapping, reloading history loses the images (SSE-only display).
+    artifacts: Array.isArray(m.artifacts) ? m.artifacts : undefined,
     status: m.status,
     error: m.error,
     timestamp: m.created_at,

--- a/frontendv2/lib/api/chat.ts
+++ b/frontendv2/lib/api/chat.ts
@@ -2,6 +2,7 @@
  * Chat API - 问答 / 流式 / 会话管理 / 历史消息.
  */
 import { request, getAuthHeaders, API_BASE_URL } from "./client";
+import type { ChatArtifact } from "@/lib/chat-stream";
 
 export interface ChatResponse {
     answer: string;
@@ -55,6 +56,9 @@ export interface ChatMessage {
     content: string;
     status: "pending" | "completed" | "failed";
     sources?: Array<{ bvid: string; title: string; url?: string }>;
+    // Binary outputs (e.g. run_code images) persisted with the message;
+    // url is a freshly presigned link refreshed by the history endpoint.
+    artifacts?: ChatArtifact[];
     tokens_used?: number;
     model?: string;
     latency_ms?: number;


### PR DESCRIPTION
## 变更内容

- **[skills]** feat: 带代码工具的技能可在 Daytona 沙箱执行（新增 run_skill_code 工具，由 DAYTONA__ENABLED 门控；load_skill 按开关返回执行指引或不可用提示）
- **[chat]** feat: 聊天消息持久化 artifacts（run_code 生成的图片），历史读取时用 minio_key 动态刷新 presigned URL，切换路由/刷新浏览器后图片可恢复
- **[minio]** feat: presigned URL 支持 nginx /minio-proxy 对外地址回退链（PUBLIC_ENDPOINT > PUBLIC_HOST > localhost 默认），解决浏览器无法解析容器内网地址
- **[frontend]** fix: 历史消息 toUIMessage 透传 artifacts 字段
- **[code]** feat: 绘图规范提示词（matplotlib 图表 title/label/图例等文字使用英文，避免默认字体渲染方块）

## 动机

1. 技能包（skill zip）的代码工具此前标注需沙箱支持暂不可执行，现可在 Daytona 沙箱中上传 tools/ 并执行入口脚本
2. 代码生成的图片此前仅依赖 SSE 实时推送 + 前端内存态，切换路由或刷新即丢失；现随聊天消息持久化（MongoDB artifacts 字段），读取历史时动态生成新签名 URL
3. presigned URL 此前返回容器内网地址（http://minio:9000/...），浏览器无法解析；现经 nginx /minio-proxy 代理返回对外地址，签名 host 由 nginx 重写保持一致，校验仍通过
4. matplotlib 默认字体不含中文，图表中文渲染成方块；提示词约束图表文字使用英文

## 验证

- ruff check app/ --ignore E501,E402：All checks passed
- pytest：97 passed（skills / chat artifacts / minio public url / SSE streamer / skill store / code agent persistence）
- 新增测试：test_run_skill_code.py、test_chat_history_artifacts.py、test_minio_public_url.py

## 部署注意

- 需重建并重启 backend + frontend：docker compose up -d --build backend frontend
- 浏览器访问入口需为 nginx（/minio-proxy 代理所在）；对外地址按需在 .env 配置 MINIO__PUBLIC_ENDPOINT 或 MINIO__PUBLIC_HOST
