### PR TITLE
[desktop] chore: 版本升至 0.1.1

### DIFF
--- a/mind-base-desktop/src-tauri/Cargo.toml
+++ b/mind-base-desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mind-base-desktop"
-version = "0.1.0"
+version = "0.1.1"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/mind-base-desktop/src-tauri/tauri.conf.json
+++ b/mind-base-desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "mind-base-desktop",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "identifier": "io.github.atoncooper.mindbase",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
与发布 tag `mind-base-desktop-v0.1.1` 对齐（tauri.conf.json + Cargo.toml）。