### PR TITLE
[kg] feat: 知识图谱构建与检索（Plan 1.0.5）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -119,6 +119,14 @@ SECURITY__API_KEY_ENCRYPTION_KEY=
 # MINIO__SECRET_KEY=
 
 # ------------------------------------------------------------
+# Knowledge Graph(Neo4j,plan/1.0.5,默认 enabled=true 但连接失败自动降级)
+# ------------------------------------------------------------
+# docker 部署:uri 默认注入 bolt://neo4j:7687(compose 已处理),无需手动填
+# 本地直连默认 bolt://localhost:7687;密码与 compose 的 neo4j 服务共享 NEO4J_PASSWORD
+# KG__URI=bolt://localhost:7687
+# NEO4J_PASSWORD=mind-base
+
+# ------------------------------------------------------------
 # Daytona(代码沙箱,code agent 用,默认 enabled=false)
 # ------------------------------------------------------------
 # DAYTONA__ENABLED=true

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 MindBase 是一个个人知识库 RAG 系统，把 B 站收藏和云盘文档转化为可检索、可问答、可复习的知识。
 
-核心链路：同步 B 站收藏夹 → ASR 语音转文字 → 文本向量化（embedding）→ 写入 Milvus → ReAct Agent 流式问答（来源追踪）。
+核心链路：同步 B 站收藏夹 → ASR 语音转文字 → 文本向量化（embedding）→ 写入 Milvus → ReAct Agent 流式问答（来源追踪）。可选知识图谱：LLM 从转写稿抽取实体与关系写入 Neo4j（带原文引文防幻觉），问答时支持跨视频实体关联检索。
 
 除问答外，AI 还能自动生成 Markdown 笔记（Note Agent）、在 Daytona 沙箱运行代码（Code Agent）、按内容出题练习（Quiz）、定时出题邮件提醒（app-task，Go 独立服务 + 自写 DB 轮询调度）。前端采用 Apple 风格界面：顶部导航栏承载功能，黑白极简，壁纸背景（静态/动态 mp4）。
 
-后端 FastAPI + LangGraph multi-agent（Chat / Memory / Note / Code / Quiz 五个 agent，经 delegate 按需调用）。存储：MySQL + Milvus + MongoDB + Redis + MinIO + Daytona（可选）。前端 Next.js 16。支持 OpenAI / DashScope / DeepSeek 多 LLM Provider。
+后端 FastAPI + LangGraph multi-agent（Chat / Memory / Note / Code / Quiz 五个 agent，经 delegate 按需调用）。存储：MySQL + Milvus + MongoDB + Redis + MinIO + Neo4j（可选，知识图谱）+ Daytona（可选）。前端 Next.js 16。支持 OpenAI / DashScope / DeepSeek 多 LLM Provider。
 
 适合「收藏了很多但没时间整理」的学习者，把碎片化收藏变成可用的知识库。
 
@@ -51,13 +51,20 @@ cd app-task && docker compose up -d --build
 - **入口**：导航栏 `对话`
 - **Agent**：Chat（默认路由）+ Memory / Note / Code（经 delegate 调用）
 - **流式 SSE**：route / chunk / step / sources / done / error 六种事件
-- **工具**：vector_search / list_videos / get_video_summaries / delegate_to_agent
+- **工具**：vector_search / kg_search（知识图谱实体关联检索，Neo4j 可用时注册）/ list_videos / get_video_summaries / delegate_to_agent
 
 ### 收藏夹
 
 - **入口**：导航栏 `收藏夹`
 - 同步 B 站收藏夹与视频列表，分 P 查看、ASR 内容、向量化状态
 - 支持整理预览（清理无效视频）
+- **知识图谱面板**：一键从视频转写稿抽取实体与关系写入 Neo4j（幂等，内容未变自动跳过），展示实体 / 关系 / 证据 / 覆盖视频统计与构建进度；未连接 Neo4j 时自动降级为不可用态
+
+### 知识图谱（kg_search）
+
+- 构建链路：收藏夹 → 圈定已转写分P → LLM 结构化抽取（每条关系必须携带原文引文）→ 校验防幻觉边 → 写 Neo4j + 实体向量进 Milvus
+- 查询链路：query 实体链接 → 子图多跳扩展 → 证据回捞（按用户收藏范围过滤），擅长「XX 在哪些视频里讲过」「A 和 B 有什么关联」类跨视频聚合问题
+- 与 vector_search 协同：实体/关系/聚合类问题走图谱，内容细节走向量检索
 
 ### 云盘
 
@@ -100,7 +107,7 @@ cd app-task && docker compose up -d --build
 |------|------|---------|
 | 认证 | `/auth` | 扫码登录 / 密码登录 / token 管理 |
 | 收藏夹 | `/favorites` | 列表 / 同步 / 整理 |
-| 知识库 | `/knowledge` | 构建 / 状态 / 清空 |
+| 知识库 | `/knowledge` | 构建 / 状态 / 清空 / 知识图谱 kg（build / active / status / stats） |
 | 聊天 | `/chat` | ask / ask/stream / sessions / history |
 | ASR | `/asr` | create / update / reasr / versions |
 | 向量化 | `/vec/page` | create / revector / status |
@@ -172,10 +179,10 @@ app/
   agent/                 LangGraph agents (chat / memory / note / code / quiz)
   harness/               AgentHarness (orchestrator + runtime + lifecycle + scheduler)
   routers/               FastAPI 路由（薄层）
-  services/              业务服务 (rag / auth / notes / wallpaper / preferences / quiz / cloud ...)
-  repository/            数据访问 (MySQL / Mongo / Milvus)
-  tools/                 Agent 工具 (chat / notes / code / harness / context / skill)
-  infra/                 基础设施 (config / minio / cache / redis / mongo)
+  services/              业务服务 (rag / auth / notes / kg 知识图谱 / wallpaper / preferences / quiz / cloud ...)
+  repository/            数据访问 (MySQL / Mongo / Milvus / Neo4j)
+  tools/                 Agent 工具 (chat 含 vector_search/kg_search / notes / code / harness / context / skill)
+  infra/                 基础设施 (config / minio / cache / redis / mongo / neo4j)
   config/                YAML 配置 (default.yaml / config.yaml)
   response/              Pydantic 请求/响应 schema
   models.py              SQLAlchemy ORM 模型
@@ -216,6 +223,10 @@ nginx/nginx.conf                nginx 反代 + 缓存配置
 ### Q: 笔记功能需要 MongoDB 吗？
 
 是。笔记正文和修订存 MongoDB，元数据存 MySQL。未连接 MongoDB 时创建/更新笔记抛 `RuntimeError`。
+
+### Q: 知识图谱需要 Neo4j 吗？
+
+是。构建与检索都依赖 Neo4j（docker compose 已内置 `neo4j` 服务，storage/full profile 自动拉起）。未连接时系统自动降级：`kg_search` 工具不注册、收藏夹页图谱面板显示不可用，其余功能不受影响。密码经 `.env` 的 `NEO4J_PASSWORD` 与后端 `KG__PASSWORD` 共享。
 
 ### Q: 如何切换 LLM Provider？
 

--- a/app/agent/chat/graph.py
+++ b/app/agent/chat/graph.py
@@ -157,6 +157,8 @@ async def inject_context(
         "search_chat_history" in registered or "get_recent_context" in registered
     )
     has_delegate = "delegate_to_agent" in registered
+    # Plan 1.0.5: knowledge graph tool (only registered when Neo4j is up)
+    has_kg_tools = "kg_search" in registered
 
     from langchain_core.messages import HumanMessage, SystemMessage
 
@@ -182,6 +184,7 @@ async def inject_context(
             conversation_context=conversation_context,
             has_context_tools=has_context_tools,
             has_delegate=has_delegate,
+            has_kg_tools=has_kg_tools,
             skills_section=skills_section,
             forced_skills_section=forced_skills_section,
         )

--- a/app/agent/chat/prompts.py
+++ b/app/agent/chat/prompts.py
@@ -59,6 +59,8 @@ SYSTEM_PROMPT = """\
 - 「总结一下我的收藏夹」→ get_video_summaries()
 - 「概述收藏夹里哲学类视频」→ 先 get_video_summaries()，再按需 vector_search
 
+{kg_section}
+
 {context_tools_section}
 
 {skills_section}
@@ -96,6 +98,7 @@ SYSTEM_PROMPT = """\
   │      必须告诉用户"代码执行失败/超时，未生成结果"，禁止编造"已生成图片""已保存 xxx.png"
   │      "图像特点：蓝色直线…"等任何执行结果。只有工具明确返回了产物/输出，才能据实描述。
   │
+{kg_decision}
   └─ 具体深度问题 → vector_search
       关键信号：涉及具体观点、概念、论据、细节
       信息不足时：换个 query 再搜（最多 3 轮）
@@ -231,6 +234,29 @@ _CONTEXT_TOOLS_SECTION = """\
 """
 
 
+_KG_TOOLS_SECTION = """\
+### kg_search — 知识图谱检索（实体关联）
+**何时使用**：需要跨视频聚合、实体关系、关联路径的问题
+- 「RAG 在哪些视频里被讲到过」→ kg_search(query="RAG")
+- 「LangChain 和 LlamaIndex 有什么关系/对比」→ kg_search(query="LangChain 和 LlamaIndex 对比")
+- 「XX 提出的方法还有谁讲过」→ 先 kg_search(query="XX")，再按需 vector_search
+
+**注意**：
+- query 传入具体实体名或概念词，效果最好
+- 返回的是实体卡片 + 关系 + 出处引文；需要更细的内容细节时再配合 vector_search
+"""
+
+
+# 决策树中 KG 分支（仅当 kg_search 已注册时注入）
+_KG_DECISION = (
+    "  ├─ 实体/关系/跨视频聚合类问题 → kg_search\n"
+    "  │   关键信号：「哪些视频提到」「和…有什么关系」「有什么区别」「对比」"
+    "「都讲过什么」「关联」\n"
+    "  │   配合：kg_search 定位视频与关系后，可用 vector_search 深挖具体内容\n"
+    "  │\n"
+)
+
+
 def build_system_prompt(
     query: str,
     *,
@@ -239,6 +265,7 @@ def build_system_prompt(
     conversation_context: str = "",
     has_context_tools: bool = False,
     has_delegate: bool = False,
+    has_kg_tools: bool = False,
     skills_section: str = "",
     forced_skills_section: str = "",
 ) -> str:
@@ -255,6 +282,8 @@ def build_system_prompt(
     date_status = f"当前日期：{datetime.now().strftime('%Y年%m月%d日')}"
 
     context_tools_section = _CONTEXT_TOOLS_SECTION if (has_context_tools or has_delegate) else ""
+    kg_section = _KG_TOOLS_SECTION if has_kg_tools else ""
+    kg_decision = _KG_DECISION if has_kg_tools else ""
 
     return SYSTEM_PROMPT.format(
         query=query,
@@ -262,6 +291,8 @@ def build_system_prompt(
         date_status=date_status,
         conversation_context=conversation_context or "（无历史对话上下文）",
         context_tools_section=context_tools_section,
+        kg_section=kg_section,
+        kg_decision=kg_decision,
         skills_section=skills_section,
         forced_skills_section=forced_skills_section,
     )

--- a/app/config/default.yaml
+++ b/app/config/default.yaml
@@ -220,6 +220,28 @@ ingest:
   asr_chunk_concurrency: 3          # 长音频 PCM 切块并行识别数（DashScope 并发限流）
 
 
+# ---- Knowledge Graph (Neo4j + MySQL, plan/1.0.5-KnowledgeGraph) ---
+# Derived store: entities/relations extracted from Mongo ASR documents.
+# Rebuildable at any time; failures degrade gracefully (kg_search tool
+# simply won't register / endpoints report unavailable).
+# Start (docker): included in ""/storage/full profiles alongside Milvus.
+kg:
+  enabled: true
+  uri: ""                               # inject via KG__URI env var; docker: bolt://neo4j:7687
+  username: neo4j                       # password via env: KG__PASSWORD
+  database: neo4j                       # Neo4j database name (community edition = neo4j)
+  entity_collection_name: kg_entities   # Milvus collection for semantic entity linking
+  extract_model: qwen-flash             # LLM for entity/relation extraction (structured output)
+  max_text_chars: 8000                  # truncate ASR text before extraction (cost guard)
+  seed_top_n: 5                         # entity-linking candidates per query
+  link_score_threshold: 0.55            # min cosine similarity for query->entity linking
+  max_hops: 2                           # subgraph expansion depth over RELATES edges
+  expand_limit_per_hop: 50              # per-hop neighbor cap (super-node guard)
+  evidence_limit: 100                   # max APPEARS_IN evidence rows returned per retrieval
+  concurrency: 2                        # parallel page extractions (LLM QPS guard)
+  page_batch_size: 50                   # max pages processed per build run
+
+
 # ---- LangSmith tracing --------------------------------------------
 # Set enabled=true + LANGSMITH__API_KEY env var to activate.
 langsmith:

--- a/app/database.py
+++ b/app/database.py
@@ -56,6 +56,10 @@ async def _migrate_add_columns():
         ("video", "vector_chunk_count", "INTEGER DEFAULT 0"),
         ("video", "vector_error", "TEXT"),
         ("video", "vector_asr_version", "INTEGER"),
+        # Plan 1.0.5: knowledge graph extraction status (derived, independent
+        # of is_vectorized flow; no Milvus rebuild needed — new collection only)
+        ("video", "kg_status", "VARCHAR(20) DEFAULT 'none'"),
+        ("video", "kg_version", "INTEGER"),
         # Plan 0012: Quiz pages mode columns
         ("quiz_sets", "source_type", "VARCHAR(20) DEFAULT 'folder'"),
         ("quiz_sets", "source_pages", "TEXT"),

--- a/app/harness/app.py
+++ b/app/harness/app.py
@@ -342,6 +342,21 @@ class AgentHarness:
         except Exception:
             logger.exception("[HARNESS] failed to acquire RAG service")
 
+        # Plan 1.0.5: knowledge graph service (optional; None when Neo4j down)
+        kg: Any = None
+        try:
+            from app.services.kg import get_kg_service
+
+            kg_service = get_kg_service()
+            if kg_service.is_available():
+                kg = kg_service
+            else:
+                logger.warning(
+                    "[HARNESS] KG unavailable (Neo4j not connected) — kg_search skipped"
+                )
+        except Exception:
+            logger.exception("[HARNESS] failed to acquire KG service")
+
         deps = ToolDeps(
             rag=rag,
             ctx_mgr=self._ctx_mgr,
@@ -349,6 +364,7 @@ class AgentHarness:
             db_deps=db_deps,
             lifecycle=self._lifecycle,
             skill_manager=self._skill_manager,
+            kg=kg,
         )
 
         manager = ToolManager(deps)

--- a/app/infra/config.py
+++ b/app/infra/config.py
@@ -381,6 +381,33 @@ class QuizSection(_Section):
     queue: QuizQueueSection = Field(default_factory=QuizQueueSection)
 
 
+class KgSection(_Section):
+    """Knowledge graph (plan/1.0.5): Neo4j graph store + Milvus entity index.
+
+    Optional dependency — when unreachable the kg_search tool is skipped and
+    /knowledge/kg endpoints report unavailable; nothing else is affected.
+    """
+
+    enabled: bool = True
+    uri: str = "bolt://localhost:7687"
+    username: str = "neo4j"
+    database: str = "neo4j"
+    password: SecretStr = Field(
+        default=SecretStr(""),
+        validation_alias=AliasChoices("KG__PASSWORD", "NEO4J_PASSWORD"),
+    )
+    entity_collection_name: str = "kg_entities"
+    extract_model: str = "qwen-flash"
+    max_text_chars: int = 8000
+    seed_top_n: int = 5
+    link_score_threshold: float = 0.55
+    max_hops: int = 2
+    expand_limit_per_hop: int = 50
+    evidence_limit: int = 100
+    concurrency: int = 2
+    page_batch_size: int = 50
+
+
 # ---------------------------------------------------------------------------
 # Top-level aggregator
 # ---------------------------------------------------------------------------
@@ -417,6 +444,7 @@ class AppConfig(BaseSettings):
     slow_sql: SlowSqlSection = Field(default_factory=SlowSqlSection)
     transaction: TransactionSection = Field(default_factory=TransactionSection)
     quiz: QuizSection = Field(default_factory=QuizSection)
+    kg: KgSection = Field(default_factory=KgSection)
 
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/app/infra/neo4j.py
+++ b/app/infra/neo4j.py
@@ -1,0 +1,166 @@
+"""Async Neo4j client via the official ``neo4j`` driver (KG feature).
+
+Lazy initialisation: call :func:`init` during application startup.
+If ``kg.enabled`` is false — or the connection fails — the module stays in a
+disabled state and callers degrade gracefully (mirrors ``infra/mongo.py``).
+
+Usage:
+    from app.infra.neo4j import init, close, is_enabled, get_driver
+
+    await init()          # startup
+    driver = get_driver() # None when disabled/unreachable
+    await close()         # shutdown
+
+Sessions are short-lived per operation:
+    async with session(database="neo4j") as s:
+        rows = await run(s, "MATCH (e:Entity) RETURN e LIMIT $n", n=10)
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from loguru import logger
+
+from app.infra.config import config
+
+# Module-level state — populated by init()
+_driver: Any | None = None
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle
+# ---------------------------------------------------------------------------
+
+
+async def init() -> None:
+    """Connect to Neo4j and verify connectivity.
+
+    No-op when ``kg.enabled`` is false.  Connection failures are logged as
+    warnings (Neo4j is treated as an optional dependency — KG degrades).
+    """
+    global _driver
+
+    if not config.kg.enabled:
+        logger.info("[NEO4J] disabled (kg.enabled=false), skipping init")
+        return
+
+    from neo4j import AsyncGraphDatabase
+
+    # 空 uri（YAML 默认）回退本地默认端口，便于非 Docker 直连开发
+    uri = config.kg.uri.strip() or "bolt://localhost:7687"
+    password = config.kg.password.get_secret_value()
+    try:
+        _driver = AsyncGraphDatabase.driver(
+            uri,
+            auth=(config.kg.username, password),
+            connection_timeout=10.0,
+            max_connection_pool_size=20,
+        )
+        await _driver.verify_connectivity()
+    except Exception as exc:
+        logger.warning(
+            "[NEO4J] init failed (KG features degraded): {} — uri={}",
+            exc,
+            uri,
+        )
+        try:
+            if _driver is not None:
+                await _driver.close()
+        except Exception:
+            pass
+        _driver = None
+        return
+
+    await ensure_constraints()
+    latency = await ping()
+    logger.info(
+        "[NEO4J] connected: uri={} db={} latency={}ms",
+        uri,
+        config.kg.database,
+        latency.get("latency_ms"),
+    )
+
+
+async def ensure_constraints() -> None:
+    """Idempotently create uniqueness constraints for the KG schema."""
+    statements = [
+        "CREATE CONSTRAINT kg_entity_eid IF NOT EXISTS "
+        "FOR (e:Entity) REQUIRE e.eid IS UNIQUE",
+        "CREATE CONSTRAINT kg_entity_name IF NOT EXISTS "
+        "FOR (e:Entity) REQUIRE e.name_lower IS UNIQUE",
+        "CREATE CONSTRAINT kg_video_bvid IF NOT EXISTS "
+        "FOR (v:Video) REQUIRE v.bvid IS UNIQUE",
+    ]
+    async with session() as s:
+        for stmt in statements:
+            try:
+                await run(s, stmt)
+            except Exception as exc:
+                logger.warning("[NEO4J] constraint creation failed: {}", exc)
+
+
+async def close() -> None:
+    """Close the driver and release the connection pool."""
+    global _driver
+    if _driver is not None:
+        try:
+            await _driver.close()
+        except Exception as exc:
+            logger.debug("[NEO4J] close error (ignored): {}", exc)
+        _driver = None
+    logger.info("[NEO4J] closed")
+
+
+async def ping() -> dict[str, Any]:
+    """Return connection health with round-trip latency in milliseconds."""
+    start = time.time()
+    if _driver is None:
+        return {"ok": False, "latency_ms": 0, "error": "not initialized"}
+    try:
+        async with _driver.session(database=config.kg.database) as s:
+            await s.run("RETURN 1")
+        return {
+            "ok": True,
+            "latency_ms": int((time.time() - start) * 1000),
+            "error": None,
+        }
+    except Exception as exc:
+        return {
+            "ok": False,
+            "latency_ms": int((time.time() - start) * 1000),
+            "error": str(exc),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def get_driver() -> Any | None:
+    """Return the raw AsyncDriver handle, or None if disabled/unreachable."""
+    return _driver
+
+
+def is_enabled() -> bool:
+    """Return True if Neo4j is enabled and connected."""
+    return _driver is not None
+
+
+def session(database: str | None = None) -> Any:
+    """Return an async session context manager.
+
+    Raises RuntimeError when the driver is not initialized — callers that
+    need soft-failure semantics should check :func:`is_enabled` first.
+    """
+    if _driver is None:
+        raise RuntimeError("[NEO4J] not initialized or disabled")
+    return _driver.session(database=database or config.kg.database)
+
+
+async def run(s: Any, cypher: str, **params: Any) -> list[dict[str, Any]]:
+    """Execute a cypher statement on an open session; return rows as dicts."""
+    result = await s.run(cypher, **params)
+    return await result.data()

--- a/app/main.py
+++ b/app/main.py
@@ -242,6 +242,14 @@ async def lifespan(app: FastAPI):
         except Exception as e:
             logger.warning(f"[MAIN] MinIO init failed (cloud drive disabled): {e}")
 
+    # Plan 1.0.5: Knowledge graph (Neo4j) — optional dependency, degrades gracefully
+    try:
+        from app.infra.neo4j import init as neo4j_init
+
+        await neo4j_init()
+    except Exception as e:
+        logger.warning(f"[MAIN] Neo4j init failed (KG features degraded): {e}")
+
     # 初始化 ApiKeyManager（用户自定义 API Key 加密服务）
     from app.services.llm.api_key_manager import ApiKeyManager
 
@@ -375,6 +383,10 @@ async def lifespan(app: FastAPI):
         from app.infra.mongo import close as close_mongo
 
         await _asyncio.shield(close_mongo())
+
+        from app.infra.neo4j import close as close_neo4j
+
+        await _asyncio.shield(close_neo4j())
 
         from app.infra.milvus import close as close_milvus
 

--- a/app/models.py
+++ b/app/models.py
@@ -131,6 +131,12 @@ class Video(Base):
     vector_error = Column(Text, nullable=True)
     vector_asr_version = Column(Integer, nullable=True)  # ASR version captured at last vectorization (change detection)
 
+    # 知识图谱状态（Plan 1.0.5）——派生自 Mongo ASR 正文，独立于向量化流转
+    kg_status = Column(
+        String(20), default="none"
+    )  # none / pending / processing / done / failed
+    kg_version = Column(Integer, nullable=True)  # content version captured at last KG extraction
+
     created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
     updated_at = Column(
         DateTime,

--- a/app/repository/kg_entity_index.py
+++ b/app/repository/kg_entity_index.py
@@ -1,0 +1,271 @@
+"""KgEntityIndex — Milvus 实体向量索引（KG 查询期语义实体链接）。
+
+独立小 collection（默认 ``kg_entities``），与 bilibili_videos/cloud_drive 平级：
+查询期把用户 query 向量化，检索最相似的实体（name+type+description 文本），
+得到种子实体 eid 集合后再去 Neo4j 做子图扩展。
+
+Schema::
+
+    id INT64 auto_id PK ｜ eid VARCHAR(64) ｜ name VARCHAR(256)
+    type VARCHAR(32)     ｜ text VARCHAR(2048) ｜ embedding FLOAT_VECTOR(dim)
+
+索引：IVF_FLAT nlist=128 COSINE（实体量级远小于文档块，小 nlist 足够）。
+
+⚠️ 同步客户端（与 vector_store_milvus 一致）——异步调用方必须用
+``asyncio.to_thread`` 包装，禁止在事件循环内直接调用。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from loguru import logger
+
+from app.infra.config import config
+
+
+class KgEntityIndex:
+    """Milvus 实体向量索引。纯数据访问，embedding_fn 由上层注入。"""
+
+    def __init__(self, embedding_fn: Any, collection_name: str | None = None):
+        self._embedding_fn = embedding_fn
+        self._collection_name = (
+            collection_name or config.kg.entity_collection_name
+        )
+        self._client: Any | None = None
+        self._dimension: int | None = None
+
+    # ------------------------------------------------------------------
+    # 连接与建表
+    # ------------------------------------------------------------------
+
+    def _build_client(self) -> Any | None:
+        from pymilvus import MilvusClient
+
+        kwargs: dict[str, Any] = {"uri": config.milvus.uri}
+        if config.milvus.token:
+            kwargs["token"] = config.milvus.token
+        try:
+            return MilvusClient(**kwargs)
+        except Exception as e:
+            logger.error(
+                "[KG_INDEX] failed to connect '{}': {}", config.milvus.uri, e
+            )
+            return None
+
+    def _probe_dimension(self) -> int:
+        if self._dimension is None:
+            self._dimension = len(self._embedding_fn.embed_query("dim-probe"))
+            logger.info("[KG_INDEX] detected entity embedding dim={}", self._dimension)
+        return self._dimension
+
+    def _ensure_collection(self) -> bool:
+        """惰性建表。dim 与存量不一致时 drop+recreate（同 RAGService 自愈策略）。
+
+        返回 False 表示不可用（连接失败）。
+        """
+        if self._client is not None:
+            return True
+        if not config.milvus.enabled:
+            return False
+        self._client = self._build_client()
+        if self._client is None:
+            return False
+
+        dim = self._probe_dimension()
+        try:
+            if self._client.has_collection(self._collection_name):
+                desc = self._client.describe_collection(self._collection_name)
+                existing_dim = 0
+                for field in desc.get("fields", []):
+                    if field.get("name") == "embedding":
+                        params = field.get("params") or field.get("typeParams") or {}
+                        try:
+                            existing_dim = int(params.get("dim", 0))
+                        except (TypeError, ValueError):
+                            existing_dim = 0
+                if existing_dim not in (0, dim):
+                    logger.warning(
+                        "[KG_INDEX] collection '{}' dim mismatch "
+                        "(existing={}, expected={}) — recreating",
+                        self._collection_name,
+                        existing_dim,
+                        dim,
+                    )
+                    self._client.drop_collection(self._collection_name)
+
+            if not self._client.has_collection(self._collection_name):
+                from pymilvus import DataType
+
+                schema = self._client.create_schema(enable_dynamic_field=True)
+                schema.add_field(
+                    field_name="id",
+                    datatype=DataType.INT64,
+                    is_primary=True,
+                    auto_id=True,
+                )
+                schema.add_field(
+                    field_name="eid", datatype=DataType.VARCHAR, max_length=64
+                )
+                schema.add_field(
+                    field_name="name", datatype=DataType.VARCHAR, max_length=256
+                )
+                schema.add_field(
+                    field_name="type", datatype=DataType.VARCHAR, max_length=32
+                )
+                schema.add_field(
+                    field_name="text", datatype=DataType.VARCHAR, max_length=2048
+                )
+                schema.add_field(
+                    field_name="embedding",
+                    datatype=DataType.FLOAT_VECTOR,
+                    dim=dim,
+                )
+                index_params = self._client.prepare_index_params()
+                index_params.add_index(
+                    field_name="embedding",
+                    index_type="IVF_FLAT",
+                    metric_type="COSINE",
+                    params={"nlist": 128},
+                )
+                self._client.create_collection(
+                    self._collection_name, schema=schema, index_params=index_params
+                )
+                logger.info(
+                    "[KG_INDEX] created collection '{}'", self._collection_name
+                )
+
+            self._client.load_collection(self._collection_name)
+            return True
+        except Exception as e:
+            logger.error("[KG_INDEX] ensure_collection failed: {}", e)
+            self._client = None
+            return False
+
+    # ------------------------------------------------------------------
+    # 写入 / 删除
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def build_embedding_text(entity: dict[str, Any]) -> str:
+        """实体向量化文本：name | type | description。"""
+        parts = [
+            entity.get("name", ""),
+            f"({entity['type']})" if entity.get("type") else "",
+            (entity.get("description") or "").strip()[:1500],
+        ]
+        return " ".join(p for p in parts if p)
+
+    def upsert(self, entities: list[dict[str, Any]]) -> int:
+        """按 eid 先删后插（Milvus auto_id 下 upsert 的等价实现）。
+
+        entities 每项: {eid, name, type, description}。
+        """
+        if not entities or not self._ensure_collection():
+            return 0
+        rows: list[dict[str, Any]] = []
+        for ent in entities:
+            text = self.build_embedding_text(ent)[:2000]
+            if not text.strip():
+                continue
+            rows.append(
+                {
+                    "eid": ent["eid"],
+                    "name": ent["name"][:250],
+                    "type": (ent.get("type") or "other")[:30],
+                    "text": text,
+                    "embedding": self._embedding_fn.embed_documents([text])[0],
+                }
+            )
+        if not rows:
+            return 0
+        self.delete_by_eids([r["eid"] for r in rows])
+        try:
+            res = self._client.insert(self._collection_name, data=rows)
+            inserted = int(res.get("insert_count", len(rows)))
+            logger.info(
+                "[KG_INDEX] upserted {} entity vectors", inserted
+            )
+            return inserted
+        except Exception as e:
+            logger.error("[KG_INDEX] insert failed: {}", e)
+            return 0
+
+    def delete_by_eids(self, eids: list[str]) -> int:
+        if not eids or not self._ensure_collection():
+            return 0
+        quoted = ", ".join(f"'{e}'" for e in eids)
+        expr = f"eid in [{quoted}]"
+        try:
+            res = self._client.delete(self._collection_name, filter=expr)
+            return int(res if isinstance(res, int) else 0)
+        except Exception as e:
+            logger.warning("[KG_INDEX] delete failed: {}", e)
+            return 0
+
+    # ------------------------------------------------------------------
+    # 检索
+    # ------------------------------------------------------------------
+
+    def search(self, query: str, top_n: int = 5) -> list[dict[str, Any]]:
+        """query→实体链接。返回 [{eid, name, type, score}]（score=COSINE 相似度）。"""
+        if not self._ensure_collection():
+            return []
+        query_embedding = self._embedding_fn.embed_query(query)
+        try:
+            results = self._client.search(
+                collection_name=self._collection_name,
+                data=[query_embedding],
+                anns_field="embedding",
+                search_params={
+                    "metric_type": "COSINE",
+                    "params": {"nprobe": 16},
+                },
+                limit=max(top_n, 1),
+                output_fields=["eid", "name", "type"],
+            )
+        except Exception as e:
+            logger.error("[KG_INDEX] search failed: {}", e)
+            return []
+        hits: list[dict[str, Any]] = []
+        for topk in results:
+            for hit in topk:
+                entity = hit.get("entity", {}) or {}
+                hits.append(
+                    {
+                        "eid": hit.get("eid", ""),
+                        "name": entity.get("name", ""),
+                        "type": entity.get("type", ""),
+                        "score": float(hit.get("distance", 0.0)),
+                    }
+                )
+        return hits
+
+    # ------------------------------------------------------------------
+    # 统计 / 运维
+    # ------------------------------------------------------------------
+
+    def count(self) -> int:
+        if not self._ensure_collection():
+            return 0
+        try:
+            stats = self._client.get_collection_stats(self._collection_name)
+            return int(stats.get("row_count", 0))
+        except Exception as e:
+            logger.debug("[KG_INDEX] get stats failed: {}", e)
+            return 0
+
+    def clear(self) -> None:
+        """清空实体向量（危险操作，配合图谱重建使用）。"""
+        if self._ensure_collection():
+            self._client.drop_collection(self._collection_name)
+            self._client = None
+            logger.warning("[KG_INDEX] collection dropped")
+
+    def close(self) -> None:
+        if self._client is not None:
+            try:
+                self._client.close()
+            except Exception as exc:
+                logger.debug("[KG_INDEX] close error (ignored): {}", exc)
+            self._client = None

--- a/app/repository/kg_graph_repository.py
+++ b/app/repository/kg_graph_repository.py
@@ -1,0 +1,363 @@
+"""KgGraphRepository — 全部 Neo4j 访问封装（Plan 1.0.5 知识图谱）。
+
+Graph schema::
+
+    (:Entity {eid, name, name_lower, type, description, aliases,
+              mention_count, created_at, updated_at})
+    (:Video  {bvid})
+    (a:Entity)-[:RELATES     {rel_type, weight, quotes}]->(b:Entity)
+    (e:Entity)-[:APPEARS_IN  {page_index, quote}]->(v:Video)
+
+设计要点：
+- ``eid`` 由 ``sha1(name_lower)[:16]`` 确定性生成，跨重建稳定（供 Milvus 同步）
+- Entity 以 ``name_lower`` MERGE、Video 以 ``bvid`` MERGE —— 天然幂等
+- APPEARS_IN 按 ``(entity, video, page_index)`` 建边；重抽某分P 前
+  先按 ``(bvid, page_index)`` 删旧边再写新边（delete-before-write 幂等）
+- 关系统一用 RELATES 类型 + rel_type 属性（Cypher 无法参数化关系类型）
+
+定位：纯数据访问，不感知 uid/收藏夹/HTTP。被 services/kg 调用。
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+from loguru import logger
+
+from app.infra import neo4j
+
+# 每条 RELATES 边保留的证据引文上限（防属性膨胀）
+MAX_RELATION_QUOTES = 3
+
+
+def normalize_name(name: str) -> str:
+    """实体名归一化键：小写 + 去首尾空白 + 合并内部空白。"""
+    return " ".join((name or "").split()).lower()
+
+
+def eid_for_name(name: str) -> str:
+    """由归一化名称确定性生成实体 ID。"""
+    return hashlib.sha1(normalize_name(name).encode("utf-8")).hexdigest()[:16]
+
+
+class KgGraphRepository:
+    """Neo4j 图数据访问。所有方法在 Neo4j 不可用时抛 RuntimeError，
+    调用方（services/kg）负责先检查 :func:`app.infra.neo4j.is_enabled`。
+    """
+
+    # ------------------------------------------------------------------
+    # 写入：实体 / 视频 / 证据 / 关系
+    # ------------------------------------------------------------------
+
+    async def upsert_entities(self, entities: list[dict[str, Any]]) -> list[str]:
+        """批量 MERGE 实体。
+
+        每行字段: name(必填) / type / description / alias(可选别名)。
+        description 非空才覆盖（避免 stub 清空已有描述）；
+        mention_count 每次 upsert 自增（近似热度指标）。
+        返回涉及的全部 eid。
+        """
+        if not entities:
+            return []
+        rows = [
+            {
+                "name": e["name"],
+                "name_lower": normalize_name(e["name"]),
+                "eid": e.get("eid") or eid_for_name(e["name"]),
+                "type": e.get("type") or "other",
+                "description": (e.get("description") or "").strip(),
+                "alias": (e.get("alias") or "").strip(),
+            }
+            for e in entities
+        ]
+        cypher = """
+        UNWIND $rows AS row
+        MERGE (e:Entity {name_lower: row.name_lower})
+        ON CREATE SET e.eid = row.eid, e.created_at = timestamp(),
+                      e.aliases = [], e.mention_count = 0
+        SET e.name = row.name,
+            e.updated_at = timestamp(),
+            e.type = CASE WHEN coalesce(row.type,'') <> ''
+                          THEN row.type ELSE coalesce(e.type, 'other') END,
+            e.description = CASE WHEN coalesce(row.description,'') <> ''
+                                 THEN row.description ELSE coalesce(e.description,'') END,
+            e.mention_count = coalesce(e.mention_count, 0) + 1
+        FOREACH (_ IN CASE WHEN coalesce(row.alias,'') <> ''
+                            AND NOT row.alias IN coalesce(e.aliases, [])
+                           THEN [1] ELSE [] END |
+          SET e.aliases = coalesce(e.aliases, []) + row.alias
+        )
+        RETURN DISTINCT e.eid AS eid
+        """
+        async with neo4j.session() as s:
+            result = await neo4j.run(s, cypher, rows=rows)
+        return [r["eid"] for r in result]
+
+    async def link_appearances(
+        self, bvid: str, page_index: int, appearances: list[dict[str, Any]]
+    ) -> int:
+        """为 (bvid, page_index) 写入实体证据边 APPEARS_IN。
+
+        appearances 每项: {eid, quote}。MERGE 键含 page_index，
+        同一实体的不同分P 证据互不覆盖。
+        """
+        rows = [
+            {"eid": a["eid"], "quote": (a.get("quote") or "").strip()}
+            for a in appearances
+            if a.get("eid")
+        ]
+        if not rows:
+            return 0
+        # 同页同实体去重，保留最短非空引文（更聚焦）
+        dedup: dict[str, str] = {}
+        for r in rows:
+            cur = dedup.get(r["eid"])
+            if cur is None or (r["quote"] and len(r["quote"]) < len(cur)):
+                dedup[r["eid"]] = r["quote"] or (cur or "")
+        rows = [{"eid": k, "quote": v} for k, v in dedup.items()]
+
+        cypher = """
+        MERGE (v:Video {bvid: $bvid})
+        WITH v
+        UNWIND $rows AS row
+        MATCH (e:Entity {eid: row.eid})
+        MERGE (e)-[ev:APPEARS_IN {page_index: $page_index}]->(v)
+        ON CREATE SET ev.created_at = timestamp()
+        SET ev.quote = row.quote, ev.updated_at = timestamp()
+        RETURN count(ev) AS linked
+        """
+        async with neo4j.session() as s:
+            result = await neo4j.run(
+                s, cypher, bvid=bvid, page_index=page_index, rows=rows
+            )
+        return int(result[0]["linked"]) if result else 0
+
+    async def upsert_relations(self, relations: list[dict[str, Any]]) -> None:
+        """批量 MERGE 关系边。
+
+        每行字段: src_eid / dst_eid / rel_type / quote。
+        weight 自增；quotes 保留最近 MAX_RELATION_QUOTES 条去重样本。
+        """
+        seen: set[tuple[str, str, str]] = set()
+        rows: list[dict[str, str]] = []
+        for rel in relations:
+            key = (rel["src_eid"], rel["dst_eid"], rel["rel_type"])
+            if key in seen:
+                continue
+            seen.add(key)
+            rows.append(
+                {
+                    "src_eid": rel["src_eid"],
+                    "dst_eid": rel["dst_eid"],
+                    "rel_type": rel["rel_type"],
+                    "quote": (rel.get("quote") or "").strip(),
+                }
+            )
+        if not rows:
+            return
+        cypher = """
+        UNWIND $rows AS row
+        MATCH (a:Entity {eid: row.src_eid})
+        MATCH (b:Entity {eid: row.dst_eid})
+        MERGE (a)-[r:RELATES {rel_type: row.rel_type}]->(b)
+        SET r.weight = coalesce(r.weight, 0) + 1,
+            r.updated_at = timestamp(),
+            r.quotes = CASE
+                WHEN coalesce(row.quote,'') = '' THEN coalesce(r.quotes, [])
+                WHEN row.quote IN coalesce(r.quotes, []) THEN r.quotes
+                WHEN size(coalesce(r.quotes, [])) < $max_quotes
+                    THEN coalesce(r.quotes, []) + row.quote
+                ELSE coalesce(r.quotes, [])[1..] + row.quote
+            END
+        """
+        async with neo4j.session() as s:
+            await neo4j.run(s, cypher, rows=rows, max_quotes=MAX_RELATION_QUOTES)
+
+    # ------------------------------------------------------------------
+    # 删除与清理
+    # ------------------------------------------------------------------
+
+    async def delete_page_evidence(self, bvid: str, page_index: int) -> int:
+        """删除某分P 的全部证据边（重抽前的 delete-before-write）。"""
+        cypher = """
+        MATCH (:Video {bvid: $bvid})<-[ev:APPEARS_IN]-(:Entity)
+        WHERE ev.page_index = $page_index
+        DELETE ev
+        RETURN count(ev) AS deleted
+        """
+        async with neo4j.session() as s:
+            result = await neo4j.run(s, cypher, bvid=bvid, page_index=page_index)
+        return int(result[0]["deleted"]) if result else 0
+
+    async def delete_video(self, bvid: str) -> dict[str, int]:
+        """级联删除视频节点的全部图谱痕迹，并回收孤儿节点。
+
+        返回 {"entities_removed", "videos_removed"}。
+        """
+        del_video = """
+        MATCH (v:Video {bvid: $bvid})
+        DETACH DELETE v
+        RETURN count(v) AS deleted
+        """
+        cleanup_entity = """
+        MATCH (e:Entity) WHERE NOT (e)--()
+        DELETE e
+        RETURN count(e) AS removed
+        """
+        cleanup_video = """
+        MATCH (v:Video) WHERE NOT ()-[:APPEARS_IN]->(v)
+        DELETE v
+        RETURN count(v) AS removed
+        """
+        entities_removed = videos_removed = 0
+        async with neo4j.session() as s:
+            res = await neo4j.run(s, del_video, bvid=bvid)
+            videos_removed += int(res[0]["deleted"]) if res else 0
+            res = await neo4j.run(s, cleanup_entity)
+            entities_removed += int(res[0]["removed"]) if res else 0
+            res = await neo4j.run(s, cleanup_video)
+            videos_removed += int(res[0]["removed"]) if res else 0
+        if entities_removed or videos_removed:
+            logger.info(
+                "[KG_REPO] delete_video bvid={} entities_removed={} videos_removed={}",
+                bvid,
+                entities_removed,
+                videos_removed,
+            )
+        return {"entities_removed": entities_removed, "videos_removed": videos_removed}
+
+    # ------------------------------------------------------------------
+    # 检索：邻居扩展 / 证据回捞 / 实体详情
+    # ------------------------------------------------------------------
+
+    async def neighbors(
+        self, eids: list[str], exclude_eids: list[str], limit: int
+    ) -> list[dict[str, Any]]:
+        """一跳邻居展开（BFS 单步），返回邻居实体及连接关系信息。"""
+        if not eids:
+            return []
+        cypher = """
+        UNWIND $eids AS eid
+        MATCH (e:Entity {eid: eid})-[r:RELATES]-(n:Entity)
+        WHERE n.eid <> eid AND NOT n.eid IN $exclude
+        RETURN DISTINCT n.eid AS eid, n.name AS name, n.type AS type,
+               n.description AS description, r.rel_type AS rel_type,
+               e.eid AS from_eid
+        LIMIT $limit
+        """
+        async with neo4j.session() as s:
+            return await neo4j.run(
+                s, cypher, eids=eids, exclude=exclude_eids, limit=limit
+            )
+
+    async def fetch_evidence(
+        self, eids: list[str], bvids: list[str], limit: int
+    ) -> list[dict[str, Any]]:
+        """回捞证据边。bvids 为空表示不过滤作用域（仅限管理/调试用途）。"""
+        if not eids:
+            return []
+        cypher = """
+        UNWIND $eids AS eid
+        MATCH (e:Entity {eid: eid})-[ev:APPEARS_IN]->(v:Video)
+        WHERE size($bvids) = 0 OR v.bvid IN $bvids
+        RETURN e.eid AS eid, e.name AS name, e.type AS type,
+               v.bvid AS bvid, ev.page_index AS page_index, ev.quote AS quote
+        LIMIT $limit
+        """
+        async with neo4j.session() as s:
+            return await neo4j.run(
+                s, cypher, eids=eids, bvids=bvids or [], limit=limit
+            )
+
+    async def relations_among(self, eids: list[str]) -> list[dict[str, Any]]:
+        """子图成员之间的关系边（双向各查一次由 UNWIND 全量覆盖）。"""
+        if len(eids) < 2:
+            return []
+        cypher = """
+        UNWIND $eids AS eid
+        MATCH (a:Entity {eid: eid})-[r:RELATES]->(b:Entity)
+        WHERE b.eid IN $eids
+        RETURN DISTINCT a.eid AS src_eid, a.name AS src_name,
+               r.rel_type AS rel_type, b.eid AS dst_eid, b.name AS dst_name,
+               coalesce(r.weight, 1) AS weight, coalesce(r.quotes, []) AS quotes
+        """
+        async with neo4j.session() as s:
+            return await neo4j.run(s, cypher, eids=eids)
+
+    async def entities_by_eids(self, eids: list[str]) -> list[dict[str, Any]]:
+        if not eids:
+            return []
+        cypher = """
+        UNWIND $eids AS eid
+        MATCH (e:Entity {eid: eid})
+        RETURN e.eid AS eid, e.name AS name, e.type AS type,
+               e.description AS description, coalesce(e.aliases, []) AS aliases
+        """
+        async with neo4j.session() as s:
+            return await neo4j.run(s, cypher, eids=eids)
+
+    async def find_entities_by_names(
+        self, names: list[str], limit: int = 20
+    ) -> list[dict[str, Any]]:
+        """按名称/别名的精确匹配兜底查询（Milvus 语义链接失败时使用）。"""
+        cleaned = [normalize_name(n) for n in names if n and n.strip()]
+        if not cleaned:
+            return []
+        cypher = """
+        UNWIND $names AS nm
+        MATCH (e:Entity)
+        WHERE e.name_lower = nm OR nm IN coalesce(e.aliases, [])
+        RETURN DISTINCT e.eid AS eid, e.name AS name, e.type AS type,
+               e.description AS description
+        LIMIT $limit
+        """
+        async with neo4j.session() as s:
+            return await neo4j.run(s, cypher, names=cleaned, limit=limit)
+
+    # ------------------------------------------------------------------
+    # 统计 / 运维
+    # ------------------------------------------------------------------
+
+    async def stats(self) -> dict[str, int]:
+        cypher = """
+        CALL {
+            MATCH (e:Entity) RETURN count(e) AS entities
+        }
+        CALL {
+            MATCH ()-[r:RELATES]->() RETURN count(r) AS relations
+        }
+        CALL {
+            MATCH ()-[a:APPEARS_IN]->() RETURN count(a) as evidence
+        }
+        CALL {
+            MATCH (v:Video) RETURN count(v) AS videos
+        }
+        RETURN entities, relations, evidence, videos
+        """
+        async with neo4j.session() as s:
+            rows = await neo4j.run(s, cypher)
+        row = rows[0] if rows else {}
+        return {
+            "entities": int(row.get("entities", 0)),
+            "relations": int(row.get("relations", 0)),
+            "evidence": int(row.get("evidence", 0)),
+            "videos": int(row.get("videos", 0)),
+        }
+
+    async def clear_all(self) -> None:
+        """清空图谱（危险操作，仅管理端点/测试使用）。"""
+        async with neo4j.session() as s:
+            await neo4j.run(s, "MATCH (n) WHERE n:Entity OR n:Video DETACH DELETE n")
+        logger.warning("[KG_REPO] graph cleared (all Entity/Video nodes)")
+
+
+_repo: KgGraphRepository | None = None
+
+
+def get_kg_graph_repository() -> KgGraphRepository:
+    """模块级懒加载单例（与 note_repository 的工厂模式一致）。"""
+    global _repo
+    if _repo is None:
+        _repo = KgGraphRepository()
+    return _repo

--- a/app/routers/knowledge.py
+++ b/app/routers/knowledge.py
@@ -304,9 +304,116 @@ async def delete_video_from_knowledge(
 
         rag = get_rag_service()
         rag.delete_video(bvid)
+
+        # Plan 1.0.5: 知识图谱级联清理（best-effort，失败不影响向量删除结果）
+        try:
+            from app.services.kg import get_kg_service
+
+            await get_kg_service().delete_video_data(bvid)
+        except Exception as kg_err:
+            logger.warning(f"[KG] graph cascade cleanup failed bvid={bvid}: {kg_err}")
+
         return {"message": f"已删除视频 {bvid}"}
     except HTTPException:
         raise
+    except Exception as e:
+        raise internal_error(e)
+
+
+# ==================== 知识图谱（Plan 1.0.5: Neo4j + MySQL） ====================
+
+
+class KgBuildRequest(BaseModel):
+    """知识图谱构建请求（作用域与 /knowledge/build 一致）。"""
+
+    folder_ids: List[int]
+
+
+@router.post("/kg/build")
+async def build_knowledge_graph(
+    request: KgBuildRequest,
+    uid: int = Depends(get_current_uid),
+):
+    """触发收藏夹范围的知识图谱抽取（后台任务）。
+
+    幂等：内容未变更的分P 自动跳过；已有活跃任务时复用其 task_id。
+    """
+    from app.services.kg import get_kg_service
+
+    service = get_kg_service()
+    if not service.is_available():
+        raise HTTPException(
+            status_code=503, detail="知识图谱存储不可用（Neo4j 未连接）"
+        )
+    try:
+        return await service.try_start_build(uid=uid, folder_ids=request.folder_ids)
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except RuntimeError as e:
+        raise HTTPException(status_code=503, detail=str(e))
+    except Exception as e:
+        raise internal_error(e)
+
+
+@router.get("/kg/active")
+async def get_active_kg_task(uid: int = Depends(get_current_uid)):
+    """查询当前是否有活跃的 KG 构建任务（前端禁用按钮 / 复用 task_id）。"""
+    from app.repository.knowledge_repository import get_knowledge_repository
+    from app.services.kg import get_kg_service
+
+    task_id = get_kg_service().get_active_task_id()
+    if task_id is None:
+        return {"task_id": None}
+    try:
+        async with get_db_context() as db:
+            row = await get_knowledge_repository().get_build_status_row(
+                task_id, uid, db
+            )
+        if row is None:
+            # 不属于当前用户的活跃任务：对调用方不可见
+            return {"task_id": None}
+    except Exception:
+        return {"task_id": None}
+    return {"task_id": task_id}
+
+
+@router.get("/kg/status/{task_id}")
+async def get_kg_build_status(task_id: str, uid: int = Depends(get_current_uid)):
+    """获取 KG 构建任务状态（async_tasks 表，uid 归属校验防 IDOR）。"""
+    from app.repository.knowledge_repository import get_knowledge_repository
+
+    try:
+        async with get_db_context() as db:
+            row = await get_knowledge_repository().get_build_status_row(
+                task_id, uid, db
+            )
+    except Exception as e:
+        logger.warning(f"[KG] status read failed: {e}")
+        raise internal_error(e)
+    if row is None:
+        raise HTTPException(status_code=404, detail="任务不存在")
+
+    current_step = ""
+    if row.steps:
+        last = row.steps[-1] if row.steps else {}
+        current_step = last.get("name", "")
+    return {
+        "task_id": task_id,
+        "status": row.status or "pending",
+        "progress": row.progress or 0,
+        "current_step": current_step,
+        "result": row.result or {},
+        "error": row.error or "",
+    }
+
+
+@router.get("/kg/stats")
+async def get_kg_stats(uid: int = Depends(get_current_uid)):
+    """图谱统计：实体/关系/证据/视频计数 + 实体向量数 + 待抽取分P数。"""
+    from app.services.kg import get_kg_service
+
+    try:
+        return await get_kg_service().stats()
     except Exception as e:
         raise internal_error(e)
 

--- a/app/services/kg/__init__.py
+++ b/app/services/kg/__init__.py
@@ -1,0 +1,29 @@
+"""知识图谱服务包（Plan 1.0.5）。
+
+模块划分：
+- extractor: LLM structured output 抽取（实体/关系/引文）
+- resolver:  归一化与校验（纯函数，防幻觉边的核心防线）
+- service:   build 编排 / 幂等状态机 / 删除级联 / 统计
+- retriever: 查询期 实体链接 → 子图扩展 → 证据回捞
+
+用法::
+
+    from app.services.kg import get_kg_service
+
+    svc = get_kg_service()
+    if svc.is_available():
+        result = await svc.try_start_build(uid=1, folder_ids=[123])
+"""
+
+from app.services.kg.extractor import ExtractionResult, KgExtractor
+from app.services.kg.retriever import KgRetrievalResult, KgRetriever
+from app.services.kg.service import KgService, get_kg_service
+
+__all__ = [
+    "ExtractionResult",
+    "KgExtractor",
+    "KgRetrievalResult",
+    "KgRetriever",
+    "KgService",
+    "get_kg_service",
+]

--- a/app/services/kg/extractor.py
+++ b/app/services/kg/extractor.py
@@ -1,0 +1,141 @@
+"""KgExtractor — 从 ASR 正文抽取实体与关系（LLM structured output）。
+
+设计：
+- 使用 ``with_structured_output`` 强约束输出（quiz 链路同款模式）
+- **防幻觉边**：每条关系必须携带原文引文 quote，校验在 resolver 中进行
+- 模型/成本护栏走配置：kg.extract_model / kg.max_text_chars
+
+定位：只负责调 LLM 产出 ExtractionResult；归一化/校验/写库分别在
+resolver.py 与 service.py。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from loguru import logger
+from pydantic import BaseModel, Field
+
+from app.infra.config import config
+
+
+class ExtractedEntity(BaseModel):
+    """LLM 抽取出的单个实体。"""
+
+    name: str = Field(description="实体名称，尽量使用视频中出现的原文叫法")
+    type: str = Field(
+        default="other",
+        description="实体类型: person/org/concept/tech/tool/book/event/method/place/other",
+    )
+    description: str = Field(
+        default="", description="一句话描述该实体在本视频中的含义或角色"
+    )
+    quote: str = Field(
+        default="",
+        description="原文中明确提到该实体的片段摘抄（20字以内），找不到就留空",
+    )
+
+
+class ExtractedRelation(BaseModel):
+    """LLM 抽取出的单条关系（必须携带原文证据）。"""
+
+    src: str = Field(description="起点实体名，必须与 entities 中某个 name 一致")
+    dst: str = Field(description="终点实体名，必须与 entities 中某个 name 一致")
+    relation_type: str = Field(
+        description="关系动词短语，如 讲解了/使用了/提出了/对比了/依赖于/属于"
+    )
+    quote: str = Field(
+        description="支持该关系的原文片段（直接摘抄，20字以内），禁止编造"
+    )
+
+
+class ExtractionResult(BaseModel):
+    """一次分P抽取的完整结果。"""
+
+    entities: list[ExtractedEntity] = Field(default_factory=list)
+    relations: list[ExtractedRelation] = Field(default_factory=list)
+
+
+EXTRACTION_SYSTEM_PROMPT = """\
+你是知识图谱构建专家，从视频文字稿中抽取「实体」和「实体间关系」。
+
+## 实体抽取规则
+1. 只抽取**具体、有信息量**的实体：人物(person)、组织机构(org)、技术概念\
+(concept)、技术/框架/算法(tech)、工具/软件(tool)、书籍/论文(book)、事件\
+(event)、方法论(method)、地点(place)
+2. 忽略：泛指词（"大家""这个方法"）、无实义的普通名词、纯口语填充
+3. name 使用视频中的原文叫法；type 从给定枚举中选择
+4. description 用一句话说明该实体在**本视频语境下**的含义，不超过 50 字
+5. quote 是文字稿中提到该实体的原文摘抄（20 字以内）；找不到原文就留空，\
+禁止编造
+6. 单个视频片段最多 30 个实体，宁缺毋滥
+
+## 关系抽取规则
+1. 只抽取文本稿中**明确表达**的关系；禁止根据常识推测文中未提及的关系
+2. src/dst 必须严格等于已抽取实体的 name
+3. relation_type 用简短中文动词短语（讲解了/使用了/提出了/对比了/依赖了/创立了）
+4. **quote 必须是文字稿的原文摘抄**（20 字以内），作为该关系的证据；\
+找不到原文支撑就放弃这条关系
+5. 单个视频片段最多 40 条关系
+
+## 输出
+严格按照 schema 返回 JSON，没有实体时返回空列表。
+"""
+
+
+class KgExtractor:
+    """LLM 抽取器。惰性初始化 LLM（首次调用才建立客户端）。"""
+
+    def __init__(self) -> None:
+        self._structured_llm: Any | None = None
+
+    def _get_structured_llm(self) -> Any:
+        if self._structured_llm is None:
+            from langchain_openai import ChatOpenAI
+
+            api_key = config.llm.api_key.get_secret_value()
+            llm = ChatOpenAI(
+                api_key=api_key,
+                base_url=config.llm.base_url,
+                model=config.kg.extract_model,
+                temperature=0,
+                timeout=120,
+                max_retries=2,
+            )
+            self._structured_llm = llm.with_structured_output(ExtractionResult)
+            logger.info(
+                "[KG_EXTRACTOR] initialized model={} ", config.kg.extract_model
+            )
+        return self._structured_llm
+
+    async def extract(self, text: str, title: str = "") -> ExtractionResult:
+        """抽取一个分P的实体与关系。
+
+        text 超长时按 kg.max_text_chars 截断（成本护栏）。
+        LLM 失败时抛异常，由上层标记任务失败并保留重试机会。
+        """
+        max_chars = config.kg.max_text_chars
+        truncated = text[:max_chars]
+        if len(text) > max_chars:
+            logger.info(
+                "[KG_EXTRACTOR] text truncated {} -> {} chars",
+                len(text),
+                max_chars,
+            )
+
+        user_prompt = f"视频标题：{title or '（未知）'}\n\n文字稿：\n{truncated}"
+        result: ExtractionResult = await self._get_structured_llm().ainvoke(
+            [
+                {"role": "system", "content": EXTRACTION_SYSTEM_PROMPT},
+                {"role": "user", "content": user_prompt},
+            ]
+        )
+        if not isinstance(result, ExtractionResult):
+            # langchain 在部分模型上可能返回 dict
+            result = ExtractionResult.model_validate(result)
+        logger.info(
+            "[KG_EXTRACTOR] extracted entities={} relations={}",
+            len(result.entities),
+            len(result.relations),
+        )
+        return result

--- a/app/services/kg/resolver.py
+++ b/app/services/kg/resolver.py
@@ -1,0 +1,180 @@
+"""KgResolver — 抽取结果的归一化与校验（纯函数，可独立单测）。
+
+职责：
+1. 实体名归一化（复用 repository 的 normalize_name/eid_for_name 单一实现）
+2. 实体类型白名单映射（中文别名 → 规范英文枚举）
+3. 关系校验：**quote 必填且达到最小长度**（防幻觉边的核心防线）、
+   端点必须可解析到已知实体（未知端点自动创建 stub 实体）、去自环
+4. 批内去重与数量上限
+
+本模块不依赖 LLM / 数据库 / 网络。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from app.repository.kg_graph_repository import eid_for_name, normalize_name
+from app.services.kg.extractor import ExtractionResult
+
+# 规范实体类型枚举（与 Neo4j Entity.type 对齐）
+CANONICAL_TYPES = {
+    "person",
+    "org",
+    "concept",
+    "tech",
+    "tool",
+    "book",
+    "event",
+    "method",
+    "place",
+    "other",
+}
+
+# 中文/英文别名 → 规范类型
+_TYPE_ALIAS_MAP: dict[str, str] = {
+    "人物": "person", "人名": "person", "人": "person", "作者": "person",
+    "up主": "person", "up": "person", "专家": "person", "讲师": "person",
+    "组织": "org", "机构": "org", "公司": "org", "团队": "org", "企业": "org",
+    "概念": "concept", "理论": "concept", "术语": "concept", "学科": "concept",
+    "技术": "tech", "框架": "tech", "语言": "tech", "协议": "tech",
+    "算法": "tech", "模型": "tech", "架构": "tech", "标准": "tech",
+    "工具": "tool", "软件": "tool", "库": "tool", "平台": "tool",
+    "产品": "tool", "服务": "tool", "网站": "tool",
+    "书": "book", "书籍": "book", "论文": "book", "著作": "book", "教材": "book",
+    "事件": "event", "会议": "event", "历史事件": "event",
+    "方法": "method", "方法论": "method", "流程": "method", "实践": "method",
+    "技巧": "method", "策略": "method",
+    "地点": "place", "位置": "place", "国家": "place", "城市": "place",
+    "其他": "other",
+    # English aliases
+    "people": "person", "company": "org", "organization": "org",
+    "technology": "tech", "framework": "tech", "library": "tool",
+    "software": "tool", "paper": "book", "conference": "event",
+}
+
+# 校验参数默认值（测试可覆盖）
+DEFAULT_MIN_QUOTE_CHARS = 8
+DEFAULT_MAX_ENTITIES = 30
+DEFAULT_MAX_RELATIONS = 40
+MAX_NAME_LEN = 100
+
+
+def normalize_entity_type(raw: str | None) -> str:
+    """任意输入映射到规范实体类型；无法识别时回退 other。"""
+    key = (raw or "").strip().lower()
+    if not key:
+        return "other"
+    if key in CANONICAL_TYPES:
+        return key
+    mapped = _TYPE_ALIAS_MAP.get(key)
+    if mapped in CANONICAL_TYPES:
+        return mapped
+    return "other"
+
+
+@dataclass
+class ResolvedExtraction:
+    """校验后、可直接写图的结构化结果。
+
+    entities 每项: {eid, name, type, description}
+    relations 每项: {src_eid, dst_eid, rel_type, quote}
+    """
+
+    entities: list[dict] = field(default_factory=list)
+    relations: list[dict] = field(default_factory=list)
+    dropped_relations: int = 0  # 因缺引文/自环等被丢弃的关系数（观测用）
+
+
+def resolve_extraction(
+    result: ExtractionResult,
+    *,
+    min_quote_chars: int = DEFAULT_MIN_QUOTE_CHARS,
+    max_entities: int = DEFAULT_MAX_ENTITIES,
+    max_relations: int = DEFAULT_MAX_RELATIONS,
+) -> ResolvedExtraction:
+    """把 LLM 原始抽取结果清洗为可直接入库的形态。
+
+    步骤：实体清洗去重 → 关系端点解析（stub 补全）→ 引文校验 → 上限裁剪。
+    """
+    resolved = ResolvedExtraction()
+
+    # ---- 实体清洗：按归一化键去重，保留首个非空描述/引文 ----
+    by_key: dict[str, dict] = {}
+    for ent in result.entities:
+        name = (ent.name or "").strip()
+        if not name or len(name) > MAX_NAME_LEN:
+            continue
+        key = normalize_name(name)
+        if not key:
+            continue
+        existing = by_key.get(key)
+        desc = (ent.description or "").strip()
+        quote = (ent.quote or "").strip()[:300]
+        if existing is None:
+            by_key[key] = {
+                "eid": eid_for_name(name),
+                "name": name,
+                "type": normalize_entity_type(ent.type),
+                "description": desc,
+                "quote": quote,
+            }
+        else:
+            if not existing["description"] and desc:
+                existing["description"] = desc
+            if not existing["quote"] and quote:
+                existing["quote"] = quote
+    resolved.entities = list(by_key.values())[:max_entities]
+
+    def _entity_eid(raw_name: str) -> str | None:
+        """端点解析：命中已知实体；未命中则创建 stub（保住关系召回）。"""
+        name = (raw_name or "").strip()
+        key = normalize_name(name)
+        if not key or len(name) > MAX_NAME_LEN:
+            return None
+        ent = by_key.get(key)
+        if ent is not None:
+            return ent["eid"]
+        stub = {
+            "eid": eid_for_name(name),
+            "name": name,
+            "type": "other",
+            "description": "",
+            "quote": "",
+        }
+        by_key[key] = stub
+        resolved.entities.append(stub)
+        return stub["eid"]
+
+    # ---- 关系校验：端点解析 + 自环剔除 + 引文强制 ----
+    seen_rel: set[tuple[str, str, str]] = set()
+    for rel in result.relations:
+        if len(resolved.relations) >= max_relations:
+            break
+        src_eid = _entity_eid(rel.src)
+        dst_eid = _entity_eid(rel.dst)
+        quote = (rel.quote or "").strip()[:300]
+        rel_type = (rel.relation_type or "").strip()[:50]
+        if (
+            src_eid is None
+            or dst_eid is None
+            or src_eid == dst_eid
+            or not rel_type
+            or len(quote) < min_quote_chars
+        ):
+            resolved.dropped_relations += 1
+            continue
+        dedup_key = (src_eid, dst_eid, rel_type)
+        if dedup_key in seen_rel:
+            continue
+        seen_rel.add(dedup_key)
+        resolved.relations.append(
+            {
+                "src_eid": src_eid,
+                "dst_eid": dst_eid,
+                "rel_type": rel_type,
+                "quote": quote,
+            }
+        )
+
+    return resolved

--- a/app/services/kg/retriever.py
+++ b/app/services/kg/retriever.py
@@ -1,0 +1,284 @@
+"""KgRetriever — 查询期知识图谱检索。
+
+流程：query → Milvus 实体链接（种子实体）→ Neo4j BFS 子图扩展
+（RELATES 边，≤ max_hops）→ APPEARS_IN 证据回捞（按用户 bvids 作用域过滤）
+→ 组装实体卡片 + sources（与 vector_search 同构，复用 SSE 协议）。
+
+Milvus 客户端为同步实现，经 ``asyncio.to_thread`` 调用；
+Neo4j 为原生异步驱动。
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any
+
+from loguru import logger
+
+from app.infra import neo4j
+from app.infra.config import config
+from app.repository.kg_entity_index import KgEntityIndex
+from app.repository.kg_graph_repository import get_kg_graph_repository
+
+
+@dataclass
+class KgRetrievalResult:
+    """检索结果。content 供 LLM 阅读；sources 进 SSE sources 帧。"""
+
+    content: str = ""
+    sources: list[dict[str, Any]] = field(default_factory=list)
+    entity_count: int = 0
+    evidence_count: int = 0
+
+    @property
+    def has_results(self) -> bool:
+        return bool(self.sources)
+
+
+class KgRetriever:
+    """KG 查询编排。依赖不可用时返回空结果（不抛异常）。"""
+
+    def __init__(self) -> None:
+        self._graph = get_kg_graph_repository()
+        self._entity_index: KgEntityIndex | None = None
+
+    # ------------------------------------------------------------------
+    # 依赖惰性获取
+    # ------------------------------------------------------------------
+
+    def _get_entity_index(self) -> KgEntityIndex | None:
+        if self._entity_index is None:
+            try:
+                from app.services.rag import get_rag_service
+
+                rag = get_rag_service()
+                if rag.embeddings is None:
+                    return None
+                self._entity_index = KgEntityIndex(rag.embeddings)
+            except Exception as e:
+                logger.warning("[KG_RETRIEVER] entity index unavailable: {}", e)
+                return None
+        return self._entity_index
+
+    def is_available(self) -> bool:
+        """Neo4j 已连接且实体索引可构建（Milvus 开启）。"""
+        if not neo4j.is_enabled():
+            return False
+        return self._get_entity_index() is not None
+
+    # ------------------------------------------------------------------
+    # 主入口
+    # ------------------------------------------------------------------
+
+    async def retrieve(
+        self,
+        query: str,
+        bvids: list[str] | None = None,
+        k: int = 8,
+    ) -> KgRetrievalResult:
+        """执行一次 KG 检索。
+
+        bvids 为用户可见范围（来自 _bvids 隐式注入）；None/空 表示
+        不过滤作用域（仅限管理调试，工具链路始终传入用户范围）。
+        """
+        empty = KgRetrievalResult()
+        if not neo4j.is_enabled():
+            return empty
+        index = self._get_entity_index()
+        if index is None:
+            return empty
+
+        # ---- 1. 实体链接（Milvus，同步客户端走线程池）----
+        try:
+            seeds = await asyncio.to_thread(
+                index.search, query, config.kg.seed_top_n
+            )
+        except Exception as e:
+            logger.error("[KG_RETRIEVER] entity linking failed: {}", e)
+            return empty
+        threshold = config.kg.link_score_threshold
+        seeds = [s for s in seeds if s.get("score", 0.0) >= threshold]
+        if not seeds:
+            logger.info(
+                "[KG_RETRIEVER] no linked entities above threshold={} query='{}'",
+                threshold,
+                query[:50],
+            )
+            return empty
+
+        seed_scores = {s["eid"]: s["score"] for s in seeds}
+        seed_eids = list(seed_scores)
+
+        try:
+            # ---- 2. BFS 子图扩展（Neo4j 异步）----
+            visited: set[str] = set(seed_eids)
+            frontier = list(seed_eids)
+            for _hop in range(max(config.kg.max_hops, 0)):
+                if not frontier:
+                    break
+                rows = await self._graph.neighbors(
+                    frontier,
+                    exclude_eids=list(visited),
+                    limit=config.kg.expand_limit_per_hop,
+                )
+                new_ids = [r["eid"] for r in rows if r["eid"] not in visited]
+                visited.update(new_ids)
+                frontier = new_ids
+            all_eids = list(visited)
+
+            # ---- 3. 证据 + 关系 + 实体详情 ----
+            evidence = await self._graph.fetch_evidence(
+                all_eids, bvids or [], config.kg.evidence_limit
+            )
+            relations = await self._graph.relations_among(all_eids)
+            entities = await self._graph.entities_by_eids(all_eids)
+        except Exception as e:
+            logger.error("[KG_RETRIEVER] graph traversal failed: {}", e)
+            return empty
+
+        if not evidence and not relations:
+            return empty
+
+        # ---- 4. 标题解析（MySQL video 表）----
+        ev_bvids = sorted({e["bvid"] for e in evidence})
+        titles = await _page_titles(ev_bvids)
+
+        content = _format_content(
+            entities=entities,
+            relations=relations,
+            evidence=evidence,
+            titles=titles,
+            seed_names=[s["name"] for s in seeds],
+            limit=k,
+        )
+        sources = _build_sources(evidence, seed_scores, titles)
+        logger.info(
+            "[KG_RETRIEVER] done query='{}' entities={} evidence={} sources={}",
+            query[:50],
+            len(entities),
+            len(evidence),
+            len(sources),
+        )
+        return KgRetrievalResult(
+            content=content,
+            sources=sources,
+            entity_count=len(entities),
+            evidence_count=len(evidence),
+        )
+
+
+# ---------------------------------------------------------------------------
+# 辅助：标题解析 / 内容组装 / 来源构建
+# ---------------------------------------------------------------------------
+
+
+async def _page_titles(bvids: list[str]) -> dict[tuple[str, int], str]:
+    """(bvid, page_index) -> page_title，供来源标注使用。"""
+    if not bvids:
+        return {}
+    from sqlalchemy import select
+
+    from app.database import get_db_context
+    from app.models import Video
+
+    mapping: dict[tuple[str, int], str] = {}
+    try:
+        async with get_db_context() as db:
+            rows = await db.execute(
+                select(Video.bvid, Video.page_index, Video.page_title).where(
+                    Video.bvid.in_(bvids)
+                )
+            )
+            for bvid, page_index, page_title in rows.fetchall():
+                mapping[(bvid, int(page_index))] = (
+                    page_title or f"P{page_index + 1}"
+                )
+    except Exception as e:
+        logger.warning("[KG_RETRIEVER] title lookup failed: {}", e)
+    return mapping
+
+
+def _format_content(
+    *,
+    entities: list[dict],
+    relations: list[dict],
+    evidence: list[dict],
+    titles: dict[tuple[str, int], str],
+    seed_names: list[str],
+    limit: int,
+) -> str:
+    """组装 LLM 可读的实体卡片文本。"""
+    ent_by_id = {e["eid"]: e for e in entities}
+
+    rel_by_src: dict[str, list[dict]] = {}
+    for rel in relations:
+        rel_by_src.setdefault(rel["src_eid"], []).append(rel)
+
+    ev_by_eid: dict[str, list[dict]] = {}
+    for ev in evidence:
+        ev_by_eid.setdefault(ev["eid"], []).append(ev)
+
+    # 命中证据的实体优先展示，其次是无证据的关联实体
+    ordered = [e for e in entities if e["eid"] in ev_by_eid]
+    ordered += [e for e in entities if e["eid"] not in ev_by_eid]
+
+    parts: list[str] = [
+        f"知识图谱检索结果（核心实体：{'、'.join(seed_names[:3])}）"
+    ]
+    shown = 0
+    for ent in ordered:
+        if shown >= limit:
+            break
+        lines = [f"\n## {ent['name']}（{ent['type']}）"]
+        if ent.get("description"):
+            lines.append(f"描述：{ent['description']}")
+
+        rels = rel_by_src.get(ent["eid"], [])
+        if rels:
+            rel_strs = [
+                f"{r['src_name']} --{r['rel_type']}--> {r['dst_name']}"
+                for r in rels[:5]
+            ]
+            lines.append("关系：" + "；".join(rel_strs))
+
+        for ev in ev_by_eid.get(ent["eid"], [])[:5]:
+            title = titles.get((ev["bvid"], int(ev.get("page_index") or 0)), ev["bvid"])
+            quote = (ev.get("quote") or "").strip()
+            if quote:
+                lines.append(f'出处：【{title}】"{quote}"')
+            else:
+                lines.append(f"出处：【{title}】")
+        parts.append("\n".join(lines))
+        shown += 1
+
+    if not evidence:
+        parts.append("\n（注意：以下实体在你的当前范围内暂无视频出处证据）")
+    return "\n\n".join(parts)
+
+
+def _build_sources(
+    evidence: list[dict],
+    seed_scores: dict[str, float],
+    titles: dict[tuple[str, int], str],
+) -> list[dict[str, Any]]:
+    """按 bvid 去重构建 sources，字段与 vector_search 的输出同构。"""
+    seen: set[str] = set()
+    sources: list[dict[str, Any]] = []
+    for ev in evidence:
+        bvid = ev.get("bvid") or ""
+        if not bvid or bvid in seen:
+            continue
+        seen.add(bvid)
+        page_index = ev.get("page_index")
+        title = titles.get((bvid, int(page_index or 0)), bvid)
+        source: dict[str, Any] = {
+            "title": title,
+            "score": round(float(seed_scores.get(ev.get("eid"), 0.0)), 4),
+            "bvid": bvid,
+            "url": f"https://www.bilibili.com/video/{bvid}",
+        }
+        if page_index is not None:
+            source["page_index"] = page_index
+        sources.append(source)
+    return sources

--- a/app/services/kg/retriever.py
+++ b/app/services/kg/retriever.py
@@ -209,8 +209,6 @@ def _format_content(
     limit: int,
 ) -> str:
     """组装 LLM 可读的实体卡片文本。"""
-    ent_by_id = {e["eid"]: e for e in entities}
-
     rel_by_src: dict[str, list[dict]] = {}
     for rel in relations:
         rel_by_src.setdefault(rel["src_eid"], []).append(rel)

--- a/app/services/kg/service.py
+++ b/app/services/kg/service.py
@@ -21,7 +21,6 @@ Neo4j/Milvus 不可用时端点报 unavailable，绝不阻塞主链路。
 from __future__ import annotations
 
 import asyncio
-from datetime import datetime, timezone
 from typing import Any
 
 from loguru import logger

--- a/app/services/kg/service.py
+++ b/app/services/kg/service.py
@@ -1,0 +1,444 @@
+"""KgService — 知识图谱构建与查询编排（Plan 1.0.5）。
+
+入库管道（独立触发，复刻「ASR/向量化解耦」模式）::
+
+    POST /knowledge/kg/build
+      └► try_start_build(uid, folder_ids)
+           ├─ folder_ids → media_ids → bvids（MySQL，scope 辅助）
+           ├─ 单活跃任务守卫（同进程同时最多一个 build）
+           ├─ task_type="kg_extract" 进 async_tasks（TaskTracker）
+           └─ 并发信号量逐分P：process_page（幂等）
+                Mongo 正文 → LLM 抽取 → resolver 校验 → Cypher MERGE
+                → 实体向量 upsert Milvus → video.kg_status='done'
+
+幂等：``video.kg_version`` 记录抽取时的 content version，
+内容未变则跳过；重抽前 delete-before-write 清旧证据边。
+
+失败隔离：单分P 失败置 kg_status='failed' 可重试，不影响其他分P；
+Neo4j/Milvus 不可用时端点报 unavailable，绝不阻塞主链路。
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from typing import Any
+
+from loguru import logger
+from sqlalchemy import or_, select
+
+from app.infra.config import config
+from app.infra.neo4j import is_enabled as neo4j_ok
+from app.repository.kg_entity_index import KgEntityIndex
+from app.repository.kg_graph_repository import get_kg_graph_repository
+from app.services.async_task.tracker import TaskTracker
+from app.services.kg.extractor import KgExtractor
+from app.services.kg.resolver import resolve_extraction
+from app.services.kg.retriever import KgRetriever
+
+# 后台任务强引用，防 GC（同 vector_page_service 模式）
+_background_tasks: set[asyncio.Task] = set()
+
+
+class KgService:
+    """知识图谱服务：build 编排 + 删除级联 + 统计 + 检索入口。"""
+
+    def __init__(self) -> None:
+        self._tracker = TaskTracker()
+        self._extractor = KgExtractor()
+        self._retriever = KgRetriever()
+        self._graph = get_kg_graph_repository()
+        self._entity_index: KgEntityIndex | None = None
+        self._active_lock = asyncio.Lock()
+        self._active_task_id: str | None = None
+
+    # ------------------------------------------------------------------
+    # 可用性 / 依赖
+    # ------------------------------------------------------------------
+
+    def is_available(self) -> bool:
+        """Neo4j 已连接即可构建；实体索引（Milvus）缺失仅影响语义链接。"""
+        return neo4j_ok()
+
+    @property
+    def retriever(self) -> KgRetriever:
+        return self._retriever
+
+    def _get_entity_index(self) -> KgEntityIndex | None:
+        if self._entity_index is None:
+            try:
+                from app.services.rag import get_rag_service
+
+                rag = get_rag_service()
+                if rag.embeddings is None:
+                    return None
+                self._entity_index = KgEntityIndex(rag.embeddings)
+            except Exception as e:
+                logger.warning("[KG] entity index unavailable: {}", e)
+                return None
+        return self._entity_index
+
+    def get_active_task_id(self) -> str | None:
+        return self._active_task_id
+
+    # ------------------------------------------------------------------
+    # 构建入口
+    # ------------------------------------------------------------------
+
+    async def try_start_build(
+        self, uid: int, folder_ids: list[int] | None = None
+    ) -> dict[str, Any]:
+        """为用户收藏夹触发 KG 构建。已有活跃任务时复用其 task_id。
+
+        返回 {"task_id": str, "reused": bool}。
+        Raises ValueError 当范围内无已同步数据或 Neo4j 不可用。
+        """
+        if not self.is_available():
+            raise RuntimeError("知识图谱存储不可用（Neo4j 未连接）")
+
+        async with self._active_lock:
+            if self._active_task_id is not None:
+                return {"task_id": self._active_task_id, "reused": True}
+
+            bvids = await self._resolve_bvids(uid, folder_ids)
+            if not bvids:
+                raise ValueError("未找到已同步的收藏夹视频，请先执行收藏夹同步")
+
+            task_id = await self._tracker.create(
+                uid=uid,
+                task_type="kg_extract",
+                target={"folder_ids": folder_ids or [], "bvid_count": len(bvids)},
+            )
+            self._active_task_id = task_id
+
+        task = asyncio.create_task(self._run_build(task_id, uid, bvids))
+        _background_tasks.add(task)
+        task.add_done_callback(_background_tasks.discard)
+        logger.info("[KG] build started task_id={} uid={} bvids={}", task_id, uid, len(bvids))
+        return {"task_id": task_id, "reused": False}
+
+    async def _resolve_bvids(
+        self, uid: int, folder_ids: list[int] | None
+    ) -> list[str]:
+        """收藏夹范围解析（复用 chat 链路的 scope 辅助，纯 DB 查询）。"""
+        from app.database import get_db_context
+        from app.services.chat.scope import (
+            get_bvids_by_media_ids,
+            get_media_ids_for_uid,
+        )
+
+        async with get_db_context() as db:
+            media_ids = await get_media_ids_for_uid(db, uid, folder_ids or None)
+            if not media_ids:
+                return []
+            return await get_bvids_by_media_ids(db, media_ids)
+
+    async def _select_pending_pages(self, bvids: list[str]) -> list[dict[str, Any]]:
+        """圈定待抽取分P：ASR 完成且（从未抽取 / 失败可重试 / 内容已变更）。"""
+        from app.database import get_db_context
+        from app.models import Video
+
+        stmt = (
+            select(Video.bvid, Video.cid, Video.page_index, Video.page_title, Video.version)
+            .where(
+                Video.bvid.in_(bvids),
+                Video.is_processed.is_(True),
+                or_(
+                    Video.kg_version.is_(None),
+                    Video.kg_status == "failed",
+                    Video.kg_version != Video.version,
+                ),
+            )
+            .limit(config.kg.page_batch_size)
+        )
+        async with get_db_context() as db:
+            rows = (await db.execute(stmt)).fetchall()
+        return [
+            {
+                "bvid": r.bvid,
+                "cid": r.cid,
+                "page_index": r.page_index,
+                "page_title": r.page_title,
+                "version": r.version,
+            }
+            for r in rows
+        ]
+
+    async def _run_build(
+        self, task_id: str, uid: int, bvids: list[str]
+    ) -> None:
+        """后台执行整轮构建；单分P 失败隔离，最终 complete（带错误摘要）。"""
+        try:
+            await self._tracker.start(task_id)
+            await self._tracker.step(
+                task_id, name="init", status="processing", progress=0
+            )
+
+            pages = await self._select_pending_pages(bvids)
+            total = len(pages)
+            logger.info("[KG] pending pages={} task_id={}", total, task_id)
+            if not pages:
+                await self._tracker.complete(
+                    task_id, result={"total": 0, "message": "所有分P已是最新"}
+                )
+                return
+
+            sem = asyncio.Semaphore(max(config.kg.concurrency, 1))
+            counters = {"ok": 0, "failed": 0}
+            progress_lock = asyncio.Lock()
+
+            async def _one(page: dict[str, Any]) -> None:
+                async with sem:
+                    try:
+                        await self.process_page(
+                            bvid=page["bvid"],
+                            cid=page["cid"],
+                            page_index=page["page_index"],
+                            page_title=page.get("page_title"),
+                            expected_version=page["version"],
+                        )
+                        counters["ok"] += 1
+                    except Exception as exc:
+                        counters["failed"] += 1
+                        logger.error(
+                            "[KG] page failed bvid={} p{}: {}",
+                            page["bvid"],
+                            page["page_index"],
+                            exc,
+                        )
+                    finally:
+                        async with progress_lock:
+                            done = counters["ok"] + counters["failed"]
+                            await self._tracker.set_progress(
+                                task_id, int(done * 100 / total)
+                            )
+                            await self._tracker.step(
+                                task_id,
+                                name=f"extract:{page['bvid']}:p{page['page_index']}",
+                                status="done",
+                                progress=int(done * 100 / total),
+                            )
+
+            await asyncio.gather(*[_one(p) for p in pages])
+
+            await self._tracker.complete(
+                task_id,
+                result={
+                    "total": total,
+                    "ok": counters["ok"],
+                    "failed": counters["failed"],
+                },
+            )
+            logger.info(
+                "[KG] build done task_id={} ok={} failed={}",
+                task_id,
+                counters["ok"],
+                counters["failed"],
+            )
+        except Exception as e:
+            logger.exception("[KG] build failed task_id={}", task_id)
+            await self._tracker.fail(task_id, str(e))
+        finally:
+            self._active_task_id = None
+
+    # ------------------------------------------------------------------
+    # 单分P 幂等管道
+    # ------------------------------------------------------------------
+
+    async def process_page(
+        self,
+        bvid: str,
+        cid: int,
+        page_index: int,
+        page_title: str | None = None,
+        expected_version: int | None = None,
+    ) -> dict[str, Any]:
+        """抽取单个分P并写图。幂等：内容未变直接跳过。
+
+        Raises 异常由调用方决定如何标记状态（build 内捕获计数）。
+        """
+        from app.models import Video
+        from app.database import get_db_context
+        from app.repository.mongo_asr_repository import get_latest
+        from app.infra.mongo import is_enabled as mongo_ok
+
+        # ---- Phase 1: 幂等检查 + 置 processing ----
+        async with get_db_context() as db:
+            row = (
+                await db.execute(
+                    select(Video).where(Video.bvid == bvid, Video.cid == cid)
+                )
+            ).scalar_one_or_none()
+            if not row:
+                raise ValueError(f"Video not found: bvid={bvid}, cid={cid}")
+            if not row.is_processed:
+                raise ValueError(f"ASR not done yet: bvid={bvid}, cid={cid}")
+
+            content_version = (
+                expected_version if expected_version is not None else row.version
+            )
+            if (
+                row.kg_status == "done"
+                and row.kg_version == content_version
+                and expected_version is None
+            ):
+                return {"skipped": True, "reason": "up to date"}
+
+            row.kg_status = "processing"
+            await db.commit()
+
+        try:
+            # ---- Phase 2: 读正文 ----
+            text = ""
+            if mongo_ok():
+                doc = await get_latest(bvid, cid)
+                if doc:
+                    text = doc.get("content", "")
+            if not text:
+                raise ValueError(f"no ASR content in MongoDB: bvid={bvid}, cid={cid}")
+
+            title = page_title or f"P{page_index + 1}"
+
+            # ---- Phase 3: 删旧证据边（delete-before-write）----
+            removed = await self._graph.delete_page_evidence(bvid, page_index)
+            if removed:
+                logger.debug(
+                    "[KG] removed {} stale evidence edges bvid={} p{}",
+                    removed,
+                    bvid,
+                    page_index,
+                )
+
+            # ---- Phase 4: 抽取 + 校验 ----
+            raw = await self._extractor.extract(text, title=title)
+            resolved = resolve_extraction(raw)
+            if not resolved.entities:
+                logger.info("[KG] no entities extracted bvid={} p{}", bvid, page_index)
+
+            # ---- Phase 5: 写图 ----
+            if resolved.entities:
+                await self._graph.upsert_entities(resolved.entities)
+                appearances = [
+                    {"eid": ent["eid"], "quote": ent.get("quote", "")}
+                    for ent in resolved.entities
+                ]
+                await self._graph.link_appearances(bvid, page_index, appearances)
+            if resolved.relations:
+                await self._graph.upsert_relations(resolved.relations)
+
+            # ---- Phase 6: 实体向量 upsert（best-effort，Milvus 故障不回滚）----
+            if resolved.entities:
+                index = self._get_entity_index()
+                if index is not None:
+                    try:
+                        await asyncio.to_thread(index.upsert, resolved.entities)
+                    except Exception as exc:
+                        logger.warning("[KG] entity index upsert failed: {}", exc)
+
+            # ---- Phase 7: 确认 done ----
+            async with get_db_context() as db:
+                row = (
+                    await db.execute(
+                        select(Video).where(Video.bvid == bvid, Video.cid == cid)
+                    )
+                ).scalar_one_or_none()
+                if row:
+                    row.kg_status = "done"
+                    row.kg_version = content_version
+                    await db.commit()
+
+            result = {
+                "entities": len(resolved.entities),
+                "relations": len(resolved.relations),
+                "dropped_relations": resolved.dropped_relations,
+            }
+            logger.info(
+                "[KG] page done bvid={} p{} entities={} relations={}",
+                bvid,
+                page_index,
+                result["entities"],
+                result["relations"],
+            )
+            return result
+
+        except Exception:
+            # 失败路径：标记 failed，保留重试机会（不影响其他分P）
+            try:
+                async with get_db_context() as db:
+                    row = (
+                        await db.execute(
+                            select(Video).where(Video.bvid == bvid, Video.cid == cid)
+                        )
+                    ).scalar_one_or_none()
+                    if row:
+                        row.kg_status = "failed"
+                        await db.commit()
+            except Exception as db_err:
+                logger.error("[KG] failed to mark failed status: {}", db_err)
+            raise
+
+    # ------------------------------------------------------------------
+    # 删除级联 / 统计
+    # ------------------------------------------------------------------
+
+    async def delete_video_data(self, bvid: str) -> dict[str, int]:
+        """视频删除时的图谱级联清理（best-effort，不抛异常）。"""
+        if not neo4j_ok():
+            return {"entities_removed": 0, "videos_removed": 0}
+        try:
+            return await self._graph.delete_video(bvid)
+        except Exception as e:
+            logger.error("[KG] delete cascade failed bvid={}: {}", bvid, e)
+            return {"entities_removed": 0, "videos_removed": 0}
+
+    async def stats(self) -> dict[str, Any]:
+        """图谱统计：Neo4j 计数 + Milvus 实体向量数 + 待抽取分P数。"""
+        result: dict[str, Any] = {
+            "available": self.is_available(),
+            "graph": {"entities": 0, "relations": 0, "evidence": 0, "videos": 0},
+            "entity_vectors": 0,
+            "pending_pages": 0,
+        }
+        if not self.is_available():
+            return result
+        try:
+            result["graph"] = await self._graph.stats()
+        except Exception as e:
+            logger.warning("[KG] graph stats failed: {}", e)
+        index = self._get_entity_index()
+        if index is not None:
+            try:
+                result["entity_vectors"] = await asyncio.to_thread(index.count)
+            except Exception as e:
+                logger.warning("[KG] entity vector stats failed: {}", e)
+        try:
+            from app.database import get_db_context
+            from app.models import Video
+            from sqlalchemy import func
+
+            async with get_db_context() as db:
+                cnt = await db.execute(
+                    select(func.count(Video.id)).where(
+                        Video.is_processed.is_(True),
+                        or_(
+                            Video.kg_version.is_(None),
+                            Video.kg_status == "failed",
+                            Video.kg_version != Video.version,
+                        ),
+                    )
+                )
+                result["pending_pages"] = int(cnt.scalar() or 0)
+        except Exception as e:
+            logger.warning("[KG] pending count failed: {}", e)
+        return result
+
+
+_service: KgService | None = None
+
+
+def get_kg_service() -> KgService:
+    """模块级懒加载单例。"""
+    global _service
+    if _service is None:
+        _service = KgService()
+    return _service

--- a/app/test/kg/test_kg_graph_repository.py
+++ b/app/test/kg/test_kg_graph_repository.py
@@ -1,0 +1,133 @@
+"""KgGraphRepository 集成测试（需真实 Neo4j，未连接自动跳过）。
+
+运行前：docker compose up -d neo4j（或本地 bolt://localhost:7687）。
+"""
+
+import pytest
+import pytest_asyncio
+
+from app.infra import neo4j
+from app.repository.kg_graph_repository import (
+    eid_for_name,
+    get_kg_graph_repository,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _neo4j_ready() -> bool:
+    if not neo4j.is_enabled():
+        try:
+            await neo4j.init()
+        except Exception:
+            return False
+    return neo4j.is_enabled()
+
+
+@pytest_asyncio.fixture
+async def graph_repo():
+    if not await _neo4j_ready():
+        pytest.skip("Neo4j 未连接（docker compose up -d neo4j 启动后重跑）")
+    repo = get_kg_graph_repository()
+    yield repo
+    await repo.clear_all()
+    await neo4j.close()
+
+
+BVID = "BV1kgTest000"
+
+
+class TestEntityUpsert:
+    async def test_merge_idempotent(self, graph_repo):
+        ents = [{"name": "RAG", "type": "tech", "description": "检索增强生成", "quote": ""}]
+        eids1 = await graph_repo.upsert_entities(ents)
+        # 重复 upsert 同名实体：MERGE 幂等，不产生新节点
+        eids2 = await graph_repo.upsert_entities(ents)
+        assert eids1 == eids2 == [eid_for_name("RAG")]
+        stats = await graph_repo.stats()
+        assert stats["entities"] == 1
+
+        rows = await graph_repo.entities_by_eids(eids1)
+        assert rows[0]["type"] == "tech"
+        assert rows[0]["description"] == "检索增强生成"
+
+    async def test_alias_accumulates(self, graph_repo):
+        await graph_repo.upsert_entities(
+            [{"name": "RAG", "alias": "检索增强生成"}]
+        )
+        await graph_repo.upsert_entities([{"name": "RAG", "alias": "Retrieval-Augmented Generation"}])
+        rows = await graph_repo.find_entities_by_names(["检索增强生成"])
+        assert len(rows) == 1 and rows[0]["eid"] == eid_for_name("RAG")
+
+
+class TestEvidenceAndRelations:
+    async def test_appears_in_per_page(self, graph_repo):
+        await graph_repo.upsert_entities([{"name": "RAG", "quote": ""}])
+        eid = eid_for_name("RAG")
+        n1 = await graph_repo.link_appearances(
+            BVID, 0, [{"eid": eid, "quote": "第一页引文，足够长"}]
+        )
+        n2 = await graph_repo.link_appearances(
+            BVID, 1, [{"eid": eid, "quote": "第二页引文，也够长"}]
+        )
+        assert n1 == 1 and n2 == 1
+
+        ev = await graph_repo.fetch_evidence([eid], [BVID], limit=10)
+        assert {e["page_index"] for e in ev} == {0, 1}
+
+        # 作用域过滤：不在范围内的 bvid 查不到
+        ev_other = await graph_repo.fetch_evidence([eid], ["BV9other9999"], limit=10)
+        assert ev_other == []
+
+    async def test_delete_before_write(self, graph_repo):
+        await graph_repo.upsert_entities([{"name": "RAG", "quote": ""}])
+        eid = eid_for_name("RAG")
+        await graph_repo.link_appearances(BVID, 0, [{"eid": eid, "quote": "旧引文，会被替换"}])
+        removed = await graph_repo.delete_page_evidence(BVID, 0)
+        assert removed == 1
+        assert await graph_repo.fetch_evidence([eid], [BVID], limit=10) == []
+
+    async def test_relations_weight_and_quotes(self, graph_repo):
+        await graph_repo.upsert_entities([{"name": "A"}, {"name": "B"}])
+        a, b = eid_for_name("A"), eid_for_name("B")
+        for quote in ("第一次提到的原文证据内容", "第二次提到的原文证据内容"):
+            await graph_repo.upsert_relations(
+                [{"src_eid": a, "dst_eid": b, "rel_type": "依赖于", "quote": quote}]
+            )
+        rels = await graph_repo.relations_among([a, b])
+        assert len(rels) == 1
+        assert rels[0]["weight"] == 2
+        assert len(rels[0]["quotes"]) == 2
+
+    async def test_neighbors_expansion(self, graph_repo):
+        await graph_repo.upsert_entities([{"name": "A"}, {"name": "B"}, {"name": "C"}])
+        a, b, c = eid_for_name("A"), eid_for_name("B"), eid_for_name("C")
+        await graph_repo.upsert_relations(
+            [
+                {"src_eid": a, "dst_eid": b, "rel_type": "讲解了", "quote": "A 讲解了 B 的原文证据"},
+                {"src_eid": b, "dst_eid": c, "rel_type": "依赖于", "quote": "B 依赖于 C 的原文证据"},
+            ]
+        )
+        hop1 = await graph_repo.neighbors([a], exclude_eids=[a], limit=10)
+        assert {r["eid"] for r in hop1} == {b}
+
+    async def test_delete_video_cascade_and_orphans(self, graph_repo):
+        await graph_repo.upsert_entities(
+            [{"name": "孤儿实体", "quote": ""}, {"name": "共享实体", "quote": ""}]
+        )
+        orphan, shared = eid_for_name("孤儿实体"), eid_for_name("共享实体")
+        await graph_repo.link_appearances(BVID, 0, [{"eid": orphan, "quote": ""}])
+        # 「共享」= 同时挂在两个视频上；只挂一个的话删除后即成孤儿被回收
+        await graph_repo.link_appearances(BVID, 0, [{"eid": shared, "quote": ""}])
+        await graph_repo.link_appearances("BV1anchor00000", 0, [{"eid": shared, "quote": ""}])
+        await graph_repo.upsert_entities([{"name": "锚点实体"}])
+        anchor = eid_for_name("锚点实体")
+        await graph_repo.link_appearances("BV1anchor00000", 0, [{"eid": anchor, "quote": ""}])
+
+        result = await graph_repo.delete_video(BVID)
+        assert result["videos_removed"] >= 1
+        # 孤儿实体被回收；仍被其他视频引用的实体保留
+        remaining = await graph_repo.entities_by_eids([orphan, shared, anchor])
+        ids = {r["eid"] for r in remaining}
+        assert orphan not in ids
+        assert shared in ids and anchor in ids

--- a/app/test/kg/test_kg_resolver.py
+++ b/app/test/kg/test_kg_resolver.py
@@ -1,0 +1,121 @@
+"""KG resolver 单测：归一化 / 别名合并 / 防幻觉边校验 / 数量上限。
+
+纯函数测试，不依赖 Neo4j / Milvus / LLM。
+"""
+
+import pytest
+
+from app.repository.kg_graph_repository import eid_for_name, normalize_name
+from app.services.kg.extractor import ExtractedEntity, ExtractedRelation, ExtractionResult
+from app.services.kg.resolver import resolve_extraction
+
+
+def _mk(
+    entities: list[tuple[str, str, str, str]],
+    relations: list[tuple[str, str, str, str]],
+) -> ExtractionResult:
+    return ExtractionResult(
+        entities=[ExtractedEntity(name=n, type=t, description=d, quote=q) for n, t, d, q in entities],
+        relations=[
+            ExtractedRelation(src=s, dst=t2, relation_type=r, quote=q)
+            for s, t2, r, q in relations
+        ],
+    )
+
+
+class TestNormalize:
+    def test_normalize_name(self):
+        assert normalize_name("  RAG  ") == "rag"
+        assert normalize_name("LangChain   框架") == "langchain 框架"
+        assert normalize_name("") == ""
+        assert normalize_name(None) == ""
+
+    def test_eid_deterministic(self):
+        assert eid_for_name("RAG") == eid_for_name(" rag ")
+        assert len(eid_for_name("RAG")) == 16
+        assert eid_for_name("A") != eid_for_name("B")
+
+    def test_entity_type_mapping(self):
+        from app.services.kg.resolver import normalize_entity_type
+
+        assert normalize_entity_type("人物") == "person"
+        assert normalize_entity_type("框架") == "tech"
+        assert normalize_entity_type("工具") == "tool"
+        assert normalize_entity_type("PERSON") == "person"
+        assert normalize_entity_type("不存在的类型") == "other"
+        assert normalize_entity_type("") == "other"
+
+
+class TestResolveExtraction:
+    def test_dedup_and_alias_merge(self):
+        out = resolve_extraction(
+            _mk(
+                [
+                    ("RAG", "技术", "检索增强生成", "q1"),
+                    ("rag ", "", "", ""),  # 归一化后同名 → 合并，描述保留首个非空
+                    ("LangChain", "框架", "框架", "q2"),
+                ],
+                [],
+            )
+        )
+        names = {e["name"] for e in out.entities}
+        assert names == {"RAG", "LangChain"}
+        rag = next(e for e in out.entities if e["name"] == "RAG")
+        assert rag["description"] == "检索增强生成"  # 空描述不清空已有值
+        assert rag["type"] == "tech"
+
+    def test_hallucinated_relations_dropped(self):
+        """防幻觉边核心防线：无引文/短引文/自环全部丢弃。"""
+        out = resolve_extraction(
+            _mk(
+                [("A", "概念", "", ""), ("B", "概念", "", "")],
+                [
+                    ("A", "B", "依赖于", "这是一段足够长的原文证据引文"),  # 合法
+                    ("A", "B", "无证据", ""),  # 空 quote → 弃
+                    ("A", "B", "短引文", "太短"),  # < min_quote_chars → 弃
+                    ("A", "A", "自环", "这是一段足够长的原文证据引文"),  # 自环 → 弃
+                ],
+            )
+        )
+        assert len(out.relations) == 1
+        assert out.relations[0]["rel_type"] == "依赖于"
+        assert out.dropped_relations == 3
+
+    def test_unknown_endpoint_creates_stub(self):
+        """关系端点未在实体列表中时自动创建 stub，保住关系召回。"""
+        out = resolve_extraction(
+            _mk(
+                [("A", "概念", "", "")],
+                [("A", "未知实体XYZ", "提到了", "这是一段足够长的原文证据引文")],
+            )
+        )
+        stubs = [e for e in out.entities if e["name"] == "未知实体XYZ"]
+        assert len(stubs) == 1
+        assert stubs[0]["type"] == "other"
+        rel = out.relations[0]
+        assert rel["dst_eid"] == stubs[0]["eid"]
+
+    def test_relation_dedup_within_batch(self):
+        out = resolve_extraction(
+            _mk(
+                [("A", "", "", ""), ("B", "", "", "")],
+                [
+                    ("A", "B", "使用了", "第一条足够长的原文证据"),
+                    ("A", "B", "使用了", "第二条足够长的原文证据"),
+                ],
+            )
+        )
+        assert len(out.relations) == 1
+        # 权重去重靠 Neo4j MERGE 自增；批内只保留一条
+
+    def test_count_caps(self):
+        ents = [(f"E{i}", "", "", "") for i in range(50)]
+        rels = [(f"E{i}", f"E{i+1}", "关联", "这是一段足够长的原文证据引文") for i in range(49)]
+        out = resolve_extraction(_mk(ents, rels), max_entities=10, max_relations=5)
+        assert len(out.entities) <= 10
+        assert len(out.relations) <= 5
+
+    def test_empty_input(self):
+        out = resolve_extraction(ExtractionResult(entities=[], relations=[]))
+        assert out.entities == []
+        assert out.relations == []

--- a/app/test/kg/test_kg_search_tool.py
+++ b/app/test/kg/test_kg_search_tool.py
@@ -1,0 +1,119 @@
+"""KgSearchTool 门控与降级单测。
+
+不依赖真实 Neo4j/Milvus：不可用时 from_deps 应返回 None（工具不注册），
+run() 失败应返回提示文本而非抛异常（ReAct 循环容错）。
+"""
+
+import sys
+from types import SimpleNamespace
+
+from app.tools._deps import ToolDeps
+from app.tools.chat.kg_search import KgSearchTool
+from app.services.kg.retriever import KgRetrievalResult
+
+
+def _unavailable_kg():
+    """模拟 Neo4j 未连接的 KgService。"""
+    svc = SimpleNamespace()
+    svc.is_available = lambda: False
+
+    class _R:
+        def is_available(self):
+            return False
+
+    retriever = _R()
+
+    async def _retrieve(*a, **kw):
+        raise RuntimeError("neo4j down")
+
+    retriever.retrieve = _retrieve
+    svc.retriever = retriever
+    return svc
+
+
+def _available_kg(content: str, sources: list):
+    """模拟可用的 KgService，retrieve 返回真实 KgRetrievalResult。"""
+    svc = SimpleNamespace()
+    svc.is_available = lambda: True
+
+    class _R:
+        def __init__(self):
+            self.last_call = None
+            self._content = content
+            self._sources = sources
+
+        def is_available(self):
+            return True
+
+        async def retrieve(self, query, bvids=None, k=8):
+            self.last_call = (query, bvids, k)
+            return KgRetrievalResult(
+                content=self._content,
+                sources=self._sources,
+                entity_count=3,
+                evidence_count=5,
+            )
+
+    retriever = _R()
+    svc.retriever = retriever
+    return svc, retriever
+
+
+class TestGating:
+    def test_from_deps_none_when_unavailable(self):
+        assert KgSearchTool.from_deps(ToolDeps(kg=_unavailable_kg())) is None
+
+    def test_from_deps_none_when_missing(self):
+        assert KgSearchTool.from_deps(ToolDeps(kg=None)) is None
+
+    def test_tool_metadata(self):
+        tool = KgSearchTool(_unavailable_kg())
+        assert tool.name == "kg_search"
+        params = tool.parameters()
+        assert params["required"] == ["query"]
+        assert "知识图谱" in tool.description
+
+
+class TestRun:
+    def test_run_degrades_on_failure(self):
+        """Neo4j 故障时 run 返回提示文本，绝不抛异常打断 ReAct 循环。"""
+        import asyncio
+
+        tool = KgSearchTool(_unavailable_kg())
+        out = asyncio.run(tool.run(query="RAG", _bvids=["BV1xx411c7mD"]))
+        assert out["sources"] == []
+        assert out["content"]
+
+    def test_run_passes_scope_and_formats_result(self):
+        import asyncio
+
+        svc, retriever = _available_kg(
+            "实体卡片",
+            [{"title": "T", "score": 0.9, "bvid": "BV1", "url": "u"}],
+        )
+        tool = KgSearchTool(svc)
+        out = asyncio.run(tool.run(query="LangChain 对比", _bvids=["BV1", "BV2"], k=5))
+        assert out == {"content": "实体卡片", "sources": [{"title": "T", "score": 0.9, "bvid": "BV1", "url": "u"}]}
+        # 隐式作用域 bvids 必须传给检索器；k 被透传
+        assert retriever.last_call == ("LangChain 对比", ["BV1", "BV2"], 5)
+
+    def test_run_empty_result_message(self):
+        import asyncio
+
+        svc, _ = _available_kg("", [])
+        tool = KgSearchTool(svc)
+        out = asyncio.run(tool.run(query="不存在的东西"))
+        assert "没有找到" in out["content"]
+        assert out["sources"] == []
+
+    def test_run_k_clamped(self):
+        import asyncio
+
+        svc, retriever = _available_kg("x", [])
+        tool = KgSearchTool(svc)
+        asyncio.run(tool.run(query="q", k=999))
+        assert retriever.last_call[2] <= 20
+
+
+if __name__ == "__main__":
+    sys.exit(__import__("pytest").main([__file__, "-v"]))

--- a/app/tools/_deps.py
+++ b/app/tools/_deps.py
@@ -30,3 +30,4 @@ class ToolDeps:
     db_deps: Any = None
     lifecycle: Any = None
     skill_manager: Any = None
+    kg: Any = None  # Plan 1.0.5: KgService（知识图谱检索/构建）

--- a/app/tools/chat/kg_search.py
+++ b/app/tools/chat/kg_search.py
@@ -1,0 +1,91 @@
+"""KgSearchTool - 知识图谱检索（实体链接 + 子图扩展 + 证据回捞）。
+
+Plan 1.0.5：与 vector_search 输出协议同构 —— 返回
+``{"content": <text>, "sources": [<source dict>]}``，
+sources 经 AgentRuntime 提升进 ToolMessage.additional_kwargs 并最终进入
+SSE sources 帧。依赖不可用时 from_deps 返回 None，工具不注册。
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from app.tools import ToolDeps, register_tool
+
+logger = logging.getLogger(__name__)
+
+
+@register_tool
+class KgSearchTool:
+    """知识图谱语义检索。
+
+    LLM 在遇到「实体关联/多视频聚合/关系路径」类问题时调用；
+    具体内容细节类问题仍应使用 vector_search。
+    """
+
+    def __init__(self, kg_service: Any) -> None:
+        self._kg = kg_service
+
+    @classmethod
+    def from_deps(cls, deps: ToolDeps) -> "KgSearchTool | None":
+        if deps.kg is None:
+            return None
+        try:
+            if not deps.kg.retriever.is_available():
+                return None
+        except Exception:
+            return None
+        return cls(deps.kg)
+
+    @property
+    def name(self) -> str:
+        return "kg_search"
+
+    @property
+    def description(self) -> str:
+        return (
+            "在用户收藏内容的**知识图谱**中检索实体及其关联。"
+            "适合回答「某概念/人物/技术在哪些视频中出现过」「A 和 B 有什么关系/区别"
+            "」「XX 相关的内容有哪些」这类需要跨视频聚合或关系路径的问题。\n"
+            "不适合查具体细节内容（那请用 vector_search）；两者可配合："
+            "先用本工具定位相关视频和实体关系，再用 vector_search 深挖内容。\n"
+            "query 传入具体实体名或概念词，效果最好。"
+        )
+
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "检索词，应为具体实体名或概念（如 'RAG'、'LangChain 和 LlamaIndex 的对比'）",
+                },
+                "k": {
+                    "type": "integer",
+                    "description": "返回实体卡片数量上限，默认8",
+                },
+            },
+            "required": ["query"],
+        }
+
+    async def run(self, *, query: str, k: int = 8, **kwargs: Any) -> dict[str, Any]:
+        """执行图谱检索；失败降级为提示文本（ReAct 循环可改用其他工具）。"""
+        k = min(max(k, 1), 20)
+        # 隐式注入的用户可见范围（与 vector_search 一致）
+        bvids = kwargs.get("_bvids")
+
+        try:
+            result = await self._kg.retriever.retrieve(
+                query, bvids=bvids or [], k=k
+            )
+        except Exception as e:
+            logger.warning("[kg_search] retrieve failed: %s", e, exc_info=True)
+            return {"content": "知识图谱检索暂时不可用。", "sources": []}
+
+        if not result.has_results:
+            return {
+                "content": "知识图谱中没有找到相关实体（可能该主题尚未构建图谱）。",
+                "sources": [],
+            }
+        return {"content": result.content, "sources": result.sources}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,9 @@ services:
       - MILVUS__TOKEN=${MILVUS__TOKEN:-}
       # MongoDB — override via .env for external Mongo
       - MONGO__URI=${MONGO__URI:-mongodb://admin:mind-base@mongo:27017/?authSource=admin}
+      # Knowledge graph (Neo4j) — password shares NEO4J_PASSWORD with the neo4j service
+      - KG__URI=${KG__URI:-bolt://neo4j:7687}
+      - KG__PASSWORD=${NEO4J_PASSWORD:-mind-base}
       # Redis — override via .env for external Redis
       - REDIS__URL=${REDIS__URL:-redis://:mind-base@redis:6379/1}
       # LLM
@@ -294,6 +297,31 @@ services:
     networks:
       - mind-base-net
 
+  # Knowledge graph store (KG feature, plan/1.0.5-KnowledgeGraph).
+  # Optional at runtime: the backend degrades gracefully when it is down or
+  # kg.enabled=false (kg_search tool simply won't register).
+  neo4j:
+    image: neo4j:5-community
+    container_name: mind-base-neo4j
+    profiles: ["", "storage", "full"]
+    ports:
+      - "${NEO4J_HTTP_PORT:-7474}:7474"   # Browser UI (dev/debug only)
+      - "${NEO4J_BOLT_PORT:-7687}:7687"   # Bolt protocol (app connects here)
+    environment:
+      - NEO4J_AUTH=neo4j/${NEO4J_PASSWORD:-mind-base}
+    volumes:
+      - neo4j_data:/data
+      - neo4j_logs:/logs
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:7474 || exit 1"]
+      interval: 15s
+      timeout: 10s
+      retries: 5
+      start_period: 40s
+    networks:
+      - mind-base-net
+
   etcd:
     image: quay.io/coreos/etcd:v3.5.14
     container_name: mind-base-etcd
@@ -486,6 +514,8 @@ volumes:
   mongo_data:
   milvus_data:
   etcd_data:
+  neo4j_data:
+  neo4j_logs:
   minio_data:
   certbot_www:
   nginx_video_cache:

--- a/frontendv2/components/favorites/favorites-view.tsx
+++ b/frontendv2/components/favorites/favorites-view.tsx
@@ -23,6 +23,7 @@ import { favoritesV2Api, type FavoriteFolderV2 } from "@/lib/api/favorites";
 import { knowledgeApi, type BuildStatus, type FolderStatus } from "@/lib/api/knowledge";
 import { cn } from "@/lib/utils";
 import { FolderCard } from "./folder-card";
+import { KgPanel } from "./kg-panel";
 
 type LoadState = "loading" | "ready" | "error";
 
@@ -296,6 +297,9 @@ export function FavoritesView() {
                     />
                 ))}
             </div>
+
+            {/* Knowledge graph panel (Plan 1.0.5) - build scope follows folder selection */}
+            <KgPanel selectedFolderIds={Array.from(selectedIds)} />
 
             {/* Build bar - sticky bottom, slides up when there's a selection or active build */}
             <AnimatePresence>

--- a/frontendv2/components/favorites/kg-panel.tsx
+++ b/frontendv2/components/favorites/kg-panel.tsx
@@ -1,0 +1,338 @@
+"use client";
+
+/**
+ * KgPanel - 知识图谱面板（收藏夹页）。
+ *
+ * 图谱统计（实体/关系/证据/覆盖视频/待抽取分P）+ 构建入口 + 进度轮询。
+ * 设计：plan/1.0.5-KnowledgeGraph/frontend-design.md；后端契约 /knowledge/kg/*。
+ */
+import { useCallback, useEffect, useRef, useState } from "react";
+import { AlertCircle, CheckCircle2, Loader2, Network, X } from "lucide-react";
+import { kgApi, type KgStats } from "@/lib/api";
+import { cn } from "@/lib/utils";
+
+const KG_POLL_INTERVAL_MS = 2000;
+const KG_POLL_MAX_ATTEMPTS = 300; // ~10 min ceiling（KG 抽取慢于向量构建）
+const RESULT_CLEAR_MS = 6000;
+
+type LoadState = "loading" | "ready" | "error";
+
+interface BuildRun {
+    taskId: string;
+    status: string;
+    progress: number;
+    currentStep: string;
+}
+
+interface KgResult {
+    total?: number;
+    ok?: number;
+    failed?: number;
+    message?: string;
+}
+
+export function KgPanel({ selectedFolderIds }: { selectedFolderIds: number[] }) {
+    const [stats, setStats] = useState<KgStats | null>(null);
+    const [loadState, setLoadState] = useState<LoadState>("loading");
+    const [build, setBuild] = useState<BuildRun | null>(null);
+    const [resultMsg, setResultMsg] = useState<string>("");
+    const [error, setError] = useState<string>("");
+    const pollTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const resultTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    const refreshStats = useCallback(async () => {
+        try {
+            setStats(await kgApi.getStats());
+        } catch {
+            // 统计刷新失败不致命，保留旧值
+        }
+    }, []);
+
+    const stopPoll = useCallback(() => {
+        if (pollTimer.current) {
+            clearTimeout(pollTimer.current);
+            pollTimer.current = null;
+        }
+    }, []);
+
+    const pollBuild = useCallback(
+        (taskId: string) => {
+            let attempts = 0;
+            const tick = async () => {
+                attempts += 1;
+                try {
+                    const s = await kgApi.getStatus(taskId);
+                    setBuild({
+                        taskId,
+                        status: s.status,
+                        progress: s.progress,
+                        currentStep: s.current_step,
+                    });
+                    if (s.status === "done" || s.status === "completed") {
+                        setBuild(null);
+                        stopPoll();
+                        const r = (s.result ?? {}) as KgResult;
+                        setResultMsg(
+                            r.message ??
+                                `已抽取 ${r.ok ?? 0} 个分P${r.failed ? `，失败 ${r.failed}` : ""}`,
+                        );
+                        // 结果摘要停留一段时间后自动收起
+                        if (resultTimer.current) clearTimeout(resultTimer.current);
+                        resultTimer.current = setTimeout(() => setResultMsg(""), RESULT_CLEAR_MS);
+                        void refreshStats();
+                        return;
+                    }
+                    if (s.status === "failed") {
+                        setBuild(null);
+                        stopPoll();
+                        setError(s.error || "知识图谱构建失败");
+                        void refreshStats();
+                        return;
+                    }
+                } catch {
+                    // 瞬时网络错误 - 继续轮询直到上限
+                }
+                if (attempts >= KG_POLL_MAX_ATTEMPTS) {
+                    setBuild(null);
+                    stopPoll();
+                    setError("跟踪超时，请稍后刷新查看结果");
+                    return;
+                }
+                pollTimer.current = setTimeout(tick, KG_POLL_INTERVAL_MS);
+            };
+            void tick();
+        },
+        [refreshStats, stopPoll]
+    );
+
+    const init = useCallback(async () => {
+        setLoadState("loading");
+        setError("");
+        try {
+            const [statsRes, activeRes] = await Promise.allSettled([
+                kgApi.getStats(),
+                kgApi.getActiveTask(),
+            ]);
+            if (statsRes.status === "rejected") throw statsRes.reason;
+            setStats(statsRes.value);
+            setLoadState("ready");
+            if (
+                statsRes.value.available &&
+                activeRes.status === "fulfilled" &&
+                activeRes.value.task_id
+            ) {
+                // 刷新页面后恢复对活跃任务的跟踪
+                const taskId = activeRes.value.task_id;
+                setBuild({ taskId, status: "pending", progress: 0, currentStep: "" });
+                pollBuild(taskId);
+            }
+        } catch {
+            setLoadState("error");
+        }
+    }, [pollBuild]);
+
+    useEffect(() => {
+        // Mount-time data fetch (external-system sync, not derived state).
+        // eslint-disable-next-line react-hooks/set-state-in-effect
+        void init();
+        const pollTimerRef = pollTimer;
+        const resultTimerRef = resultTimer;
+        return () => {
+            if (pollTimerRef.current) clearTimeout(pollTimerRef.current);
+            if (resultTimerRef.current) clearTimeout(resultTimerRef.current);
+        };
+    }, [init]);
+
+    const handleBuild = useCallback(async () => {
+        if (build) return;
+        setError("");
+        setResultMsg("");
+        if (resultTimer.current) clearTimeout(resultTimer.current);
+        setBuild({ taskId: "", status: "pending", progress: 0, currentStep: "提交构建任务…" });
+        try {
+            const res = await kgApi.build(selectedFolderIds);
+            setBuild({ taskId: res.task_id, status: "pending", progress: 0, currentStep: "" });
+            pollBuild(res.task_id);
+        } catch (e) {
+            setBuild(null);
+            setError(e instanceof Error ? e.message : "发起知识图谱构建失败");
+        }
+    }, [build, selectedFolderIds, pollBuild]);
+
+    const cancelTracking = useCallback(() => {
+        stopPoll();
+        setBuild(null);
+    }, [stopPoll]);
+
+    // ───────────────────────────────────────────────
+    // Render
+    // ───────────────────────────────────────────────
+    if (loadState === "loading") {
+        return (
+            <section className="mt-8">
+                <div className="h-28 animate-pulse rounded-2xl bg-border-subtle" />
+            </section>
+        );
+    }
+
+    if (loadState === "error") {
+        return (
+            <section className="mt-8">
+                <div className="flex flex-col items-center rounded-2xl border border-border-subtle py-8 text-center">
+                    <AlertCircle className="h-5 w-5 text-danger" />
+                    <p className="mt-2 text-[13px] text-secondary">知识图谱状态加载失败</p>
+                    <button type="button" onClick={() => void init()} className="btn-pill btn-ghost mt-3 h-8 px-4 text-[12px]">
+                        重试
+                    </button>
+                </div>
+            </section>
+        );
+    }
+
+    const available = stats?.available ?? false;
+    const graph = stats?.graph;
+    const building = build !== null;
+    const scopeNote =
+        selectedFolderIds.length > 0
+            ? `作用域：所选 ${selectedFolderIds.length} 个收藏夹`
+            : "作用域：全部收藏夹";
+
+    return (
+        <section className="mt-8">
+            <div className="rounded-2xl border border-border-subtle bg-surface p-5">
+                <div className="flex items-start justify-between gap-3">
+                    <div className="flex items-center gap-2.5">
+                        <span className="grid h-9 w-9 place-items-center rounded-full bg-accent-soft text-accent">
+                            <Network className="h-4 w-4" />
+                        </span>
+                        <div>
+                            <h2 className="text-[15px] font-semibold text-foreground">知识图谱</h2>
+                            <p className="mt-0.5 text-[12px] text-secondary">
+                                从视频文字稿抽取实体与关系，问答时可检索实体关联
+                            </p>
+                        </div>
+                    </div>
+                    {!available && (
+                        <span className="shrink-0 rounded-full bg-border-subtle px-2.5 py-1 text-[11px] text-secondary">
+                            Neo4j 未连接
+                        </span>
+                    )}
+                </div>
+
+                {error && (
+                    <div className="mt-4 flex items-center gap-2 rounded-xl border border-danger/20 bg-danger/5 px-3.5 py-2.5 text-[12px] text-danger">
+                        <AlertCircle className="h-3.5 w-3.5 shrink-0" />
+                        <span className="flex-1">{error}</span>
+                        <button
+                            type="button"
+                            onClick={() => setError("")}
+                            className="text-danger/70 hover:text-danger"
+                        >
+                            <X className="h-3.5 w-3.5" />
+                        </button>
+                    </div>
+                )}
+
+                {resultMsg && !building && (
+                    <div className="mt-4 flex items-center gap-2 rounded-xl border border-success/20 bg-success/5 px-3.5 py-2.5 text-[12px] text-success">
+                        <CheckCircle2 className="h-3.5 w-3.5 shrink-0" />
+                        <span className="flex-1">{resultMsg}</span>
+                        <button
+                            type="button"
+                            onClick={() => {
+                                if (resultTimer.current) clearTimeout(resultTimer.current);
+                                setResultMsg("");
+                            }}
+                            className="text-success/70 hover:text-success"
+                        >
+                            <X className="h-3.5 w-3.5" />
+                        </button>
+                    </div>
+                )}
+
+                {building && build ? (
+                    <KgProgress build={build} onCancel={cancelTracking} />
+                ) : available && graph ? (
+                    <>
+                        <div className="mt-4 grid grid-cols-4 gap-3">
+                            <StatCell label="实体" value={graph.entities} />
+                            <StatCell label="关系" value={graph.relations} />
+                            <StatCell label="证据" value={graph.evidence} />
+                            <StatCell label="视频" value={graph.videos} />
+                        </div>
+                        {(stats?.pending_pages ?? 0) > 0 && (
+                            <p className="mt-3 text-[11px] text-secondary">
+                                {stats?.pending_pages} 个分P 待抽取 / 需更新
+                            </p>
+                        )}
+                        <div className="mt-4 flex items-center justify-between gap-3 border-t border-border-subtle pt-4">
+                            <p className="truncate text-[11px] text-secondary">{scopeNote}</p>
+                            <button
+                                type="button"
+                                disabled={!available}
+                                onClick={() => void handleBuild()}
+                                className="btn-pill btn-primary h-8 shrink-0 px-4 text-[12px] disabled:opacity-50"
+                            >
+                                <Network className="h-3.5 w-3.5" />
+                                构建知识图谱
+                            </button>
+                        </div>
+                    </>
+                ) : (
+                    <p className="mt-4 text-[12px] text-secondary">
+                        知识图谱存储不可用（Neo4j 未连接），无法构建或查询。
+                    </p>
+                )}
+            </div>
+        </section>
+    );
+}
+
+// ══════════════════════════════════════════════════════════════
+// Sub-components
+// ══════════════════════════════════════════════════════════════
+
+function StatCell({ label, value }: { label: string; value: number }) {
+    return (
+        <div className="rounded-xl bg-surface-elevated px-3 py-2.5 text-center">
+            <p className="text-[18px] font-semibold tabular-nums leading-tight text-foreground">
+                {value.toLocaleString()}
+            </p>
+            <p className="mt-0.5 text-[11px] text-secondary">{label}</p>
+        </div>
+    );
+}
+
+function KgProgress({ build, onCancel }: { build: BuildRun; onCancel: () => void }) {
+    const pct = Math.max(0, Math.min(100, build.progress));
+    return (
+        <div className="mt-4">
+            <div className="flex items-center gap-2.5">
+                <Loader2 className="h-4 w-4 animate-spin text-accent" />
+                <div className="min-w-0 flex-1">
+                    <p className="truncate text-[13px] font-medium text-foreground">
+                        {build.currentStep || "知识图谱构建中…"}
+                    </p>
+                    <p className="text-[11px] text-secondary">正在抽取实体与关系</p>
+                </div>
+                <span className="text-[12px] font-medium tabular-nums text-secondary">{pct}%</span>
+                <button
+                    type="button"
+                    onClick={onCancel}
+                    className="grid h-7 w-7 place-items-center rounded-full text-secondary transition-colors hover:bg-border-subtle hover:text-foreground"
+                    title="不再跟踪"
+                >
+                    <X className="h-3.5 w-3.5" />
+                </button>
+            </div>
+            <div className="mt-2.5 h-1.5 w-full overflow-hidden rounded-full bg-border-subtle">
+                <div
+                    className={cn(
+                        "h-full rounded-full bg-accent transition-[width] duration-500 ease-out"
+                    )}
+                    style={{ width: `${pct}%` }}
+                />
+            </div>
+        </div>
+    );
+}

--- a/frontendv2/lib/api/index.ts
+++ b/frontendv2/lib/api/index.ts
@@ -15,6 +15,7 @@ export { API_BASE_URL } from "./client";
 export * from "./auth";
 export * from "./favorites";
 export * from "./knowledge";
+export * from "./kg";
 export * from "./chat";
 export * from "./session-summary";
 export * from "./code-executions";

--- a/frontendv2/lib/api/kg.ts
+++ b/frontendv2/lib/api/kg.ts
@@ -1,0 +1,66 @@
+/**
+ * Knowledge Graph API - 知识图谱构建 / 统计（Plan 1.0.5）.
+ *
+ * 后端契约见 app/routers/knowledge.py 的 KG 段；前端设计见 plan/1.0.5-KnowledgeGraph/frontend-design.md.
+ */
+import { request } from "./client";
+
+export type KgTaskStatus =
+    | "pending"
+    | "processing"
+    | "running"
+    | "done"
+    | "completed"
+    | "failed";
+
+export interface KgGraphStats {
+    entities: number;
+    relations: number;
+    evidence: number;
+    videos: number;
+}
+
+export interface KgStats {
+    available: boolean;
+    graph: KgGraphStats;
+    entity_vectors: number;
+    pending_pages: number;
+}
+
+export interface KgBuildStart {
+    task_id: string;
+    reused: boolean;
+}
+
+export interface KgActiveTask {
+    task_id: string | null;
+}
+
+export interface KgBuildStatus {
+    task_id: string;
+    status: KgTaskStatus;
+    progress: number;
+    current_step: string;
+    /** 完成时 {total, ok, failed} 或 {total: 0, message}；进行中为 {} */
+    result: Record<string, unknown>;
+    error: string;
+}
+
+export const kgApi = {
+    // 图谱统计（Neo4j 计数 + 待抽取分P数）
+    getStats: () => request<KgStats>("/knowledge/kg/stats"),
+
+    // 触发构建（folder_ids 为空数组 = 用户全部收藏夹）；已有活跃任务时复用其 task_id
+    build: (folderIds: number[]) =>
+        request<KgBuildStart>("/knowledge/kg/build", {
+            method: "POST",
+            body: JSON.stringify({ folder_ids: folderIds }),
+        }),
+
+    // 探测活跃任务（刷新页面后恢复轮询）
+    getActiveTask: () => request<KgActiveTask>("/knowledge/kg/active"),
+
+    // 轮询构建状态
+    getStatus: (taskId: string) =>
+        request<KgBuildStatus>(`/knowledge/kg/status/${taskId}`),
+};

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,6 +37,7 @@ PyYAML>=6.0
 motor>=3.6
 redis[hiredis]>=5.0
 pymilvus>=2.4.0
+neo4j>=5.0
 matplotlib>=3.7
 datasets>=2.14
 ragas>=0.1


### PR DESCRIPTION
## 概要

落地 Plan 1.0.5 知识图谱：从 ASR 转写稿抽取实体/关系写入 Neo4j，chat agent 经 `kg_search` 工具获得跨视频实体关联检索能力；前端（frontendv2）收藏夹页新增图谱面板。

### 后端（[kg]）
- **基础设施**：Neo4j 异步客户端，连接失败自动降级（不阻塞主链路）
- **构建管道** `KgService`：收藏夹圈定已转写分P → 并发抽取 → 幂等落库
  - 幂等：`video.kg_version` 记录内容版本，未变更自动跳过；重抽前 delete-before-write 清旧证据边
  - 防幻觉：LLM 结构化输出强制携带原文引文 quote，resolver 校验最小引文长度 / 类型白名单 / 去自环 / 端点解析
  - 失败隔离：单分P失败置 failed 可重试，不影响其他分P
- **查询链路** `KgRetriever`：Milvus 实体链接（种子实体）→ Neo4j BFS 子图扩展 → APPEARS_IN 证据回捞（按用户 bvids 作用域过滤）
- **Agent 接入**：chat agent 注册 `kg_search` 工具 + prompt 决策树注入（Neo4j 可用时）
- **API**：`POST /knowledge/kg/build`、`GET /knowledge/kg/active`、`GET /knowledge/kg/status/{task_id}`、`GET /knowledge/kg/stats`
- **部署**：compose 内置 neo4j 服务（storage/full profile）；requirements / .env.example / default.yaml 同步

### 前端（[frontend]）
- `lib/api/kg.ts`：kgApi 四端点封装
- `KgPanel` 组件：统计四格（实体/关系/证据/视频）、构建触发（作用域跟随勾选收藏夹）、2s 进度轮询、刷新后活跃任务恢复跟踪、Neo4j 不可用降级态

### 文档（[docs]）
- README 补充 KG 模块说明、API 概览、FAQ

### Lint 修复
- 清理未使用变量与导入（ruff F841/F401），CI 门禁恢复绿色

## 测试

- [x] `app/test/kg/` 单测（resolver / graph repository / search tool），Neo4j 未连接自动 skip
- [x] frontendv2 `npm run lint`（kg 相关文件零告警）+ `npm run build` 通过
- [x] `ruff check app/ --ignore E501,E402` 通过，CI 全绿（lint ×3 / type-check ×3 / build）
- [x] docker compose 端到端：构建图谱 → 收藏夹页查看进度与统计 → 对话验证 kg_search 生效
