### PR TITLE
[chat] perf: 聊天流式返回提速与 SSE 全链路修复

### DIFF
--- a/apisix/config.yaml
+++ b/apisix/config.yaml
@@ -18,3 +18,21 @@ apisix:
   control:
     ip: 0.0.0.0
     port: 9090
+
+# Custom nginx directives.
+# proxy_buffering off: /chat/* and /task-quiz/chat are SSE streams. APISIX
+# (nginx-based) buffers upstream responses by default, which collapses
+# token-by-token streaming into one bulk delivery.
+#
+# NOTE: `nginx_config.http.proxy_buffering` is NOT a supported key — APISIX
+# silently ignores it (verified: absent from ngx_tpl.lua and from the
+# generated nginx.conf). Arbitrary directives must go through a
+# *_configuration_snippet slot; this one lands `proxy_buffering off;` inside
+# every location block of the generated nginx.conf (verified with
+# `apisix test` + grep). The backend also sends `X-Accel-Buffering: no` on
+# SSE responses (app/routers/streaming.py) as a per-response belt-and-braces
+# that survives even if this directive is removed.
+nginx_config:
+  http_server_location_configuration_snippet: |
+    proxy_buffering off;
+

--- a/app/agent/chat/graph.py
+++ b/app/agent/chat/graph.py
@@ -114,27 +114,23 @@ async def inject_context(
     uid = state.uid
     folder_ids = state.folder_ids
 
-    # Run independent lookups concurrently: media_ids, conversation_context,
-    # and query rewrite (an LLM call) are mutually independent.  bvids depends
-    # on media_ids so it stays serial after the gather.  Rewrite failures are
-    # non-fatal (multi-path search is simply skipped); _safe_rewrite keeps that
-    # contract without letting an exception cancel the sibling lookups.
-    async def _safe_rewrite() -> Any:
-        try:
-            return await deps.rewrite_query(state.query)
-        except Exception:
-            logger.warning("[CHAT_AGENT] query rewrite skipped", exc_info=True)
-            return None
-
+    # Run independent lookups concurrently: media_ids and conversation_context
+    # are mutually independent.  bvids depends on media_ids so it stays serial
+    # after the gather.
+    #
+    # Query rewrite has been REMOVED: the ReAct LLM already optimizes its own
+    # retrieval queries (vector_search.description instructs it to disambiguate
+    # pronouns / complete context / search from multiple angles), so the extra
+    # forced rewrite LLM call only added latency before the first token without
+    # improving recall. The LLM decides when and how to rewrite.
     has_ctx = bool(state.session_id and state.uid)
-    media_ids, conversation_context, rewrite_result = await asyncio.gather(
+    media_ids, conversation_context = await asyncio.gather(
         deps.get_media_ids(uid, folder_ids) if uid else _noop_list(),
         (
             deps.get_conversation_context(state.session_id, state.uid)
             if has_ctx
             else _noop_str()
         ),
-        _safe_rewrite(),
     )
     bvids = await deps.get_bvids(media_ids) if media_ids else []
     has_data = len(bvids) > 0
@@ -150,14 +146,10 @@ async def inject_context(
         if conversation_context:
             logger.info("  context preview: {}", conversation_context[:200])
 
+    # Always empty: outer rewrite is disabled. Kept as an empty list so
+    # runtime_dispatch / vector_search's multi-path (which skips empty
+    # rewritten_queries and falls back to a single-query search) is unchanged.
     rewritten_queries: list[str] = []
-    if rewrite_result and rewrite_result.rewrites:
-        rewritten_queries = [rq.query for rq in rewrite_result.rewrites]
-        logger.info(
-            "[CHAT_AGENT] query rewrite: original='{}' rewrites={}",
-            state.query[:50],
-            rewritten_queries,
-        )
 
     # Detect context tools in the registry
     registered = runtime.list_tool_names()

--- a/app/config/default.yaml
+++ b/app/config/default.yaml
@@ -241,6 +241,7 @@ security:
   cors:
     allow_origins:
       - http://localhost:3000   # user frontend (Next.js dev server)
+      - http://127.0.0.1:3000   # same frontend via loopback IP
 
   # Plan 0028: per-endpoint rate limits + login cooldown.
   # All windows are seconds. Override via env:

--- a/app/main.py
+++ b/app/main.py
@@ -454,6 +454,9 @@ app.add_middleware(
         "Content-Type",
         "If-Match",
         "X-Request-Id",
+        # frontendv2 marks every API fetch with this header so page navigation
+        # and API calls can be told apart; cross-origin preflights declare it.
+        "X-Requested-With",
     ],
     expose_headers=["X-Total-Count"],
 )

--- a/app/routers/chat.py
+++ b/app/routers/chat.py
@@ -26,6 +26,7 @@ from app.response import (
 )
 from app.routers.auth import get_current_uid
 from app.routers.knowledge import get_rag_service
+from app.routers.streaming import sse_streaming_response
 from app.services import chat_history as chat_history_service
 from app.services.chat import orchestrator as chat_orchestrator
 
@@ -98,7 +99,7 @@ async def ask_question_stream(
         api_key_manager=getattr(http_request.app.state, "api_key_manager", None),
         usage_writer=getattr(http_request.app.state, "usage_writer", None),
     )
-    return StreamingResponse(generator, media_type="text/event-stream")
+    return sse_streaming_response(generator)
 
 
 @router.post("/ask/agent", response_model=ChatResponse)
@@ -140,7 +141,7 @@ async def ask_question_agent_stream(
         api_key_manager=getattr(http_request.app.state, "api_key_manager", None),
         usage_writer=getattr(http_request.app.state, "usage_writer", None),
     )
-    return StreamingResponse(generator, media_type="text/event-stream")
+    return sse_streaming_response(generator)
 
 
 @router.post("/search")

--- a/app/routers/session_summary.py
+++ b/app/routers/session_summary.py
@@ -12,12 +12,12 @@ endpoint.
 """
 
 from fastapi import APIRouter, Depends, HTTPException, Request
-from fastapi.responses import StreamingResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
 from app.response.chat import SessionSummaryResponse
 from app.routers.auth import get_current_uid
+from app.routers.streaming import sse_streaming_response
 from app.services import session_summary as session_summary_service
 
 router = APIRouter(prefix="/chat", tags=["会话总结"])
@@ -35,11 +35,10 @@ async def summarize_session(
     agent, input_state, run_config = await session_summary_service.prepare_summary(
         db, uid, chat_session_id, agent_harness
     )
-    return StreamingResponse(
+    return sse_streaming_response(
         session_summary_service.stream_summary(
             agent, input_state, run_config, uid=uid, chat_session_id=chat_session_id
-        ),
-        media_type="text/event-stream",
+        )
     )
 
 

--- a/app/routers/streaming.py
+++ b/app/routers/streaming.py
@@ -1,0 +1,33 @@
+"""Shared SSE streaming-response helpers for routers.
+
+Every SSE endpoint must go through ``sse_streaming_response`` so gateway
+proxies (nginx / APISIX) stream tokens incrementally instead of collapsing
+the stream into one bulk delivery:
+
+- ``X-Accel-Buffering: no`` — nginx and APISIX both honor it per-response,
+  disabling proxy buffering even when buffering is on at the http/location
+  level.
+- ``Cache-Control: no-cache`` — keeps intermediate cache layers from holding
+  the response.
+
+Note: ``Connection: keep-alive`` is deliberately NOT set — it is a hop-by-hop
+header managed by the server/proxies (stripped by nginx, invalid on HTTP/2).
+"""
+
+from collections.abc import AsyncIterator
+
+from fastapi.responses import StreamingResponse
+
+SSE_HEADERS = {
+    "X-Accel-Buffering": "no",
+    "Cache-Control": "no-cache",
+}
+
+
+def sse_streaming_response(generator: AsyncIterator[str]) -> StreamingResponse:
+    """Build an SSE StreamingResponse with the anti-buffering headers."""
+    return StreamingResponse(
+        generator,
+        media_type="text/event-stream",
+        headers=SSE_HEADERS,
+    )

--- a/app/routers/task_quiz.py
+++ b/app/routers/task_quiz.py
@@ -9,7 +9,6 @@ import json
 from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, HTTPException, Request
-from fastapi.responses import StreamingResponse
 from loguru import logger
 
 import os
@@ -20,6 +19,7 @@ from pydantic import BaseModel, Field
 from app.agent.task_quiz.graph import get_agent
 from app.database import get_db_context
 from app.routers.auth import _get_sf
+from app.routers.streaming import sse_streaming_response
 from app.services.auth import UserService
 
 router = APIRouter(prefix="/task-quiz", tags=["task-quiz"])
@@ -73,7 +73,7 @@ async def chat(request: Request):
             logger.exception("[TASK_QUIZ] stream error")
             yield f"data: {json.dumps({'type': 'error', 'message': str(e)})}\n\n"
 
-    return StreamingResponse(stream(), media_type="text/event-stream")
+    return sse_streaming_response(stream())
 
 
 class TaskRegisterRequest(BaseModel):

--- a/frontendv2/components/chat/chat-input.tsx
+++ b/frontendv2/components/chat/chat-input.tsx
@@ -26,7 +26,12 @@ interface ChatInputProps {
 // Apple-style chat input - a single rounded card that grows with content up to
 // MAX_HEIGHT, then scrolls internally. Send button is a filled accent circle.
 // Typing "/" as the first character opens the slash menu (commands + skills).
-const MIN_HEIGHT = 24;
+// MIN_HEIGHT = one 24px line (leading-6) + py-1 (4px x 2) = 32px, which equals
+// the send button's h-8: with the flex items-end row, a single-line input is
+// then exactly as tall as the button, so the text sits vertically centered in
+// the card (previously a 24px textarea bottom-aligned against a 32px button
+// left ~4px more space above the text than below -> text looked shifted down).
+const MIN_HEIGHT = 32;
 const MAX_HEIGHT = 200;
 // input starts with "/" followed by no whitespace → slash menu is active
 const SLASH_RE = /^\/(\S*)$/;
@@ -210,7 +215,7 @@ export function ChatInput({
           placeholder={placeholder}
           disabled={disabled}
           rows={1}
-          className="flex-1 resize-none bg-transparent text-[15px] leading-relaxed text-foreground placeholder:text-tertiary focus:outline-none disabled:opacity-50"
+          className="flex-1 resize-none bg-transparent py-1 text-[15px] leading-6 text-foreground placeholder:text-tertiary focus:outline-none disabled:opacity-50"
           style={{ minHeight: `${MIN_HEIGHT}px`, maxHeight: `${MAX_HEIGHT}px` }}
           aria-label="聊天消息输入"
           aria-disabled={disabled}

--- a/frontendv2/lib/api/client.ts
+++ b/frontendv2/lib/api/client.ts
@@ -11,18 +11,24 @@
 
 import { sanitizeError } from "@/lib/error-utils";
 
-// SSR base URL: when NEXT_PUBLIC_API_URL is unset (relative-path mode), the
-// browser uses "" (current origin = nginx). But Next.js server-side fetches
-// (SSR/RSC) have no origin, so they need an absolute internal URL. Route them
-// through nginx too (NOT direct backend:8000) so SSR traffic stays behind the
-// nginx -> apisix -> backend chain and benefits from load balancing.
+// SSR base URL: Next.js server-side fetches (SSR/RSC) have no origin, so they
+// always need an absolute internal URL. Route them through nginx (NOT direct
+// backend:8000) so SSR traffic stays behind the nginx -> apisix -> backend
+// chain and benefits from load balancing.
 // NEXT_PUBLIC_APISIX_HOST is inlined at build time: docker-compose sets it to
 // "nginx:80"; local dev falls back to "localhost:9080" (apisix on host/VM).
 const INTERNAL_API_HOST = process.env.NEXT_PUBLIC_APISIX_HOST || "localhost:9080";
 
+// Browser base URL: NEXT_PUBLIC_API_URL (set at build time) points the browser
+// straight at the gateway (e.g. http://localhost -> nginx:80), bypassing the
+// Next.js server entirely - its rewrites proxy buffers SSE, collapsing
+// token-by-token streaming into one bulk delivery. Unset = "" (same-origin).
+// It must NOT be used for SSR: inside the frontend container "localhost" is
+// the Next server itself, not the gateway.
 export const API_BASE_URL =
-    process.env.NEXT_PUBLIC_API_URL ||
-    (typeof window !== "undefined" ? "" : `http://${INTERNAL_API_HOST}`);
+    typeof window !== "undefined"
+        ? process.env.NEXT_PUBLIC_API_URL || ""
+        : `http://${INTERNAL_API_HOST}`;
 
 // Authorization header built from the bili_session token in localStorage.
 export function getAuthHeaders(): Record<string, string> {


### PR DESCRIPTION
## 背景

用户感知聊天"不是流式返回"（token 一次性整块到达）。排查发现首 token 延迟与 SSE 传输链路两层问题，且 APISIX 配置写法静默无效。

## 排查结论（逐层实证）

| 层 | 问题 | 证据 |
|----|------|------|
| chat agent | `inject_context` 强制 query rewrite 增加首 token 前一次 LLM 往返 | ReAct LLM 已被 vector_search 工具描述指示自行优化 query |
| backend SSE | session_summary / task-quiz 端点无防缓冲头 | 仅 chat 两端点有 |
| APISIX | `nginx_config.http.proxy_buffering` 不是支持的键，**静默无效** | ngx_tpl.lua 无该键；3.11.0 容器实测渲染后 nginx.conf 无此指令 |
| frontendv2 | Next.js rewrites 代理缓冲 SSE（代码注释已记录的已知问题） | nginx 日志显示请求经 frontend 容器中转 |

## 改动

1. **[chat] perf** 移除强制 query rewrite；`rewritten_queries` 保留空列表，下游 multi-path 契约不变
2. **[chat] fix** 新增 `app/routers/streaming.py`（SSE_HEADERS + 工厂函数），4 个 SSE 端点统一防缓冲头；去掉 hop-by-hop 的 `Connection: keep-alive`
3. **[apisix] fix** proxy_buffering 改用 `http_server_location_configuration_snippet`（已用一次性容器实测渲染进 nginx.conf）
4. **[frontend] fix** `client.ts` 拆分浏览器/SSR base URL：浏览器直连网关（nginx:80），绕过 Next 代理；CORS 配套放行 `X-Requested-With` 头 + `http://127.0.0.1:3000` origin
5. **[frontend] fix** 聊天输入框单行文字垂直居中（textarea 与发送按钮等高）

链路保持 浏览器 → nginx → apisix → backend，仅绕开 frontend 容器内 Next.js 服务端转发一跳。

## 验证

- [x] 后端日志 `event_counts={'on_chat_model_stream': 275}` 确认逐 token 产出
- [x] APISIX 一次性容器 `apisix test` + grep 确认指令渲染
- [x] CORS 预检 OPTIONS 返回 200（补 X-Requested-With 后）
- [x] `py_compile` / router import / YAML 解析全过
- [x] 合并后端到端回归：重建 backend/frontend、重启 apisix，浏览器确认逐字流式 + 输入框居中

## 影响范围

chat agent 图、4 个 SSE 路由、APISIX http 级配置（全局 proxy_buffering off，对普通 JSON 响应无实质影响）、frontendv2 API base URL 解析、CORS 白名单。不涉及 DB schema / Milvus。