### PR TITLE
[blindspot] feat: 知识盲区地图 + 图谱可视化（Plan 1.0.6）

### DIFF
--- a/app/agent/quiz/prompts.py
+++ b/app/agent/quiz/prompts.py
@@ -16,6 +16,11 @@ QUIZ_BATCH_SYSTEM_PROMPT = """你是一个专业的习题出题专家。你的�
 - short_answer: 必须填写 keywords(3~5个关键词)、answer_template(30-100字参考答案)、explanation
 - essay: 必须填写 model_answer(参考答案)、scoring_rubric(分步骤评分标准，每项含 step/points/keywords)、explanation
 
+related_entities 规范：
+- 填写本题实际考查的 0~3 个核心概念/实体名（如 "RAG"、"Milvus"）
+- 必须使用知识片段中出现的原文叫法；片段没有具体概念时留空数组
+- 只填名词性概念，不要填动词短语或完整句子
+
 必须通过工具调用返回结构化结果，不要省略当前题型的必填字段。"""
 
 QUIZ_BATCH_USER_PROMPT = """基于以下 {chunk_count} 个知识片段，生成 {total_count} 道题。

--- a/app/agent/quiz/schemas.py
+++ b/app/agent/quiz/schemas.py
@@ -14,6 +14,10 @@ class BaseQuizQuestionOutput(BaseModel):
     source_chunk_index: int = Field(ge=0)
     question: str = Field(min_length=1, max_length=300)
     explanation: str = Field(min_length=1, max_length=500)
+    # Plan 1.0.6 blind-spot attribution: core concepts the question tests
+    # (picked from the source chunk). Empty list is valid; downstream
+    # attribution links questions to KG entities via these names.
+    related_entities: list[str] = Field(default_factory=list, max_length=5)
 
 
 class SingleChoiceQuestionOutput(BaseQuizQuestionOutput):

--- a/app/main.py
+++ b/app/main.py
@@ -34,6 +34,7 @@ if settings.langsmith_endpoint:
 from app.database import init_db
 from app.routers import auth, favorites_v2, knowledge, chat, settings as settings_router
 from app.routers.asr import router as asr_router
+from app.routers.blindspot import router as blindspot_router
 from app.routers.vector_page import router as vector_page_router
 from app.routers.credentials import router as credentials_router
 from app.routers.billing import router as billing_router
@@ -496,6 +497,7 @@ except Exception as e:
 app.include_router(auth.router)
 app.include_router(favorites_v2.router)
 app.include_router(knowledge.router)
+app.include_router(blindspot_router)
 app.include_router(chat.router)
 app.include_router(settings_router.router)
 app.include_router(asr_router)

--- a/app/repository/kg_graph_repository.py
+++ b/app/repository/kg_graph_repository.py
@@ -315,22 +315,95 @@ class KgGraphRepository:
         async with neo4j.session() as s:
             return await neo4j.run(s, cypher, names=cleaned, limit=limit)
 
+    async def entity_exposure(
+        self, bvids: list[str], limit: int = 500
+    ) -> list[dict[str, Any]]:
+        """Blind-spot map exposure aggregation (Plan 1.0.6): APPEARS_IN page
+        count per entity within scope.
+
+        Returns head entities sorted by pages desc; each item carries up to 5
+        evidence samples for review-path rendering. Empty bvids returns [] --
+        callers must ensure a non-empty scope (different semantics from
+        fetch_evidence where empty means "no filter").
+        """
+        if not bvids:
+            return []
+        cypher = """
+        MATCH (e:Entity)-[ev:APPEARS_IN]->(v:Video)
+        WHERE v.bvid IN $bvids
+        WITH e, count(ev) AS pages,
+             collect({bvid: v.bvid, page_index: ev.page_index, quote: ev.quote})[..5]
+             AS evidence_sample
+        RETURN e.eid AS eid, e.name AS name, e.type AS type,
+               e.description AS description,
+               pages, evidence_sample
+        ORDER BY pages DESC
+        LIMIT $limit
+        """
+        async with neo4j.session() as s:
+            return await neo4j.run(s, cypher, bvids=bvids, limit=limit)
+
+    async def entity_appearances(
+        self, eid: str, bvids: list[str], limit: int = 50
+    ) -> list[dict[str, Any]]:
+        """All appearances of one entity (entity-detail review path)."""
+        cypher = """
+        MATCH (e:Entity {eid: $eid})-[ev:APPEARS_IN]->(v:Video)
+        WHERE size($bvids) = 0 OR v.bvid IN $bvids
+        RETURN v.bvid AS bvid, ev.page_index AS page_index,
+               ev.quote AS quote
+        ORDER BY v.bvid, ev.page_index
+        LIMIT $limit
+        """
+        async with neo4j.session() as s:
+            return await neo4j.run(
+                s, cypher, eid=eid, bvids=bvids or [], limit=limit
+            )
+
+    async def top_entities(self, limit: int = 80) -> list[dict[str, Any]]:
+        """Head entities ranked by RELATES degree (graph overview mode)."""
+        cypher = """
+        MATCH (e:Entity)-[r:RELATES]-()
+        RETURN e.eid AS eid, e.name AS name, e.type AS type,
+               e.description AS description, count(r) AS degree
+        ORDER BY degree DESC
+        LIMIT $limit
+        """
+        async with neo4j.session() as s:
+            return await neo4j.run(s, cypher, limit=limit)
+
+    async def edges_among(self, eids: list[str]) -> list[dict[str, Any]]:
+        """Directed relation edges inside an entity set (undirected dedup is
+        the caller's job)."""
+        if len(eids) < 2:
+            return []
+        cypher = """
+        UNWIND $eids AS eid
+        MATCH (a:Entity {eid: eid})-[r:RELATES]->(b:Entity)
+        WHERE b.eid IN $eids
+        RETURN DISTINCT a.eid AS src_eid, b.eid AS dst_eid,
+               r.rel_type AS rel_type
+        """
+        async with neo4j.session() as s:
+            return await neo4j.run(s, cypher, eids=eids)
+
     # ------------------------------------------------------------------
     # 统计 / 运维
     # ------------------------------------------------------------------
 
     async def stats(self) -> dict[str, int]:
+        # CALL () { ... }: Neo4j 5.23+ requires the scope clause; bare CALL {} is deprecated
         cypher = """
-        CALL {
+        CALL () {
             MATCH (e:Entity) RETURN count(e) AS entities
         }
-        CALL {
+        CALL () {
             MATCH ()-[r:RELATES]->() RETURN count(r) AS relations
         }
-        CALL {
+        CALL () {
             MATCH ()-[a:APPEARS_IN]->() RETURN count(a) as evidence
         }
-        CALL {
+        CALL () {
             MATCH (v:Video) RETURN count(v) AS videos
         }
         RETURN entities, relations, evidence, videos

--- a/app/repository/mongo_chat_repository.py
+++ b/app/repository/mongo_chat_repository.py
@@ -156,6 +156,24 @@ async def get_messages_for_user(
     )
 
 
+async def recent_user_texts_for_user(uid: int, limit: int = 300) -> list[str]:
+    """Blind-spot map probed signal (Plan 1.0.6): the latest N user message
+    texts, newest first.
+
+    Best-effort: returns [] when Mongo is disabled.
+    """
+    if not is_enabled():
+        return []
+    cursor = (
+        coll(COLLECTION)
+        .find({"uid": uid, "role": "user"}, {"content": 1, "_id": 0})
+        .sort("created_at", -1)
+        .limit(limit)
+    )
+    rows = await cursor.to_list(length=limit)
+    return [r["content"] for r in rows if r.get("content")]
+
+
 async def _get_messages_by_query(
     query: dict[str, Any],
     *,

--- a/app/repository/mongo_quiz_repository.py
+++ b/app/repository/mongo_quiz_repository.py
@@ -55,6 +55,7 @@ async def insert_questions(
         _correct = q.get("correct_answer")
         _keywords = q.get("keywords")
         _rubric = q.get("scoring_rubric")
+        _related = q.get("related_entities")  # Plan 1.0.6 blind-spot attribution tags
 
         docs.append(
             {
@@ -88,6 +89,11 @@ async def insert_questions(
                 "bvid": q.get("bvid"),
                 "source_segment": q.get("source_segment"),
                 "chunk_id": str(q.get("source_chunk_index", "")),
+                "related_entities": (
+                    json.dumps(_related)
+                    if _related is not None and not isinstance(_related, str)
+                    else (_related or json.dumps([]))
+                ),
                 "is_valid": True,
                 "created_at": _now(),
             }
@@ -167,6 +173,45 @@ async def count_questions(quiz_uuid: str) -> int:
     return await coll(COLLECTION).count_documents(
         {"quiz_uuid": quiz_uuid, "is_valid": True}
     )
+
+
+async def get_question_attributions(quiz_uuids: list[str]) -> list[dict]:
+    """Blind-spot map (Plan 1.0.6): batch-read question entity attributions.
+
+    Returns [{question_uuid, quiz_uuid, related_entities(list), question_text}].
+    Empty related_entities means the caller can fall back to vector attribution
+    on question_text.
+    """
+    if not quiz_uuids or not is_enabled():
+        return []
+    cursor = coll(COLLECTION).find(
+        {"quiz_uuid": {"$in": list(quiz_uuids)}, "is_valid": True},
+        {
+            "question_uuid": 1,
+            "quiz_uuid": 1,
+            "related_entities": 1,
+            "question_text": 1,
+            "_id": 0,
+        },
+    )
+    results = await cursor.to_list(length=1000)
+    out: list[dict] = []
+    for r in results:
+        raw = r.get("related_entities")
+        if isinstance(raw, str):
+            try:
+                raw = json.loads(raw)
+            except (TypeError, ValueError):
+                raw = []
+        out.append(
+            {
+                "question_uuid": r.get("question_uuid", ""),
+                "quiz_uuid": r.get("quiz_uuid", ""),
+                "related_entities": raw if isinstance(raw, list) else [],
+                "question_text": r.get("question_text", ""),
+            }
+        )
+    return out
 
 
 async def delete_by_quiz(

--- a/app/routers/blindspot.py
+++ b/app/routers/blindspot.py
@@ -1,0 +1,155 @@
+"""Knowledge blind-spot map routes (Plan 1.0.6).
+
+Param parsing + auth + delegation to BlindspotService / the existing quiz
+pipeline. No business logic here.
+"""
+
+import logging
+from typing import Optional
+
+from fastapi import APIRouter, BackgroundTasks, Body, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
+
+from app.routers.auth import get_current_uid
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/blindspot", tags=["知识盲区"])
+
+
+def _parse_folder_ids(folder_ids: Optional[str]) -> list[int]:
+    """Comma-separated folder IDs -> list[int] (same rule as /quiz/generate)."""
+    if not folder_ids:
+        return []
+    out: list[int] = []
+    for part in folder_ids.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        try:
+            out.append(int(part))
+        except ValueError:
+            raise HTTPException(400, f"非法的 folder_id: {part}")
+    return out
+
+
+@router.get("/map")
+async def blindspot_map(
+    folder_ids: Optional[str] = Query(None, description="comma-separated folder IDs"),
+    uid: int = Depends(get_current_uid),
+):
+    """Five-quadrant entity map (exposure/verification/probing signals).
+
+    available=false when Neo4j is down; quadrants are empty without synced
+    videos.
+    """
+    from app.services.blindspot import get_blindspot_service
+
+    service = get_blindspot_service()
+    try:
+        return await service.map(uid=uid, folder_ids=_parse_folder_ids(folder_ids))
+    except Exception as e:
+        logger.warning("[BLINDSPOT] map failed uid=%s: %s", uid, e)
+        raise HTTPException(500, "盲区地图加载失败，请稍后重试")
+
+
+@router.get("/entity/{eid}")
+async def blindspot_entity(eid: str, uid: int = Depends(get_current_uid)):
+    """Entity detail: review path (evidence quotes) + quiz stats."""
+    if not eid or len(eid) > 128:
+        raise HTTPException(400, "非法实体 ID")
+    from app.services.blindspot import get_blindspot_service
+
+    service = get_blindspot_service()
+    try:
+        detail = await service.entity_detail(uid=uid, eid=eid)
+    except Exception as e:
+        logger.warning("[BLINDSPOT] entity detail failed eid=%s: %s", eid, e)
+        raise HTTPException(500, "实体详情加载失败，请稍后重试")
+    if detail is None:
+        raise HTTPException(404, "实体不存在或图谱不可用")
+    return detail
+
+
+class EntityQuizRequest(BaseModel):
+    question_count: int = Field(default=5, ge=1, le=20)
+    difficulty: str = Field(default="medium", pattern="^(easy|medium|hard)$")
+
+
+@router.post("/{eid}/quiz")
+async def generate_entity_quiz(
+    eid: str,
+    req: EntityQuizRequest = Body(default=EntityQuizRequest()),
+    uid: int = Depends(get_current_uid),
+    background_tasks: BackgroundTasks = BackgroundTasks(),
+):
+    """One-click quiz generation targeting a weak entity.
+
+    Uses the entity's APPEARS_IN pages as source_pages and runs the exact
+    same pipeline as POST /quiz/generate
+    (preflight -> quota -> create row -> background generation).
+    Frontend polls GET /quiz/{quiz_uuid} with the returned quiz_uuid.
+    """
+    if not eid or len(eid) > 128:
+        raise HTTPException(400, "非法实体 ID")
+
+    from app.services.blindspot import get_blindspot_service
+
+    resolved = await get_blindspot_service().entity_quiz_pages(
+        uid=uid, eid=eid, question_count=req.question_count
+    )
+    if resolved is None:
+        raise HTTPException(404, "实体不存在或图谱不可用")
+    pages = resolved["pages"]
+    if not pages:
+        raise HTTPException(400, resolved.get("message") or "该实体无可出题的视频出处")
+
+    # ---- Same flow as routers/quiz.py generate_quiz (pages mode) ----
+    from app.services.quiz_preflight import preflight_check
+
+    preflight = await preflight_check(pages=pages, question_count=req.question_count)
+    if not preflight.ok:
+        raise HTTPException(400, preflight.reason)
+
+    from app.services.llm.quiz_quota import (
+        QuizQuotaExceeded,
+        check_and_consume,
+        check_quota,
+    )
+
+    try:
+        await check_quota(uid, "generate")
+    except QuizQuotaExceeded as e:
+        raise HTTPException(429, f"今日出题次数已达上限（{e.limit} 次/天）")
+
+    from app.services.quiz_generator import QuizGeneratorService
+    from app.services.quiz_queue import enqueue_generation
+
+    entity_name = (resolved.get("entity") or {}).get("name", "")
+    title = f"薄弱点特训 · {entity_name}"[:200]
+
+    service = QuizGeneratorService()
+    quiz_uuid = await service.create_quiz_set(
+        uid=uid,
+        pages=pages,
+        question_count=req.question_count,
+        difficulty=req.difficulty,
+        title=title,
+    )
+
+    try:
+        await check_and_consume(uid, "generate")
+    except QuizQuotaExceeded:
+        logger.warning("[BLINDSPOT] quota race after row creation quiz_uuid=%s", quiz_uuid)
+
+    enqueue_generation(
+        background_tasks,
+        quiz_uuid=quiz_uuid,
+        uid=uid,
+        folder_ids=None,
+        pages=pages,
+        question_count=req.question_count,
+        difficulty=req.difficulty,
+        title=title,
+    )
+    return {"quiz_uuid": quiz_uuid, "status": "generating", "title": title}

--- a/app/routers/knowledge.py
+++ b/app/routers/knowledge.py
@@ -10,7 +10,7 @@ import re
 from datetime import datetime
 from typing import List, Optional
 
-from fastapi import APIRouter, HTTPException, Depends
+from fastapi import APIRouter, HTTPException, Depends, Query
 from loguru import logger
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -414,6 +414,24 @@ async def get_kg_stats(uid: int = Depends(get_current_uid)):
 
     try:
         return await get_kg_service().stats()
+    except Exception as e:
+        raise internal_error(e)
+
+
+@router.get("/kg/subgraph")
+async def get_kg_subgraph(
+    center: Optional[str] = Query(None, max_length=64, description="center entity eid"),
+    depth: int = Query(2, ge=1, le=3, description="BFS hops (center mode)"),
+    max_nodes: int = Query(80, ge=5, le=200, description="node cap"),
+    uid: int = Depends(get_current_uid),
+):
+    """Visualization subgraph: overview without center; BFS expansion with one."""
+    from app.services.kg import get_kg_service
+
+    try:
+        return await get_kg_service().subgraph(
+            center_eid=center, depth=depth, max_nodes=max_nodes
+        )
     except Exception as e:
         raise internal_error(e)
 

--- a/app/services/blindspot/__init__.py
+++ b/app/services/blindspot/__init__.py
@@ -1,0 +1,16 @@
+"""Knowledge blind-spot map service package (Plan 1.0.6).
+
+Aggregates four learning signals per KG entity:
+- Exposure: Neo4j APPEARS_IN evidence edges
+- Verification: MySQL quiz_answers / quiz_submissions + Mongo question
+  entity tags
+- Probing: recent user messages from Mongo chat_messages
+- (P2 planned) Consolidation: notes
+
+Read-only side path; never touches ASR/vectorization/KG build pipelines.
+Degrades gracefully when any dependency is missing.
+"""
+
+from app.services.blindspot.service import BlindspotService, get_blindspot_service
+
+__all__ = ["BlindspotService", "get_blindspot_service"]

--- a/app/services/blindspot/attribution.py
+++ b/app/services/blindspot/attribution.py
@@ -1,0 +1,48 @@
+"""Question-text -> entity attribution fallback (Plan 1.0.6, scheme B).
+
+New questions are tagged at generation time via LLM structured output
+(`related_entities`, scheme A — see quiz schemas/prompts). Legacy questions
+without tags get attributed here: the question text is embedded and matched
+against the Milvus entity index (KgEntityIndex), same linking source as
+kg_search but with a more conservative threshold.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from loguru import logger
+
+# Tighter than retrieval-time entity linking (config.kg.link_score_threshold):
+# a wrong attribution costs more than a missed one (it would charge quiz
+# mistakes to an unrelated concept). Kept as a constant on purpose.
+ATTRIBUTION_SCORE_THRESHOLD = 0.75
+_MAX_TEXT_CHARS = 500
+
+
+class EntityAttributor:
+    """Question attributor backed by KgEntityIndex. None index -> always []."""
+
+    def __init__(self, index: Any | None):
+        self._index = index
+
+    @property
+    def available(self) -> bool:
+        return self._index is not None
+
+    async def attribute(self, question_text: str, top_n: int = 3) -> list[str]:
+        """Entity names linked from the question text (threshold-filtered)."""
+        if self._index is None or not question_text.strip():
+            return []
+        text = question_text[:_MAX_TEXT_CHARS]
+        try:
+            hits = await asyncio.to_thread(self._index.search, text, top_n)
+        except Exception as e:
+            logger.warning("[BLINDSPOT] entity attribution search failed: {}", e)
+            return []
+        return [
+            h["name"]
+            for h in hits
+            if h.get("name") and h.get("score", 0.0) >= ATTRIBUTION_SCORE_THRESHOLD
+        ]

--- a/app/services/blindspot/scoring.py
+++ b/app/services/blindspot/scoring.py
@@ -1,0 +1,49 @@
+"""Blind-spot map scoring pure functions (Plan 1.0.6).
+
+No DB / LLM / network dependencies; unit-testable in isolation.
+Quadrant rules: plan/1.0.6-BlindSpotMap/1.0.6-BlindSpotMap.md section 4.
+"""
+
+from __future__ import annotations
+
+# Quadrant constants (public contract; frontend groups by these)
+QUADRANT_DANGER = "danger"  # high exposure + many wrong answers: review first
+QUADRANT_BLIND = "blind"  # seen often, never verified, never asked: false confidence
+QUADRANT_LEARNING = "learning"  # user actively probed it: aware of the gap
+QUADRANT_FAMILIAR = "familiar"  # verified with a high correct rate
+QUADRANT_UNEXPLORED = "unexplored"  # passed by once, not really engaged
+
+QUADRANTS = (
+    QUADRANT_DANGER,
+    QUADRANT_BLIND,
+    QUADRANT_LEARNING,
+    QUADRANT_FAMILIAR,
+    QUADRANT_UNEXPLORED,
+)
+
+# Correct rate >= this threshold counts as mastered (when quiz data exists)
+FAMILIAR_RATE_THRESHOLD = 0.7
+# Exposure >= this and never verified -> blind (a single pass is unexplored)
+BLIND_MIN_EXPOSURE = 2
+
+
+def classify(
+    *, exposure: int, quiz_total: int, correct_rate: float | None, probed: bool
+) -> str:
+    """Four signals -> one of five quadrants. None rate means no quiz data."""
+    if quiz_total > 0:
+        rate = correct_rate if correct_rate is not None else 0.0
+        return QUADRANT_FAMILIAR if rate >= FAMILIAR_RATE_THRESHOLD else QUADRANT_DANGER
+    if probed:
+        return QUADRANT_LEARNING
+    if exposure >= BLIND_MIN_EXPOSURE:
+        return QUADRANT_BLIND
+    if exposure >= 1:
+        return QUADRANT_UNEXPLORED
+    return QUADRANT_UNEXPLORED
+
+
+def priority(exposure: int, quiz_correct: int, quiz_wrong: int) -> int:
+    """Intra-quadrant rank: wider exposure and more mistakes rank higher;
+    correct answers offset. Result is non-negative."""
+    return max(0, exposure + 3 * quiz_wrong - quiz_correct)

--- a/app/services/blindspot/service.py
+++ b/app/services/blindspot/service.py
@@ -1,0 +1,440 @@
+"""BlindspotService - knowledge blind-spot map aggregation (Plan 1.0.6).
+
+Read-only side service: aggregates learning signals (exposure / verification
+/ probing) per KG entity into quadrant profiles. Writes no business data.
+If Neo4j / MySQL / Mongo is missing, the corresponding signal degrades to
+empty; with Neo4j entirely down the map reports available=False (the graph
+is the skeleton of the map — without it there is nothing to show).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from loguru import logger
+from sqlalchemy import select
+
+from app.infra.neo4j import is_enabled as neo4j_ok
+from app.repository.kg_graph_repository import (
+    get_kg_graph_repository,
+    normalize_name,
+)
+
+# Recent user messages scanned for the probed signal (guards full scans)
+_PROBED_SCAN_LIMIT = 300
+# Entity cap for the map response (head of the exposure ranking)
+_MAX_ENTITIES = 500
+
+
+class BlindspotService:
+    """Blind-spot map: overview + entity detail + quiz scope resolution."""
+
+    def __init__(self) -> None:
+        self._graph = get_kg_graph_repository()
+
+    # ------------------------------------------------------------------
+    # Availability
+    # ------------------------------------------------------------------
+
+    def is_available(self) -> bool:
+        return neo4j_ok()
+
+    # ------------------------------------------------------------------
+    # Overview map
+    # ------------------------------------------------------------------
+
+    async def map(self, uid: int, folder_ids: list[int] | None = None) -> dict[str, Any]:
+        """Aggregate signals and return the five-quadrant entity lists."""
+        empty = {
+            "available": self.is_available(),
+            "scope_bvids": 0,
+            "quadrants": {q: [] for q in (
+                "danger",
+                "blind",
+                "learning",
+                "familiar",
+                "unexplored",
+            )},
+            "stats": {},
+        }
+        if not self.is_available():
+            return empty
+
+        bvids = await self._resolve_bvids(uid, folder_ids)
+        if not bvids:
+            return empty
+        empty["scope_bvids"] = len(bvids)
+
+        rows = await self._graph.entity_exposure(bvids, limit=_MAX_ENTITIES)
+        if not rows:
+            return empty
+
+        quiz_by_name = await self._quiz_signals(uid, rows)
+        probed_names = await self._probed_names(uid, rows)
+
+        from app.services.blindspot.scoring import QUADRANTS, classify, priority
+
+        grouped: dict[str, list[dict[str, Any]]] = {q: [] for q in QUADRANTS}
+        counts: dict[str, int] = {q: 0 for q in QUADRANTS}
+
+        for row in rows:
+            name_key = normalize_name(row.get("name", ""))
+            sig = quiz_by_name.get(name_key) or {"total": 0, "correct": 0, "wrong": 0}
+            total = sig["total"]
+            correct = sig["correct"]
+            wrong = sig["wrong"]
+            rate = (correct / total) if total > 0 else None
+            quadrant = classify(
+                exposure=int(row.get("pages", 0)),
+                quiz_total=total,
+                correct_rate=rate,
+                probed=name_key in probed_names,
+            )
+            item = {
+                "eid": row.get("eid", ""),
+                "name": row.get("name", ""),
+                "type": row.get("type", ""),
+                "description": row.get("description") or "",
+                "exposure": int(row.get("pages", 0)),
+                "evidence_sample": row.get("evidence_sample") or [],
+                "quiz_total": total,
+                "quiz_correct": correct,
+                "quiz_wrong": wrong,
+                "probed": name_key in probed_names,
+                "priority": priority(
+                    int(row.get("pages", 0)), correct, wrong
+                ),
+            }
+            grouped[quadrant].append(item)
+            counts[quadrant] += 1
+
+        for items in grouped.values():
+            items.sort(key=lambda x: (-x["priority"], -x["exposure"], x["name"]))
+
+        return {
+            "available": True,
+            "scope_bvids": len(bvids),
+            "quadrants": grouped,
+            "stats": {
+                "total_entities": sum(counts.values()),
+                **counts,
+            },
+        }
+
+    # ------------------------------------------------------------------
+    # Entity detail
+    # ------------------------------------------------------------------
+
+    async def entity_detail(
+        self, uid: int, eid: str
+    ) -> dict[str, Any] | None:
+        """Single entity: base info + review path (titled appearances) + quiz stats."""
+        if not self.is_available():
+            return None
+        base = await self._graph.entities_by_eids([eid])
+        if not base:
+            return None
+        ent = base[0]
+
+        bvids = await self._resolve_bvids(uid, None)
+        appearances = await self._graph.entity_appearances(eid, bvids)
+        titles = await self._page_titles(
+            [(a["bvid"], int(a.get("page_index") or 0)) for a in appearances]
+        )
+
+        path = [
+            {
+                "bvid": a["bvid"],
+                "page_index": int(a.get("page_index") or 0),
+                "quote": (a.get("quote") or "").strip(),
+                "title": titles.get((a["bvid"], int(a.get("page_index") or 0)), a["bvid"]),
+            }
+            for a in appearances
+        ]
+
+        quiz_by_name = await self._quiz_signals(uid, [ent])
+        sig = quiz_by_name.get(normalize_name(ent.get("name", ""))) or {
+            "total": 0,
+            "correct": 0,
+            "wrong": 0,
+        }
+
+        return {
+            "eid": ent.get("eid", ""),
+            "name": ent.get("name", ""),
+            "type": ent.get("type", ""),
+            "description": ent.get("description") or "",
+            "exposure": len(path),
+            "review_path": path,
+            "quiz_total": sig["total"],
+            "quiz_correct": sig["correct"],
+            "quiz_wrong": sig["wrong"],
+        }
+
+    # ------------------------------------------------------------------
+    # Quiz scope resolution (router drives the existing quiz pipeline)
+    # ------------------------------------------------------------------
+
+    async def entity_quiz_pages(
+        self, uid: int, eid: str, question_count: int
+    ) -> dict[str, Any] | None:
+        """Entity -> source pages shaped like QuizSet.source_pages.
+
+        Returns None when the entity does not exist; pages=[] means the entity
+        has no appearance within the user's scope.
+        """
+        if not self.is_available():
+            return None
+        base = await self._graph.entities_by_eids([eid])
+        if not base:
+            return None
+
+        bvids = await self._resolve_bvids(uid, None)
+        appearances = await self._graph.entity_appearances(eid, bvids)
+        if not appearances:
+            return {
+                "entity": base[0],
+                "pages": [],
+                "message": "该实体在你的收藏范围内没有视频出处，无法出题",
+            }
+
+        cid_map = await self._cid_pages(sorted({a["bvid"] for a in appearances}))
+        titles = await self._page_titles(list(cid_map.keys()))
+
+        pages = []
+        for a in appearances:
+            key = (a["bvid"], int(a.get("page_index") or 0))
+            meta = cid_map.get(key)
+            if meta is None:
+                continue
+            pages.append(
+                {
+                    "bvid": a["bvid"],
+                    "cid": meta["cid"],
+                    "page_index": key[1],
+                    "page_title": meta["page_title"]
+                    or titles.get(key, f"P{key[1] + 1}"),
+                }
+            )
+        # Trim pages above ~2x question count so retrieval is not diluted
+        pages = pages[: max(question_count * 2, question_count)]
+        return {"entity": base[0], "pages": pages, "message": ""}
+
+    # ------------------------------------------------------------------
+    # Signal collection internals
+    # ------------------------------------------------------------------
+
+    async def _resolve_bvids(
+        self, uid: int, folder_ids: list[int] | None
+    ) -> list[str]:
+        """Folder scope resolution (reuses chat scope helpers; pure DB reads)."""
+        from app.database import get_db_context
+        from app.services.chat.scope import (
+            get_bvids_by_media_ids,
+            get_media_ids_for_uid,
+        )
+
+        try:
+            async with get_db_context() as db:
+                media_ids = await get_media_ids_for_uid(db, uid, folder_ids or None)
+                if not media_ids:
+                    return []
+                return await get_bvids_by_media_ids(db, media_ids)
+        except Exception as e:
+            logger.warning("[BLINDSPOT] scope resolve failed uid={}: {}", uid, e)
+            return []
+
+    async def _quiz_signals(
+        self, uid: int, entity_rows: list[dict[str, Any]]
+    ) -> dict[str, dict[str, int]]:
+        """Merge quiz answers per entity name via normalize_name keys.
+
+        Chain: MySQL submissions -> answer details -> Mongo question tags
+        (scheme A); untagged legacy questions fall back to Milvus attribution
+        (scheme B). Any broken hop only loses that signal.
+        """
+        out: dict[str, dict[str, int]] = {}
+        try:
+            sub_quiz = await self._user_submissions(uid)
+            if not sub_quiz:
+                return out
+
+            answers = await self._submission_answers(list(sub_quiz.keys()))
+            if not answers:
+                return out
+
+            quiz_uuids = sorted(set(sub_quiz.values()))
+            from app.repository import mongo_quiz_repository as mongo_quiz
+
+            attrs = {
+                a["question_uuid"]: a
+                for a in await mongo_quiz.get_question_attributions(quiz_uuids)
+            }
+
+            attributor = self._get_attributor()
+            for ans in answers:
+                attr = attrs.get(ans["question_uuid"])
+                names: list[str] = []
+                if attr is not None and attr["related_entities"]:
+                    names = attr["related_entities"]
+                elif attributor.available and attr is not None:
+                    names = await attributor.attribute(attr["question_text"])
+                for n in names:
+                    slot = out.setdefault(
+                        normalize_name(n), {"total": 0, "correct": 0, "wrong": 0}
+                    )
+                    slot["total"] += 1
+                    if ans["is_correct"]:
+                        slot["correct"] += 1
+                    else:
+                        slot["wrong"] += 1
+        except Exception as e:
+            logger.warning("[BLINDSPOT] quiz signal aggregation failed: {}", e)
+        return out
+
+    @staticmethod
+    async def _user_submissions(uid: int) -> dict[str, str]:
+        """uid -> {submission_uuid: quiz_uuid}."""
+        from app.database import get_db_context
+        from app.models import QuizSubmission
+
+        async with get_db_context() as db:
+            rows = await db.execute(
+                select(
+                    QuizSubmission.submission_uuid, QuizSubmission.quiz_uuid
+                ).where(QuizSubmission.uid == uid)
+            )
+            return {r[0]: r[1] for r in rows.fetchall() if r[0]}
+
+    @staticmethod
+    async def _submission_answers(
+        submission_uuids: list[str],
+    ) -> list[dict[str, Any]]:
+        from app.database import get_db_context
+        from app.models import QuizAnswer
+
+        chunk_size = 200
+        results: list[dict[str, Any]] = []
+        async with get_db_context() as db:
+            for i in range(0, len(submission_uuids), chunk_size):
+                chunk = submission_uuids[i : i + chunk_size]
+                rows = await db.execute(
+                    select(
+                        QuizAnswer.question_uuid,
+                        QuizAnswer.submission_uuid,
+                        QuizAnswer.is_correct,
+                    ).where(QuizAnswer.submission_uuid.in_(chunk))
+                )
+                for q_uuid, s_uuid, ok in rows.fetchall():
+                    results.append(
+                        {
+                            "question_uuid": q_uuid,
+                            "submission_uuid": s_uuid,
+                            "is_correct": bool(ok),
+                        }
+                    )
+        return results
+
+    def _get_attributor(self) -> Any:
+        """Lazily build the attributor (available=False without Milvus index)."""
+        from app.services.blindspot.attribution import EntityAttributor
+
+        try:
+            from app.services.rag import get_rag_service
+            from app.repository.kg_entity_index import KgEntityIndex
+
+            rag = get_rag_service()
+            if rag.embeddings is None:
+                return EntityAttributor(None)
+            return EntityAttributor(KgEntityIndex(rag.embeddings))
+        except Exception as e:
+            logger.warning("[BLINDSPOT] attributor unavailable: {}", e)
+            return EntityAttributor(None)
+
+    @staticmethod
+    async def _probed_names(
+        uid: int, entity_rows: list[dict[str, Any]]
+    ) -> set[str]:
+        """Entity names appearing in recent user messages (normalized), best-effort."""
+        try:
+            from app.repository import mongo_chat_repository as mongo_chat
+
+            texts = await mongo_chat.recent_user_texts_for_user(
+                uid, limit=_PROBED_SCAN_LIMIT
+            )
+            if not texts:
+                return set()
+            blob = " ".join(t.lower() for t in texts)
+            return {
+                normalize_name(r.get("name", ""))
+                for r in entity_rows
+                if r.get("name")
+                and normalize_name(r["name"]) in blob
+            }
+        except Exception as e:
+            logger.warning("[BLINDSPOT] probed signal failed: {}", e)
+            return set()
+
+    @staticmethod
+    async def _page_titles(keys: list[tuple[str, int]]) -> dict[tuple[str, int], str]:
+        """(bvid, page_index) -> page title, used by review-path rendering."""
+        if not keys:
+            return {}
+        bvid_list = sorted({b for b, _ in keys})
+        from sqlalchemy import select
+
+        from app.database import get_db_context
+        from app.models import Video
+
+        mapping: dict[tuple[str, int], str] = {}
+        try:
+            async with get_db_context() as db:
+                rows = await db.execute(
+                    select(Video.bvid, Video.page_index, Video.page_title).where(
+                        Video.bvid.in_(bvid_list)
+                    )
+                )
+                for bvid, page_index, page_title in rows.fetchall():
+                    mapping[(bvid, int(page_index))] = (
+                        page_title or f"P{page_index + 1}"
+                    )
+        except Exception as e:
+            logger.warning("[BLINDSPOT] title lookup failed: {}", e)
+        return mapping
+
+    @staticmethod
+    async def _cid_pages(bvids: list[str]) -> dict[tuple[str, int], dict[str, Any]]:
+        """(bvid, page_index) -> {cid, page_title} (source_pages need cid)."""
+        if not bvids:
+            return {}
+        from sqlalchemy import select
+
+        from app.database import get_db_context
+        from app.models import Video
+
+        mapping: dict[tuple[str, int], dict[str, Any]] = {}
+        try:
+            async with get_db_context() as db:
+                rows = await db.execute(
+                    select(Video.bvid, Video.cid, Video.page_index, Video.page_title)
+                    .where(Video.bvid.in_(bvids))
+                    .where(Video.is_processed.is_(True))
+                )
+                for bvid, cid, page_index, page_title in rows.fetchall():
+                    mapping[(bvid, int(page_index))] = {
+                        "cid": cid,
+                        "page_title": page_title or "",
+                    }
+        except Exception as e:
+            logger.warning("[BLINDSPOT] cid lookup failed: {}", e)
+        return mapping
+
+
+_service: BlindspotService | None = None
+
+
+def get_blindspot_service() -> BlindspotService:
+    global _service
+    if _service is None:
+        _service = BlindspotService()
+    return _service

--- a/app/services/kg/service.py
+++ b/app/services/kg/service.py
@@ -380,6 +380,117 @@ class KgService:
     # 删除级联 / 统计
     # ------------------------------------------------------------------
 
+    # ------------------------------------------------------------------
+    # Graph visualization subgraph (added in Plan 1.0.6)
+    # ------------------------------------------------------------------
+
+    async def subgraph(
+        self,
+        center_eid: str | None = None,
+        depth: int = 2,
+        max_nodes: int = 80,
+    ) -> dict[str, Any]:
+        """Visualization subgraph. Without center: overview (head entities +
+        their internal edges); with center: BFS expansion.
+
+        Returns {available, center, nodes: [{eid,name,type,description,degree}],
+        edges: [{src,dst,rel_type}]}.
+        """
+        if not self.is_available():
+            return {"available": False, "center": None, "nodes": [], "edges": []}
+        if center_eid:
+            return await self._subgraph_centered(center_eid, depth, max_nodes)
+        return await self._subgraph_overview(max_nodes)
+
+    async def _subgraph_overview(self, max_nodes: int) -> dict[str, Any]:
+        tops = await self._graph.top_entities(limit=max_nodes)
+        if not tops:
+            return {"available": True, "center": None, "nodes": [], "edges": []}
+        eids = [t["eid"] for t in tops]
+        rows = await self._graph.edges_among(eids)
+        nodes = [
+            {
+                "eid": t["eid"],
+                "name": t["name"],
+                "type": t.get("type") or "other",
+                "description": t.get("description") or "",
+                "degree": 0,
+            }
+            for t in tops
+        ]
+        edges = [
+            {
+                "src": r["src_eid"],
+                "dst": r["dst_eid"],
+                "rel_type": r.get("rel_type") or "关联",
+            }
+            for r in rows
+        ]
+        return self._finalize_subgraph(None, nodes, edges)
+
+    async def _subgraph_centered(
+        self, center_eid: str, depth: int, max_nodes: int
+    ) -> dict[str, Any]:
+        base = await self._graph.entities_by_eids([center_eid])
+        if not base:
+            return {"available": True, "center": None, "nodes": [], "edges": []}
+
+        node_info: dict[str, dict[str, Any]] = {
+            center_eid: {
+                "eid": center_eid,
+                "name": base[0].get("name", ""),
+                "type": base[0].get("type") or "other",
+                "description": base[0].get("description") or "",
+                "degree": 0,
+            }
+        }
+        edge_set: set[tuple[str, str, str]] = set()
+        visited = {center_eid}
+        frontier = [center_eid]
+
+        for _ in range(max(depth, 0)):
+            if not frontier or len(visited) >= max_nodes:
+                break
+            rows = await self._graph.neighbors(frontier, list(visited), limit=max_nodes)
+            next_frontier: list[str] = []
+            for r in rows:
+                pair_key = tuple(sorted((r["from_eid"], r["eid"]))) + (
+                    (r.get("rel_type") or "关联"),
+                )
+                edge_set.add(pair_key)
+                if r["eid"] not in visited and len(visited) < max_nodes:
+                    visited.add(r["eid"])
+                    node_info[r["eid"]] = {
+                        "eid": r["eid"],
+                        "name": r.get("name", ""),
+                        "type": r.get("type") or "other",
+                        "description": r.get("description") or "",
+                        "degree": 0,
+                    }
+                    next_frontier.append(r["eid"])
+            frontier = next_frontier
+
+        nodes = list(node_info.values())
+        edges = [
+            {"src": s, "dst": d, "rel_type": rt} for s, d, rt in edge_set
+        ]
+        return self._finalize_subgraph(center_eid, nodes, edges)
+
+    @staticmethod
+    def _finalize_subgraph(
+        center: str | None, nodes: list[dict[str, Any]], edges: list[dict[str, Any]]
+    ) -> dict[str, Any]:
+        """Overwrite node degrees with in-subgraph connection counts (drives
+        frontend node sizing)."""
+        degree: dict[str, int] = {}
+        for e in edges:
+            degree[e["src"]] = degree.get(e["src"], 0) + 1
+            degree[e["dst"]] = degree.get(e["dst"], 0) + 1
+        for n in nodes:
+            n["degree"] = degree.get(n["eid"], 0)
+        nodes.sort(key=lambda x: -x["degree"])
+        return {"available": True, "center": center, "nodes": nodes, "edges": edges}
+
     async def delete_video_data(self, bvid: str) -> dict[str, int]:
         """视频删除时的图谱级联清理（best-effort，不抛异常）。"""
         if not neo4j_ok():

--- a/app/test/blindspot/test_scoring.py
+++ b/app/test/blindspot/test_scoring.py
@@ -1,0 +1,123 @@
+"""Blind-spot map scoring pure-function tests (Plan 1.0.6). No DB/network."""
+
+import pytest
+
+from app.services.blindspot.attribution import EntityAttributor
+from app.services.blindspot.scoring import (
+    BLIND_MIN_EXPOSURE,
+    FAMILIAR_RATE_THRESHOLD,
+    QUADRANT_BLIND,
+    QUADRANT_DANGER,
+    QUADRANT_FAMILIAR,
+    QUADRANT_LEARNING,
+    QUADRANT_UNEXPLORED,
+    classify,
+    priority,
+)
+
+
+class TestClassify:
+    def test_high_correct_rate_is_familiar(self):
+        assert (
+            classify(exposure=5, quiz_total=10, correct_rate=0.9, probed=False)
+            == QUADRANT_FAMILIAR
+        )
+
+    def test_rate_exactly_at_threshold_is_familiar(self):
+        assert (
+            classify(
+                exposure=3, quiz_total=10, correct_rate=FAMILIAR_RATE_THRESHOLD,
+                probed=False,
+            )
+            == QUADRANT_FAMILIAR
+        )
+
+    def test_low_correct_rate_is_danger(self):
+        assert (
+            classify(exposure=4, quiz_total=6, correct_rate=0.33, probed=False)
+            == QUADRANT_DANGER
+        )
+
+    def test_all_wrong_is_danger(self):
+        assert (
+            classify(exposure=1, quiz_total=2, correct_rate=0.0, probed=True)
+            == QUADRANT_DANGER
+        )
+
+    def test_quiz_data_overrides_probed_signal(self):
+        # Verification data overrides the probing signal
+        assert (
+            classify(exposure=2, quiz_total=1, correct_rate=0.0, probed=True)
+            == QUADRANT_DANGER
+        )
+
+    def test_probed_without_quiz_is_learning(self):
+        assert (
+            classify(exposure=5, quiz_total=0, correct_rate=None, probed=True)
+            == QUADRANT_LEARNING
+        )
+
+    def test_multi_exposure_unverified_is_blind(self):
+        assert (
+            classify(
+                exposure=BLIND_MIN_EXPOSURE, quiz_total=0, correct_rate=None,
+                probed=False,
+            )
+            == QUADRANT_BLIND
+        )
+
+    def test_single_exposure_unverified_is_unexplored(self):
+        assert (
+            classify(exposure=1, quiz_total=0, correct_rate=None, probed=False)
+            == QUADRANT_UNEXPLORED
+        )
+
+    def test_zero_everything_is_unexplored(self):
+        assert (
+            classify(exposure=0, quiz_total=0, correct_rate=None, probed=False)
+            == QUADRANT_UNEXPLORED
+        )
+
+
+class TestPriority:
+    def test_wrong_outweighs_correct(self):
+        # one wrong answer (3 pts) outweighs one correct answer (1 pt)
+        assert priority(0, quiz_correct=1, quiz_wrong=1) == 2
+        assert priority(0, quiz_correct=2, quiz_wrong=1) == 1
+
+    def test_never_negative(self):
+        assert priority(0, quiz_correct=10, quiz_wrong=0) == 0
+
+    def test_exposure_adds_base_priority(self):
+        assert priority(5, quiz_correct=0, quiz_wrong=0) == 5
+
+
+class TestEntityAttributor:
+    @pytest.mark.asyncio
+    async def test_no_index_returns_empty(self):
+        attributor = EntityAttributor(None)
+        assert attributor.available is False
+        assert await attributor.attribute("什么是 RAG") == []
+
+    @pytest.mark.asyncio
+    async def test_threshold_filters_low_score_hits(self):
+        class FakeIndex:
+            def search(self, text, top_n=3):
+                return [
+                    {"eid": "1", "name": "RAG", "score": 0.9},
+                    {"eid": "2", "name": "Milvus", "score": 0.5},
+                    {"eid": "3", "name": "", "score": 0.99},
+                ]
+
+        attributor = EntityAttributor(FakeIndex())
+        names = await attributor.attribute("RAG 检索增强的原理")
+        assert names == ["RAG"]
+
+    @pytest.mark.asyncio
+    async def test_blank_text_short_circuits(self):
+        class ExplodingIndex:
+            def search(self, *_a, **_k):  # pragma: no cover
+                raise AssertionError("should not be called")
+
+        attributor = EntityAttributor(ExplodingIndex())
+        assert await attributor.attribute("   ") == []

--- a/frontendv2/app/blindspot/page.tsx
+++ b/frontendv2/app/blindspot/page.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { NavBar } from "@/components/nav-bar";
+import { BlindspotView } from "@/components/blindspot/blindspot-view";
+
+/**
+ * Blindspot page - a nav destination, so it KEEPS the top NavBar.
+ * Layout mirrors other nav pages: NavBar + centered content shell.
+ */
+export default function BlindspotPage() {
+    return (
+        <>
+            <NavBar />
+            <main className="flex-1">
+                <BlindspotView />
+            </main>
+        </>
+    );
+}

--- a/frontendv2/app/graph/page.tsx
+++ b/frontendv2/app/graph/page.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { use } from "react";
+import { NavBar } from "@/components/nav-bar";
+import { GraphView } from "@/components/kg/graph-view";
+
+/**
+ * Knowledge graph visualization page - a nav destination, so it KEEPS the
+ * top NavBar. `?center=<eid>` deep-link centers the graph on that entity
+ * (e.g. from the blindspot map).
+ */
+export default function GraphPage({
+    searchParams,
+}: {
+    searchParams: Promise<{ center?: string }>;
+}) {
+    const { center } = use(searchParams);
+    return (
+        <>
+            <NavBar />
+            <main className="flex-1">
+                <GraphView initialCenter={center} />
+            </main>
+        </>
+    );
+}

--- a/frontendv2/components/blindspot/blindspot-view.tsx
+++ b/frontendv2/components/blindspot/blindspot-view.tsx
@@ -1,0 +1,310 @@
+"use client";
+
+/**
+ * BlindspotView - knowledge blind-spot map view (Plan 1.0.6).
+ *
+ * Five-quadrant entity list: danger/blind first; cards expand into a
+ * review path (evidence quotes + pages) with one-click targeted quiz.
+ */
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { AlertCircle, CheckCircle2, Compass, RefreshCw, Target } from "lucide-react";
+import {
+    blindspotApi,
+    QUADRANT_LABELS,
+    type Quadrant,
+} from "@/lib/api";
+import { cn } from "@/lib/utils";
+import { EntityCard } from "./entity-card";
+
+type LoadState = "loading" | "ready" | "error";
+
+const QUADRANT_ORDER: Quadrant[] = [
+    "danger",
+    "blind",
+    "learning",
+    "familiar",
+    "unexplored",
+];
+
+const QUADRANT_DESC: Record<Quadrant, string> = {
+    danger: "反复出现却反复答错，最优先复习",
+    blind: "见过多次、从未验证、也没问过 —— 自以为懂了",
+    learning: "你主动追问过，正在补",
+    familiar: "有验证且正确率达标",
+    unexplored: "只路过一次，还没真正接触",
+};
+
+const QUADRANT_ACCENT: Record<Quadrant, string> = {
+    danger: "text-danger bg-danger/8 border-danger/25",
+    blind: "text-amber-600 bg-amber-500/8 border-amber-500/25",
+    learning: "text-accent bg-accent-soft border-accent/25",
+    familiar: "text-success bg-success/8 border-success/25",
+    unexplored: "text-secondary bg-border-subtle border-border-subtle",
+};
+
+export function BlindspotView() {
+    const [state, setState] = useState<LoadState>("loading");
+    const [loadError, setLoadError] = useState("");
+    const [map, setMap] = useState<Awaited<ReturnType<typeof blindspotApi.getMap>> | null>(null);
+    const [activeQuadrant, setActiveQuadrant] = useState<Quadrant>("danger");
+    const [expandedEid, setExpandedEid] = useState<string | null>(null);
+    const [generatingEid, setGeneratingEid] = useState<string | null>(null);
+    const [quizStarted, setQuizStarted] = useState<{ title: string } | null>(null);
+
+    const load = useCallback(async () => {
+        setState("loading");
+        setLoadError("");
+        try {
+            const m = await blindspotApi.getMap();
+            setMap(m);
+            const firstNonEmpty =
+                QUADRANT_ORDER.find((q) => (m.quadrants[q]?.length ?? 0) > 0) ?? "danger";
+            setActiveQuadrant(firstNonEmpty);
+            setState("ready");
+        } catch (e) {
+            setLoadError(e instanceof Error ? e.message : "盲区地图加载失败");
+            setState("error");
+        }
+    }, []);
+
+    useEffect(() => {
+        // eslint-disable-next-line react-hooks/set-state-in-effect
+        void load();
+    }, [load]);
+
+    const handleGenerateQuiz = useCallback(
+        async (eid: string) => {
+            if (generatingEid) return;
+            setGeneratingEid(eid);
+            try {
+                const res = await blindspotApi.generateQuiz(eid, 5, "medium");
+                setQuizStarted({ title: res.title });
+                setExpandedEid(null);
+            } catch (e) {
+                setLoadError(e instanceof Error ? e.message : "发起出题失败");
+            } finally {
+                setGeneratingEid(null);
+            }
+        },
+        [generatingEid],
+    );
+
+    const entities = useMemo(() => map?.quadrants[activeQuadrant] ?? [], [map, activeQuadrant]);
+
+    if (state === "loading") {
+        return (
+            <Shell>
+                <Header onRefresh={() => {}} refreshing={false} />
+                <div className="space-y-3">
+                    {Array.from({ length: 4 }).map((_, i) => (
+                        <div key={i} className="h-20 animate-pulse rounded-2xl bg-border-subtle" />
+                    ))}
+                </div>
+            </Shell>
+        );
+    }
+
+    if (state === "error") {
+        return (
+            <Shell>
+                <Header onRefresh={() => void load()} refreshing={false} />
+                {loadError && (
+                    <Banner tone="danger" text={loadError} onClose={() => setLoadError("")} />
+                )}
+                <div className="flex flex-col items-center rounded-2xl border border-border-subtle py-16 text-center">
+                    <AlertCircle className="h-7 w-7 text-danger" />
+                    <p className="mt-3 text-[14px] text-foreground">{loadError}</p>
+                    <button
+                        type="button"
+                        onClick={() => void load()}
+                        className="btn-pill btn-primary mt-5 h-9 px-5 text-[13px]"
+                    >
+                        重试
+                    </button>
+                </div>
+            </Shell>
+        );
+    }
+
+    if (!map) return null;
+
+    return (
+        <Shell>
+            <Header onRefresh={() => void load()} refreshing={false} />
+
+            {quizStarted && (
+                <div className="mb-4 flex items-center gap-2 rounded-xl border border-success/20 bg-success/5 px-3.5 py-2.5 text-[12px] text-success">
+                    <CheckCircle2 className="h-3.5 w-3.5 shrink-0" />
+                    <span className="flex-1">
+                        已创建练习「{quizStarted.title}」，正在生成题目，前往{" "}
+                        <a href="/quiz" className="underline underline-offset-2">题目练习</a> 查看
+                    </span>
+                    <button
+                        type="button"
+                        onClick={() => setQuizStarted(null)}
+                        className="text-success/70 hover:text-success"
+                        aria-label="关闭"
+                    >
+                        ×
+                    </button>
+                </div>
+            )}
+
+            {!map.available && (
+                <EmptyCard
+                    icon={<Compass className="h-5 w-5" />}
+                    title="知识图谱不可用"
+                    hint="盲区地图基于知识图谱。请确认 Neo4j 已连接并完成一次图谱构建。"
+                />
+            )}
+
+            {map.available && map.stats.total_entities === 0 && (
+                <EmptyCard
+                    icon={<Target className="h-5 w-5" />}
+                    title="暂无图谱数据"
+                    hint="先在收藏夹页同步视频并构建知识库与知识图谱，这里就会生成你的专属盲区地图。"
+                    action={
+                        <a href="/favorites" className="btn-pill btn-primary mt-6 inline-flex h-9 items-center px-5 text-[13px]">
+                            去收藏夹构建
+                        </a>
+                    }
+                />
+            )}
+
+            {map.available && map.stats.total_entities > 0 && (
+                <>
+                    <div className="flex flex-wrap gap-2">
+                        {QUADRANT_ORDER.map((q) => {
+                            const count = map.stats[q] ?? 0;
+                            const active = q === activeQuadrant;
+                            return (
+                                <button
+                                    key={q}
+                                    type="button"
+                                    onClick={() => {
+                                        setActiveQuadrant(q);
+                                        setExpandedEid(null);
+                                    }}
+                                    className={cn(
+                                        "rounded-full border px-3.5 py-1.5 text-[12px] font-medium transition-colors",
+                                        active
+                                            ? QUADRANT_ACCENT[q]
+                                            : "border-border-subtle text-secondary hover:bg-border-subtle",
+                                    )}
+                                >
+                                    {QUADRANT_LABELS[q]} · {count}
+                                </button>
+                            );
+                        })}
+                    </div>
+
+                    <p className="mt-3 text-[12px] text-secondary">{QUADRANT_DESC[activeQuadrant]}</p>
+
+                    {entities.length === 0 ? (
+                        <p className="mt-10 text-center text-[13px] text-secondary">
+                            该象限暂时没有实体
+                        </p>
+                    ) : (
+                        <div className="mt-4 space-y-2.5">
+                            {entities.map((ent) => (
+                                <EntityCard
+                                    key={ent.eid}
+                                    entity={ent}
+                                    expanded={expandedEid === ent.eid}
+                                    generating={generatingEid === ent.eid}
+                                    anyGenerating={generatingEid !== null}
+                                    onToggle={() =>
+                                        setExpandedEid(expandedEid === ent.eid ? null : ent.eid)
+                                    }
+                                    onGenerateQuiz={() => void handleGenerateQuiz(ent.eid)}
+                                />
+                            ))}
+                        </div>
+                    )}
+                </>
+            )}
+        </Shell>
+    );
+}
+
+function Shell({ children }: { children: React.ReactNode }) {
+    return <div className="mx-auto max-w-[860px] px-5 py-8 pb-24">{children}</div>;
+}
+
+function Header({ onRefresh, refreshing }: { onRefresh: () => void; refreshing: boolean }) {
+    return (
+        <div className="mb-6 flex items-end justify-between">
+            <div>
+                <h1 className="text-[26px] font-semibold tracking-tight text-foreground">知识盲区</h1>
+                <p className="mt-0.5 text-[13px] text-secondary">
+                    聚合你的曝光、答题与追问记录，找出自以为懂了的概念
+                </p>
+            </div>
+            <button
+                type="button"
+                disabled={refreshing}
+                onClick={onRefresh}
+                title="刷新"
+                className="grid h-8 w-8 place-items-center rounded-full text-secondary transition-colors hover:bg-border-subtle hover:text-foreground disabled:opacity-50"
+            >
+                <RefreshCw className={cn("h-4 w-4", refreshing && "animate-spin")} />
+            </button>
+        </div>
+    );
+}
+
+function Banner({
+    tone,
+    text,
+    onClose,
+}: {
+    tone: "danger" | "success";
+    text: string;
+    onClose: () => void;
+}) {
+    const cls =
+        tone === "danger"
+            ? "border-danger/20 bg-danger/5 text-danger"
+            : "border-success/20 bg-success/5 text-success";
+    return (
+        <div className={cn("mb-4 flex items-center gap-2 rounded-xl border px-3.5 py-2.5 text-[12px]", cls)}>
+            {tone === "danger" ? (
+                <AlertCircle className="h-3.5 w-3.5 shrink-0" />
+            ) : (
+                <CheckCircle2 className="h-3.5 w-3.5 shrink-0" />
+            )}
+            <span className="flex-1">{text}</span>
+            <button
+                type="button"
+                onClick={onClose}
+                className="opacity-70 hover:opacity-100"
+                aria-label="关闭"
+            >
+                ×
+            </button>
+        </div>
+    );
+}
+
+function EmptyCard({
+    icon,
+    title,
+    hint,
+    action,
+}: {
+    icon: React.ReactNode;
+    title: string;
+    hint: string;
+    action?: React.ReactNode;
+}) {
+    return (
+        <div className="flex flex-col items-center justify-center rounded-2xl border border-border-subtle py-20 text-center">
+            <span className="grid h-12 w-12 place-items-center rounded-full bg-border-subtle text-secondary">
+                {icon}
+            </span>
+            <p className="mt-4 text-[15px] font-medium text-foreground">{title}</p>
+            <p className="mt-1.5 max-w-xs text-[13px] text-secondary">{hint}</p>
+            {action}
+        </div>
+    );
+}

--- a/frontendv2/components/blindspot/entity-card.tsx
+++ b/frontendv2/components/blindspot/entity-card.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+/**
+ * EntityCard - single entity card on the blind-spot map.
+ *
+ * Collapsed: name/type + exposure and quiz signal badges. Expanded:
+ * review path (video title + page + quote) plus quiz/graph CTAs.
+ */
+import { useState } from "react";
+import {
+    BookOpenCheck,
+    ChevronDown,
+    Eye,
+    EyeOff,
+    HelpCircle,
+    Loader2,
+    Waypoints,
+} from "lucide-react";
+import { blindspotApi, type BlindspotEntity } from "@/lib/api";
+import { cn } from "@/lib/utils";
+import type { ReviewPathItem } from "@/lib/api";
+
+interface Props {
+    entity: BlindspotEntity;
+    expanded: boolean;
+    generating: boolean;
+    anyGenerating: boolean;
+    onToggle: () => void;
+    onGenerateQuiz: () => void;
+}
+
+export function EntityCard({
+    entity,
+    expanded,
+    generating,
+    anyGenerating,
+    onToggle,
+    onGenerateQuiz,
+}: Props) {
+    const [detail, setDetail] = useState<Awaited<
+        ReturnType<typeof blindspotApi.getEntity>
+    > | null>(null);
+    const [detailError, setDetailError] = useState("");
+
+    const toggle = async () => {
+        onToggle();
+        if (!expanded && !detail) {
+            try {
+                setDetail(await blindspotApi.getEntity(entity.eid));
+            } catch (e) {
+                setDetailError(e instanceof Error ? e.message : "详情加载失败");
+            }
+        }
+    };
+
+    return (
+        <div className="rounded-2xl border border-border-subtle bg-surface">
+            <button
+                type="button"
+                onClick={() => void toggle()}
+                className="flex w-full items-center gap-3 px-4 py-3.5 text-left"
+            >
+                <div className="min-w-0 flex-1">
+                    <p className="truncate text-[14px] font-medium text-foreground">
+                        {entity.name}
+                        <span className="ml-2 rounded-full bg-border-subtle px-2 py-0.5 text-[10px] font-normal text-secondary">
+                            {entity.type}
+                        </span>
+                        {entity.probed && (
+                            <span
+                                className="ml-1.5 inline-flex items-center align-middle text-accent"
+                                title="你在对话中追问过该概念"
+                            >
+                                <HelpCircle className="h-3 w-3" />
+                            </span>
+                        )}
+                    </p>
+                    {entity.description && (
+                        <p className="mt-0.5 truncate text-[12px] text-secondary">
+                            {entity.description}
+                        </p>
+                    )}
+                </div>
+                <SignalBadges entity={entity} />
+                <ChevronDown
+                    className={cn(
+                        "h-4 w-4 shrink-0 text-secondary transition-transform",
+                        expanded && "rotate-180",
+                    )}
+                />
+            </button>
+
+            {expanded && (
+                <div className="border-t border-border-subtle px-4 py-3.5">
+                    {detailError && <p className="text-[12px] text-danger">{detailError}</p>}
+                    {!detail && !detailError && (
+                        <p className="flex items-center gap-2 text-[12px] text-secondary">
+                            <Loader2 className="h-3.5 w-3.5 animate-spin" /> 加载复习路径…
+                        </p>
+                    )}
+                    {detail && detail.review_path.length === 0 && (
+                        <p className="text-[12px] text-secondary">暂无视频出处</p>
+                    )}
+                    {detail && detail.review_path.length > 0 && (
+                        <ul className="space-y-2">
+                            {detail.review_path.slice(0, 8).map((item) => (
+                                <PathItem key={`${item.bvid}:${item.page_index}`} item={item} />
+                            ))}
+                        </ul>
+                    )}
+
+                    <div className="mt-3.5 flex justify-end gap-2">
+                        <a
+                            href={`/graph?center=${encodeURIComponent(entity.eid)}`}
+                            className="btn-pill btn-ghost inline-flex h-8 items-center gap-1.5 px-3.5 text-[12px]"
+                            onClick={(e) => e.stopPropagation()}
+                        >
+                            <Waypoints className="h-3.5 w-3.5" />
+                            图谱中查看
+                        </a>
+                        <button
+                            type="button"
+                            disabled={anyGenerating}
+                            onClick={onGenerateQuiz}
+                            className="btn-pill btn-primary inline-flex h-8 items-center gap-1.5 px-4 text-[12px] disabled:opacity-50"
+                        >
+                            {generating ? (
+                                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                            ) : (
+                                <BookOpenCheck className="h-3.5 w-3.5" />
+                            )}
+                            针对此薄弱点出 5 道题
+                        </button>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}
+
+function SignalBadges({ entity }: { entity: BlindspotEntity }) {
+    return (
+        <div className="flex shrink-0 items-center gap-1.5 text-[11px] text-secondary">
+            <span
+                className="inline-flex items-center gap-1 rounded-full bg-border-subtle px-2 py-0.5 tabular-nums"
+                title={`出现在 ${entity.exposure} 个分P`}
+            >
+                <Eye className="h-3 w-3" />
+                {entity.exposure}
+            </span>
+            {entity.quiz_total > 0 ? (
+                <span
+                    className={cn(
+                        "inline-flex items-center gap-1 rounded-full px-2 py-0.5 tabular-nums",
+                        entity.quiz_wrong > entity.quiz_correct
+                            ? "bg-danger/10 text-danger"
+                            : "bg-success/10 text-success",
+                    )}
+                    title={`答题 ${entity.quiz_correct}/${entity.quiz_total} 正确`}
+                >
+                    <BookOpenCheck className="h-3 w-3" />
+                    {entity.quiz_correct}/{entity.quiz_total}
+                </span>
+            ) : (
+                <span
+                    className="inline-flex items-center gap-1 rounded-full bg-border-subtle px-2 py-0.5"
+                    title="尚未验证过"
+                >
+                    <EyeOff className="h-3 w-3" />
+                    未验证
+                </span>
+            )}
+        </div>
+    );
+}
+
+function PathItem({ item }: { item: ReviewPathItem }) {
+    return (
+        <li className="rounded-xl bg-surface-elevated px-3 py-2">
+            <p className="truncate text-[12px] font-medium text-foreground">
+                {item.title}
+                <span className="ml-1.5 text-[10px] font-normal text-secondary">
+                    P{item.page_index + 1}
+                </span>
+            </p>
+            {item.quote && (
+                <p className="mt-0.5 line-clamp-2 text-[11px] leading-relaxed text-secondary">
+                    “{item.quote}”
+                </p>
+            )}
+        </li>
+    );
+}

--- a/frontendv2/components/kg/force-graph.tsx
+++ b/frontendv2/components/kg/force-graph.tsx
@@ -1,0 +1,327 @@
+"use client";
+
+/**
+ * ForceGraph - knowledge graph force-directed visualization (added in 1.0.6).
+ *
+ * Dependency-free SVG: Coulomb repulsion + spring attraction + centering
+ * gravity with velocity damping. Interactions: drag nodes, zoom buttons,
+ * click a node to re-center (onSelect). Data: /knowledge/kg/subgraph.
+ */
+import { useEffect, useRef, useState } from "react";
+import { Maximize2, Minus, Plus } from "lucide-react";
+import type { KgSubgraphEdge, KgSubgraphNode } from "@/lib/api";
+
+export const TYPE_COLORS: Record<string, string> = {
+    person: "#af52de",
+    org: "#5856d6",
+    concept: "#0071e3",
+    tech: "#0a84ff",
+    tool: "#30b0c7",
+    book: "#ff9f0a",
+    event: "#ff453a",
+    method: "#34c759",
+    place: "#8e8e93",
+    other: "#8e8e93",
+};
+
+interface SimNode extends KgSubgraphNode {
+    x: number;
+    y: number;
+    vx: number;
+    vy: number;
+}
+
+interface SimEdge {
+    src: number;
+    dst: number;
+}
+
+interface Props {
+    nodes: KgSubgraphNode[];
+    edges: KgSubgraphEdge[];
+    centerEid: string | null;
+    selectedEid: string | null;
+    onSelect: (eid: string) => void;
+    height?: number;
+}
+
+const REPULSION = 2400;
+const SPRING_LEN = 110;
+const SPRING_K = 0.06;
+const GRAVITY = 0.02;
+const DAMPING = 0.85;
+const MAX_VELOCITY = 30;
+
+function initLayout(nodes: KgSubgraphNode[], height: number): SimNode[] {
+    const W = 900;
+    const H = Math.max(height, 400);
+    return nodes.map((n, i) => {
+        if (nodes.length === 1) {
+            return { ...n, x: W / 2, y: H / 2, vx: 0, vy: 0 };
+        }
+        const angle = (i / nodes.length) * Math.PI * 2;
+        const radius = Math.min(W, H) * 0.32;
+        return {
+            ...n,
+            x: W / 2 + radius * Math.cos(angle),
+            y: H / 2 + radius * Math.sin(angle),
+            vx: 0,
+            vy: 0,
+        };
+    });
+}
+
+/** One physics step: repulsion + springs + gravity + damping. Returns a new array. */
+function tick(prev: SimNode[], edges: SimEdge[]): SimNode[] {
+    const next = prev.map((n) => ({ ...n }));
+    const nCount = next.length;
+    if (nCount === 0) return next;
+
+    for (let i = 0; i < nCount; i++) {
+        for (let j = i + 1; j < nCount; j++) {
+            const a = next[i];
+            const b = next[j];
+            let dx = b.x - a.x;
+            let dy = b.y - a.y;
+            let distSq = dx * dx + dy * dy;
+            if (distSq < 1) {
+                dx = (Math.random() - 0.5) * 2;
+                dy = (Math.random() - 0.5) * 2;
+                distSq = 4;
+            }
+            const f = REPULSION / distSq;
+            const dist = Math.sqrt(distSq);
+            const fx = (dx / dist) * f;
+            const fy = (dy / dist) * f;
+            a.vx -= fx;
+            a.vy -= fy;
+            b.vx += fx;
+            b.vy += fy;
+        }
+    }
+    for (const e of edges) {
+        const a = next[e.src];
+        const b = next[e.dst];
+        if (!a || !b) continue;
+        const dx = b.x - a.x;
+        const dy = b.y - a.y;
+        const dist = Math.sqrt(dx * dx + dy * dy) || 1;
+        const f = (dist - SPRING_LEN) * SPRING_K;
+        const fx = (dx / dist) * f;
+        const fy = (dy / dist) * f;
+        a.vx += fx;
+        a.vy += fy;
+        b.vx -= fx;
+        b.vy -= fy;
+    }
+    for (const n of next) {
+        n.vx += (450 - n.x) * GRAVITY;
+        n.vy += (Math.max(400, 300) - n.y) * GRAVITY * 0.5;
+        n.vx *= DAMPING;
+        n.vy *= DAMPING;
+        n.x += Math.max(-MAX_VELOCITY, Math.min(MAX_VELOCITY, n.vx));
+        n.y += Math.max(-MAX_VELOCITY, Math.min(MAX_VELOCITY, n.vy));
+    }
+    return next;
+}
+
+export function ForceGraph({
+    nodes,
+    edges,
+    centerEid,
+    selectedEid,
+    onSelect,
+    height = 560,
+}: Props) {
+    // Derive during render: reset layout when the node signature changes
+    const sig = `${height}|${nodes.map((n) => n.eid).join(",")}`;
+    const [layoutSig, setLayoutSig] = useState(sig);
+    const [simNodes, setSimNodes] = useState<SimNode[]>(() =>
+        initLayout(nodes, height),
+    );
+    if (sig !== layoutSig) {
+        setLayoutSig(sig);
+        setSimNodes(initLayout(nodes, height));
+    }
+
+    // Edge indexing: recomputed per frame by the physics loop via dataRef;
+    const dataRef = useRef({ edges });
+    useEffect(() => {
+        dataRef.current = { edges };
+    });
+
+    const rafRef = useRef<number>(0);
+    useEffect(() => {
+        if (simNodes.length === 0) return;
+        let running = true;
+        const step = () => {
+            if (!running) return;
+            setSimNodes((prev) => {
+                const idx = new Map(prev.map((n, i) => [n.eid, i]));
+                const eIdx = dataRef.current.edges
+                    .map((e) => ({
+                        src: idx.get(e.src) ?? -1,
+                        dst: idx.get(e.dst) ?? -1,
+                    }))
+                    .filter((e) => e.src >= 0 && e.dst >= 0);
+                return tick(prev, eIdx);
+            });
+            rafRef.current = requestAnimationFrame(step);
+        };
+        rafRef.current = requestAnimationFrame(step);
+        return () => {
+            running = false;
+            cancelAnimationFrame(rafRef.current);
+        };
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- loop is driven by the layout signature
+    }, [layoutSig]);
+
+    // Render-time derived edge indices (independent of the physics loop)
+    const indexMap = new Map(simNodes.map((n, i) => [n.eid, i]));
+    const simEdges = edges
+        .map((e) => ({ src: indexMap.get(e.src) ?? -1, dst: indexMap.get(e.dst) ?? -1 }))
+        .filter((e) => e.src >= 0 && e.dst >= 0);
+
+    const [view, setView] = useState({ x: 0, y: 0, k: 1 });
+    const draggingRef = useRef<number | null>(null);
+    const svgRef = useRef<SVGSVGElement>(null);
+
+    const toWorld = (clientX: number, clientY: number) => {
+        const rect = svgRef.current?.getBoundingClientRect();
+        if (!rect) return { x: 0, y: 0 };
+        return {
+            x: (clientX - rect.left - view.x) / view.k,
+            y: (clientY - rect.top - view.y) / view.k,
+        };
+    };
+
+    const maxDeg = Math.max(1, ...simNodes.map((n) => n.degree));
+    const nodeR = (deg: number) => 8 + (deg / maxDeg) * 14;
+
+    return (
+        <div
+            className="relative overflow-hidden rounded-2xl border border-border-subtle bg-surface"
+            style={{ height }}
+        >
+            <svg
+                ref={svgRef}
+                width="100%"
+                height="100%"
+                viewBox={`0 0 900 ${Math.max(height, 400)}`}
+                onPointerMove={(ev) => {
+                    const i = draggingRef.current;
+                    if (i === null) return;
+                    const p = toWorld(ev.clientX, ev.clientY);
+                    setSimNodes((prev) =>
+                        prev.map((n, j) =>
+                            j === i ? { ...n, x: p.x, y: p.y, vx: 0, vy: 0 } : n,
+                        ),
+                    );
+                }}
+                onPointerUp={() => {
+                    draggingRef.current = null;
+                }}
+                className="touch-none select-none"
+            >
+                <g transform={`translate(${view.x},${view.y}) scale(${view.k})`}>
+                    {simEdges.map((e, i) => {
+                        const a = simNodes[e.src];
+                        const b = simNodes[e.dst];
+                        if (!a || !b) return null;
+                        const highlighted =
+                            selectedEid === a.eid || selectedEid === b.eid;
+                        return (
+                            <line
+                                key={i}
+                                x1={a.x}
+                                y1={a.y}
+                                x2={b.x}
+                                y2={b.y}
+                                stroke={highlighted ? "#0071e3" : "#d2d2d7"}
+                                strokeOpacity={highlighted ? 0.9 : 0.55}
+                                strokeWidth={highlighted ? 2 : 1}
+                            />
+                        );
+                    })}
+                    {simNodes.map((n, i) => {
+                        const isSel = n.eid === selectedEid;
+                        const isCenter = n.eid === centerEid;
+                        const r = nodeR(n.degree);
+                        return (
+                            <g
+                                key={n.eid}
+                                transform={`translate(${n.x},${n.y})`}
+                                className="cursor-pointer"
+                                onPointerDown={(ev) => {
+                                    ev.stopPropagation();
+                                    (ev.target as Element).setPointerCapture(ev.pointerId);
+                                    draggingRef.current = i;
+                                }}
+                                onClick={() => onSelect(n.eid)}
+                            >
+                                <circle
+                                    r={r + (isSel || isCenter ? 4 : 0)}
+                                    fill={TYPE_COLORS[n.type] ?? TYPE_COLORS.other}
+                                    stroke={isSel || isCenter ? "#0071e3" : "#ffffff"}
+                                    strokeWidth={isSel || isCenter ? 2.5 : 1.5}
+                                />
+                                {(n.degree >= maxDeg * 0.25 || isSel || isCenter) && (
+                                    <text
+                                        y={r + 13}
+                                        textAnchor="middle"
+                                        fontSize={11}
+                                        fill="#1d1d1f"
+                                        style={{ pointerEvents: "none" }}
+                                    >
+                                        {n.name.length > 12
+                                            ? `${n.name.slice(0, 12)}…`
+                                            : n.name}
+                                    </text>
+                                )}
+                            </g>
+                        );
+                    })}
+                </g>
+            </svg>
+
+            <div className="absolute right-3 top-3 flex flex-col gap-1.5">
+                <ZoomBtn
+                    label={<Plus className="h-3.5 w-3.5" />}
+                    onClick={() => setView((v) => ({ ...v, k: Math.min(3, v.k * 1.25) }))}
+                />
+                <ZoomBtn
+                    label={<Minus className="h-3.5 w-3.5" />}
+                    onClick={() => setView((v) => ({ ...v, k: Math.max(0.35, v.k / 1.25) }))}
+                />
+                <ZoomBtn
+                    label={<Maximize2 className="h-3.5 w-3.5" />}
+                    onClick={() => setView({ x: 0, y: 0, k: 1 })}
+                />
+            </div>
+
+            <div className="absolute bottom-3 left-3 flex max-w-[80%] flex-wrap gap-x-3 gap-y-1 rounded-xl bg-white/90 px-3 py-2 text-[10px] text-secondary shadow-sm">
+                {Object.entries(TYPE_COLORS).slice(0, 9).map(([t, c]) => (
+                    <span key={t} className="inline-flex items-center gap-1">
+                        <span
+                            className="inline-block h-2 w-2 rounded-full"
+                            style={{ background: c }}
+                        />
+                        {t}
+                    </span>
+                ))}
+            </div>
+        </div>
+    );
+}
+
+function ZoomBtn({ label, onClick }: { label: React.ReactNode; onClick: () => void }) {
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            className="grid h-7 w-7 place-items-center rounded-lg border border-border-subtle bg-white text-secondary shadow-sm hover:text-foreground"
+        >
+            {label}
+        </button>
+    );
+}

--- a/frontendv2/components/kg/graph-view.tsx
+++ b/frontendv2/components/kg/graph-view.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+/**
+ * GraphView - knowledge graph visualization page (added in Plan 1.0.6).
+ *
+ * Overview loads the head-entity subgraph; clicking a node re-centers
+ * the layout on it via BFS; the side panel shows details and links out.
+ */
+import { useCallback, useEffect, useState } from "react";
+import { AlertCircle, Loader2, RefreshCw, Waypoints } from "lucide-react";
+import { kgApi } from "@/lib/api";
+import { cn } from "@/lib/utils";
+import { ForceGraph, TYPE_COLORS } from "./force-graph";
+
+type LoadState = "loading" | "ready" | "error";
+
+export function GraphView({ initialCenter }: { initialCenter?: string }) {
+    const [state, setState] = useState<LoadState>("loading");
+    const [error, setError] = useState("");
+    const [data, setData] = useState<Awaited<ReturnType<typeof kgApi.getSubgraph>> | null>(
+        null,
+    );
+    const [selected, setSelected] = useState<string | null>(initialCenter ?? null);
+
+    const load = useCallback(async (center?: string) => {
+        setState("loading");
+        setError("");
+        try {
+            const d = await kgApi.getSubgraph(
+                center ? { center, depth: 2, maxNodes: 80 } : { maxNodes: 80 },
+            );
+            setData(d);
+            setSelected(center ?? null);
+            setState("ready");
+        } catch (e) {
+            setError(e instanceof Error ? e.message : "图谱加载失败");
+            setState("error");
+        }
+    }, []);
+
+    useEffect(() => {
+        // eslint-disable-next-line react-hooks/set-state-in-effect
+        void load(initialCenter);
+    }, [load, initialCenter]);
+
+    const selectedNode = data?.nodes.find((n) => n.eid === selected) ?? null;
+
+    return (
+        <div className="mx-auto max-w-[1100px] px-5 py-8 pb-24">
+            <div className="mb-6 flex items-end justify-between">
+                <div>
+                    <h1 className="text-[26px] font-semibold tracking-tight text-foreground">
+                        知识图谱
+                    </h1>
+                    <p className="mt-0.5 text-[13px] text-secondary">
+                        实体与关系的可视化网络 · 点击节点查看关联 / 拖拽调整布局
+                    </p>
+                </div>
+                <button
+                    type="button"
+                    disabled={state === "loading"}
+                    onClick={() => void load()}
+                    className="btn-pill btn-ghost inline-flex h-8 items-center gap-1.5 px-3.5 text-[12px] disabled:opacity-50"
+                >
+                    <RefreshCw className={cn("h-3.5 w-3.5", state === "loading" && "animate-spin")} />
+                    总览模式
+                </button>
+            </div>
+
+            {state === "loading" && (
+                <div className="grid h-[560px] place-items-center rounded-2xl border border-border-subtle bg-surface">
+                    <span className="flex items-center gap-2 text-[13px] text-secondary">
+                        <Loader2 className="h-4 w-4 animate-spin" /> 正在加载图谱…
+                    </span>
+                </div>
+            )}
+
+            {state === "error" && (
+                <div className="flex flex-col items-center rounded-2xl border border-border-subtle py-16 text-center">
+                    <AlertCircle className="h-7 w-7 text-danger" />
+                    <p className="mt-3 text-[14px] text-foreground">{error}</p>
+                    <button
+                        type="button"
+                        onClick={() => void load()}
+                        className="btn-pill btn-primary mt-5 h-9 px-5 text-[13px]"
+                    >
+                        重试
+                    </button>
+                </div>
+            )}
+
+            {state === "ready" && data && !data.available && (
+                <div className="flex flex-col items-center justify-center rounded-2xl border border-border-subtle py-20 text-center">
+                    <span className="grid h-12 w-12 place-items-center rounded-full bg-border-subtle text-secondary">
+                        <Waypoints className="h-5 w-5" />
+                    </span>
+                    <p className="mt-4 text-[15px] font-medium text-foreground">知识图谱不可用</p>
+                    <p className="mt-1.5 max-w-xs text-[13px] text-secondary">
+                        Neo4j 未连接。请启动 neo4j 服务并在收藏夹页完成一次图谱构建。
+                    </p>
+                </div>
+            )}
+
+            {state === "ready" && data && data.available && data.nodes.length === 0 && (
+                <div className="flex flex-col items-center justify-center rounded-2xl border border-border-subtle py-20 text-center">
+                    <span className="grid h-12 w-12 place-items-center rounded-full bg-border-subtle text-secondary">
+                        <Waypoints className="h-5 w-5" />
+                    </span>
+                    <p className="mt-4 text-[15px] font-medium text-foreground">图谱还是空的</p>
+                    <p className="mt-1.5 max-w-xs text-[13px] text-secondary">
+                        先在收藏夹页构建知识库与知识图谱，实体关系会出现在这里。
+                    </p>
+                </div>
+            )}
+
+            {state === "ready" && data && data.available && data.nodes.length > 0 && (
+                <div className="grid grid-cols-[1fr_260px] gap-4 max-lg:grid-cols-1">
+                    <ForceGraph
+                        nodes={data.nodes}
+                        edges={data.edges}
+                        centerEid={data.center}
+                        selectedEid={selected}
+                        onSelect={(eid) => {
+                            setSelected(eid);
+                            void load(eid);
+                        }}
+                    />
+
+                    {/* Info side panel */}
+                    <aside className="rounded-2xl border border-border-subtle bg-surface p-4">
+                        {selectedNode ? (
+                            <>
+                                <p className="text-[15px] font-semibold text-foreground">
+                                    {selectedNode.name}
+                                </p>
+                                <span
+                                    className="mt-1.5 inline-block rounded-full px-2 py-0.5 text-[10px]"
+                                    style={{
+                                        background: `${TYPE_COLORS[selectedNode.type] ?? TYPE_COLORS.other}22`,
+                                        color: TYPE_COLORS[selectedNode.type] ?? TYPE_COLORS.other,
+                                    }}
+                                >
+                                    {selectedNode.type} · {selectedNode.degree} 条关系
+                                </span>
+                                {selectedNode.description && (
+                                    <p className="mt-3 text-[12px] leading-relaxed text-secondary">
+                                        {selectedNode.description}
+                                    </p>
+                                )}
+                                <div className="mt-4 space-y-2">
+                                    <a
+                                        href={`/blindspot?center=${selectedNode.eid}`}
+                                        className="btn-pill btn-ghost block h-8 leading-8 text-center text-[12px]"
+                                    >
+                                        在盲区地图中查看
+                                    </a>
+                                    <button
+                                        type="button"
+                                        onClick={() => {
+                                            setSelected(null);
+                                            void load();
+                                        }}
+                                        className="btn-pill btn-ghost block h-8 w-full text-[12px]"
+                                    >
+                                        返回总览
+                                    </button>
+                                </div>
+                            </>
+                        ) : (
+                            <p className="text-[12px] leading-relaxed text-secondary">
+                                点击任意节点：以它为中心重新展开关联子图。
+                                <br />
+                                <br />
+                                节点大小 = 子图内关系数；颜色 = 实体类型；
+                                拖拽可调整布局；按钮区可缩放。
+                            </p>
+                        )}
+                        {data.center && (
+                            <p className="mt-3 truncate border-t border-border-subtle pt-3 text-[10px] text-secondary">
+                                当前中心：{data.nodes.find((n) => n.eid === data.center)?.name ?? "-"}
+                            </p>
+                        )}
+                    </aside>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/frontendv2/lib/api/blindspot.ts
+++ b/frontendv2/lib/api/blindspot.ts
@@ -1,0 +1,104 @@
+/**
+ * Blindspot API - knowledge blind-spot map (Plan 1.0.6).
+ *
+ * Backend contract: app/routers/blindspot.py; design: plan/1.0.6-BlindSpotMap/.
+ */
+import { request } from "./client";
+
+export type Quadrant =
+    | "danger"
+    | "blind"
+    | "learning"
+    | "familiar"
+    | "unexplored";
+
+export interface EvidenceSample {
+    bvid: string;
+    page_index: number;
+    quote: string;
+}
+
+export interface BlindspotEntity {
+    eid: string;
+    name: string;
+    type: string;
+    description: string;
+    exposure: number;
+    evidence_sample: EvidenceSample[];
+    quiz_total: number;
+    quiz_correct: number;
+    quiz_wrong: number;
+    probed: boolean;
+    priority: number;
+}
+
+export interface QuadrantStats {
+    total_entities: number;
+    danger: number;
+    blind: number;
+    learning: number;
+    familiar: number;
+    unexplored: number;
+}
+
+export interface BlindspotMap {
+    available: boolean;
+    scope_bvids: number;
+    quadrants: Record<Quadrant, BlindspotEntity[]>;
+    stats: QuadrantStats;
+}
+
+export interface ReviewPathItem {
+    bvid: string;
+    page_index: number;
+    quote: string;
+    title: string;
+}
+
+export interface BlindspotEntityDetail {
+    eid: string;
+    name: string;
+    type: string;
+    description: string;
+    exposure: number;
+    review_path: ReviewPathItem[];
+    quiz_total: number;
+    quiz_correct: number;
+    quiz_wrong: number;
+}
+
+export interface EntityQuizStart {
+    quiz_uuid: string;
+    status: string;
+    title: string;
+}
+
+export const QUADRANT_LABELS: Record<Quadrant, string> = {
+    danger: "危险区",
+    blind: "盲区",
+    learning: "追问中",
+    familiar: "已掌握",
+    unexplored: "未探索",
+};
+
+export const blindspotApi = {
+    // Five-quadrant map (empty folderIds = all user folders)
+    getMap: (folderIds?: number[]) => {
+        const q = folderIds?.length ? `?folder_ids=${folderIds.join(",")}` : "";
+        return request<BlindspotMap>(`/blindspot/map${q}`);
+    },
+
+    // Entity detail (review path + quiz stats)
+    getEntity: (eid: string) =>
+        request<BlindspotEntityDetail>(`/blindspot/entity/${encodeURIComponent(eid)}`),
+
+    // One-click quiz for a weak entity; poll GET /quiz/{quiz_uuid} afterwards
+    generateQuiz: (eid: string, questionCount = 5, difficulty = "medium") =>
+        request<EntityQuizStart>(`/blindspot/${encodeURIComponent(eid)}/quiz`, {
+            method: "POST",
+            body: JSON.stringify({
+                question_count: questionCount,
+                difficulty,
+            }),
+        }),
+};

--- a/frontendv2/lib/api/index.ts
+++ b/frontendv2/lib/api/index.ts
@@ -16,6 +16,7 @@ export * from "./auth";
 export * from "./favorites";
 export * from "./knowledge";
 export * from "./kg";
+export * from "./blindspot";
 export * from "./chat";
 export * from "./session-summary";
 export * from "./code-executions";

--- a/frontendv2/lib/api/kg.ts
+++ b/frontendv2/lib/api/kg.ts
@@ -1,7 +1,8 @@
 /**
- * Knowledge Graph API - 知识图谱构建 / 统计（Plan 1.0.5）.
+ * Knowledge Graph API - graph build / stats / visualization subgraph.
  *
- * 后端契约见 app/routers/knowledge.py 的 KG 段；前端设计见 plan/1.0.5-KnowledgeGraph/frontend-design.md.
+ * Backend contract: app/routers/knowledge.py KG section; frontend design:
+ * plan/1.0.5-KnowledgeGraph/frontend-design.md.
  */
 import { request } from "./client";
 
@@ -36,31 +37,62 @@ export interface KgActiveTask {
     task_id: string | null;
 }
 
+export interface KgSubgraphNode {
+    eid: string;
+    name: string;
+    type: string;
+    description: string;
+    degree: number;
+}
+
+export interface KgSubgraphEdge {
+    src: string;
+    dst: string;
+    rel_type: string;
+}
+
+export interface KgSubgraph {
+    available: boolean;
+    center: string | null;
+    nodes: KgSubgraphNode[];
+    edges: KgSubgraphEdge[];
+}
+
 export interface KgBuildStatus {
     task_id: string;
     status: KgTaskStatus;
     progress: number;
     current_step: string;
-    /** 完成时 {total, ok, failed} 或 {total: 0, message}；进行中为 {} */
+    /** On completion: {total, ok, failed} or {total: 0, message}; {} while running */
     result: Record<string, unknown>;
     error: string;
 }
 
 export const kgApi = {
-    // 图谱统计（Neo4j 计数 + 待抽取分P数）
+    // Graph stats (Neo4j counts + pending pages)
     getStats: () => request<KgStats>("/knowledge/kg/stats"),
 
-    // 触发构建（folder_ids 为空数组 = 用户全部收藏夹）；已有活跃任务时复用其 task_id
+    // Trigger build (empty folder_ids = all user folders); reuses the active task_id
     build: (folderIds: number[]) =>
         request<KgBuildStart>("/knowledge/kg/build", {
             method: "POST",
             body: JSON.stringify({ folder_ids: folderIds }),
         }),
 
-    // 探测活跃任务（刷新页面后恢复轮询）
+    // Detect active task (resume polling after page refresh)
     getActiveTask: () => request<KgActiveTask>("/knowledge/kg/active"),
 
-    // 轮询构建状态
+    // Poll build status
     getStatus: (taskId: string) =>
         request<KgBuildStatus>(`/knowledge/kg/status/${taskId}`),
+
+    // Visualization subgraph (no center = overview; center = BFS expansion)
+    getSubgraph: (params?: { center?: string; depth?: number; maxNodes?: number }) => {
+        const sp = new URLSearchParams();
+        if (params?.center) sp.set("center", params.center);
+        if (params?.depth) sp.set("depth", String(params.depth));
+        if (params?.maxNodes) sp.set("max_nodes", String(params.maxNodes));
+        const qs = sp.toString();
+        return request<KgSubgraph>(`/knowledge/kg/subgraph${qs ? `?${qs}` : ""}`);
+    },
 };

--- a/frontendv2/lib/nav-config.ts
+++ b/frontendv2/lib/nav-config.ts
@@ -10,6 +10,8 @@ import {
   Activity,
   BarChart3,
   Sparkles,
+  Target,
+  Waypoints,
   type LucideIcon,
 } from "lucide-react";
 
@@ -39,6 +41,8 @@ export const navItems: NavItem[] = [
   { id: "task-quiz", label: "定时出题", href: "/task-quiz", icon: CalendarClock, placement: "primary" },
   // Low-frequency modules collapsed under "更多"
   { id: "tasks", label: "任务监控", href: "/tasks", icon: Activity, placement: "more" },
+  { id: "graph", label: "知识图谱", href: "/graph", icon: Waypoints, placement: "more" },
+  { id: "blindspot", label: "知识盲区", href: "/blindspot", icon: Target, placement: "more" },
   { id: "billing", label: "用量计费", href: "/billing", icon: BarChart3, placement: "more" },
   { id: "skills", label: "技能商店", href: "/skills", icon: Sparkles, placement: "more" },
   // Right-side account area

--- a/nginx/locations.conf
+++ b/nginx/locations.conf
@@ -81,6 +81,14 @@ location /knowledge {
     proxy_pass http://apisix;
 }
 
+# Blindspot map (Plan 1.0.6) - read aggregation via APISIX.
+# NOTE: /blindspot is also a frontend page route; only /blindspot/* API
+# subpaths are proxied here (exact /blindspot falls through to location /).
+location /blindspot/ {
+    limit_req zone=api burst=5 nodelay;
+    proxy_pass http://apisix;
+}
+
 # ASR - no cache (status polling)
 location /asr         { proxy_pass http://apisix; }
 location /skills      { proxy_pass http://apisix; }


### PR DESCRIPTION
## 概要

落地 Plan 1.0.6：以 KG 实体为粒度聚合三类学习信号（曝光/验证/追问），生成五象限知识盲区地图；同期补齐图谱力导向可视化与出题实体打标，形成「发现薄弱点 → 看关联网络 → 针对性出题」闭环。

### 后端
- **[blindspot]** `BlindspotService` 只读旁路聚合：曝光(Neo4j APPEARS_IN) + 验证(MySQL quiz_answers) + 追问(Mongo chat_messages)；任一依赖缺失逐级降级，不碰 ASR/向量化/KG 构建管道
  - scoring 纯函数五象限判定（danger / blind / learning / familiar / unexplored）+ priority 排序分
  - 归因双方案：新题 LLM 出题时打标 `related_entities`（方案A）；存量题干经 Milvus 实体索引兜底归因（方案B，阈值 0.75）
  - `GET /blindspot/map`、`GET /blindspot/entity/{eid}`、`POST /blindspot/{eid}/quiz`（复用 preflight → 配额 → 生成的既有管道）
- **[kg]** `GET /knowledge/kg/subgraph` 可视化子图端点（总览模式 / 中心实体 BFS 扩展）；stats() 裸 `CALL {}` 改为 `CALL () {}` 消除 Neo4j 5.23+ 弃用告警
- **[quiz]** 出题结构化输出新增 `related_entities` 字段 + prompt 打标规范
- **[infra]** nginx locations.conf 白名单放行 `/blindspot/*` API 子路径（修复页面可见但数据请求落前端返回 404 的问题）

### 前端（零新增 npm 依赖）
- `/blindspot` 页面：五象限 tab、实体卡展开复习路径（视频标题+分P+原文引文）、一键针对薄弱点出题 CTA
- `/graph` 页面 + ForceGraph 组件（纯 SVG 力导向：斥力+弹簧+向心重力）：节点大小=关系数、颜色=实体类型，拖拽/缩放/点击回中，支持 `?center=<eid>` 深链
- 导航「更多」分组新增「知识图谱」「知识盲区」入口；盲区实体卡可跳转图谱定位

## 测试

- [x] `ruff check app/ --ignore E501,E402` 通过
- [x] `app/test/blindspot/test_scoring.py` 单测（五象限边界 / priority / 归因阈值过滤；本地以等价断言脚本全绿验证）
- [x] frontendv2 `npm run lint` 零告警 + `npm run build` 通过（/blindspot、/graph 路由均生成）
- [x] `app.main` 导入验证：3 条 blindspot 路由注册确认
- [x] 手工联调：nginx 热加载后 `/blindspot/map` 经网关穿透至 backend（401→真实登录态返回数据）；实体详情解包 bug 已修复并 mock 全链路验证
- [ ] 合并后重建 backend/frontend 镜像做端到端验收（构建图谱 → 盲区地图 → 一键出题）

> 设计文档：plan/1.0.6-BlindSpotMap/1.0.6-BlindSpotMap.md（本地）
