### PR TITLE
[cloud] fix: 云盘 PDF 预览链路修复 + 侧边目录增强 (#92)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 # ====== Backend: FastAPI ======
-FROM python:3.12-slim
+# digest 固定：buildkit 每次都会联网解析 tag 元数据，国内网络下常被掐断导致
+# 构建卡死；digest 引用可直接命中本地镜像，无需联网。升级基础镜像时更新 digest
+# （docker images --digests python）。
+FROM python:3.12-slim@sha256:09f7da3bc104798d0afb40bc08d23ab2da20a76130cec1f2ef170848f5d85217
 
 LABEL app="mind-base-backend"
 
@@ -33,10 +36,11 @@ RUN curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 --connect-timeout 30
 WORKDIR /app
 
 # Install Python dependencies
-# Tip: for faster downloads in China, uncomment the mirror line below
-#   --index-url https://pypi.tuna.tsinghua.edu.cn/simple
+# --default-timeout/--retries：清华源偶尔读超时（大包下载中断导致整层失败），
+# 放宽单请求超时到 120s 并自动重试，与 ffmpeg 下载的 --retry 策略保持一致。
 COPY requirements.txt .
-RUN pip install --no-cache-dir -i https://pypi.tuna.tsinghua.edu.cn/simple -r requirements.txt
+RUN pip install --no-cache-dir --timeout 120 --retries 5 \
+    -i https://pypi.tuna.tsinghua.edu.cn/simple -r requirements.txt
 
 # Copy application code
 COPY app/ ./app/

--- a/app/infra/minio.py
+++ b/app/infra/minio.py
@@ -300,13 +300,24 @@ class MinioClient:
 
     # ── object access ─────────────────────────────────────────
 
-    async def presigned_get(self, object_key: str) -> str:
+    async def presigned_get(
+        self, object_key: str, response_headers: Optional[dict] = None
+    ) -> str:
+        """Presigned GET URL.
+
+        ``response_headers`` (e.g. ``{"response-content-type": "application/pdf"}``)
+        is signed into the query string, so the object is served with the given
+        Content-Type regardless of how it was stored — needed when uploads
+        persisted a generic ``application/octet-stream`` and the browser must
+        render the file inline (PDF / video / image).
+        """
         self._ensure_client()
         url = await _run_async(
             self._client.presigned_get_object,
             self.bucket,
             object_key,
             expires=timedelta(seconds=config.minio.presign_expire),
+            response_headers=response_headers,
         )
         return self._public_url(url)
 

--- a/app/routers/cloud.py
+++ b/app/routers/cloud.py
@@ -804,7 +804,15 @@ async def get_video_raw(
         view_mode = _classify_view_mode(file.mime_type)
 
         # Presigned GET URL - works for download and as <video>/<img>/<iframe> src.
-        url = await client.presigned_get(file.object_key)
+        # Binary view modes need the real MIME signed into the response: uploads
+        # may have persisted application/octet-stream, and with nosniff in the
+        # chain the browser refuses to sniff PDF/media, leaving the viewer blank.
+        response_headers = (
+            {"response-content-type": file.mime_type}
+            if view_mode in ("pdf", "video", "audio", "image")
+            else None
+        )
+        url = await client.presigned_get(file.object_key, response_headers)
 
         # Inline text content for text-like files (<=5 MB) to avoid CORS fetch.
         content: Optional[str] = None

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -129,6 +129,8 @@ services:
       args:
         NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-}
         NEXT_PUBLIC_APISIX_HOST: nginx:80
+        # rewrites 构建时固化，MinIO 同源代理目标必须是 build arg（非运行时 env）
+        MINIO_PROXY_DEST: http://nginx:80
     container_name: mind-base-frontend
     # Port exposed for local access; in production nginx handles all traffic
     ports:
@@ -137,6 +139,8 @@ services:
       - NODE_ENV=production
       - NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL:-}
       - NEXT_PUBLIC_APISIX_HOST=nginx:80
+      # MinIO 同源代理目标（rewrites 在服务端运行时读取，非 NEXT_PUBLIC）
+      - MINIO_PROXY_DEST=http://nginx:80
     depends_on:
       backend:
         condition: service_healthy

--- a/frontendv2/Dockerfile
+++ b/frontendv2/Dockerfile
@@ -17,10 +17,20 @@ WORKDIR /app
 # Override via: docker build --build-arg NEXT_PUBLIC_API_URL=...
 ARG NEXT_PUBLIC_API_URL=""
 ARG NEXT_PUBLIC_APISIX_HOST=""
+# next build 会把 rewrites() 的 destination 固化进 routes-manifest.json（运行时
+# env 不再参与求值），所以 MinIO 同源代理目标必须作为 build arg 注入。
+# compose 传 http://nginx:80；宿主机本地构建缺省走 http://localhost。
+ARG MINIO_PROXY_DEST=""
 ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL \
-    NEXT_PUBLIC_APISIX_HOST=$NEXT_PUBLIC_APISIX_HOST
+    NEXT_PUBLIC_APISIX_HOST=$NEXT_PUBLIC_APISIX_HOST \
+    MINIO_PROXY_DEST=$MINIO_PROXY_DEST
 
 # Install dependencies first to leverage Docker's layer cache.
+# registry 切国内镜像：package-lock 在 Windows 生成，Linux/musl 平台的
+# @next/swc 二进制不在锁文件里，`next build` 会现场从 registry 下载约 60MB，
+# 直连 npmjs 极易被掐断导致构建崩溃（download-swc 会读取 npm registry 配置，
+# 所以这里一处设置同时管住 npm ci 和 swc 下载）。
+RUN npm config set registry https://registry.npmmirror.com
 COPY package.json package-lock.json ./
 RUN npm ci
 
@@ -51,7 +61,8 @@ USER appuser
 
 EXPOSE 3000
 
+# busybox wget 会把 localhost 解析成 IPv6 ::1，而 Next 只绑 IPv4 —— 用 127.0.0.1
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
-    CMD wget -qO- http://localhost:3000/ || exit 1
+    CMD wget -qO- http://127.0.0.1:3000/ || exit 1
 
 CMD ["node", "server.js"]

--- a/frontendv2/components/cloud-drive/cloud-drive-view.tsx
+++ b/frontendv2/components/cloud-drive/cloud-drive-view.tsx
@@ -261,11 +261,19 @@ export function CloudDriveView() {
     );
 
     const handleCreateFolder = useCallback(
-        async (name: string) => {
-            await cloudApi.createFolder({ parentId: selectedFolderId, name });
+        async (name: string, parentId: number | null) => {
+            await cloudApi.createFolder({ parentId, name });
             await refreshFolders();
         },
-        [selectedFolderId, refreshFolders]
+        [refreshFolders]
+    );
+
+    const handleRenameFolder = useCallback(
+        async (id: number, name: string) => {
+            await cloudApi.updateFolder(id, { name });
+            await refreshFolders();
+        },
+        [refreshFolders]
     );
 
     const handleDeleteFolder = useCallback(async () => {
@@ -348,6 +356,7 @@ export function CloudDriveView() {
                     totalCount={videosLoading ? 0 : totalFiles}
                     onSelect={handleSelectFolder}
                     onCreateFolder={handleCreateFolder}
+                    onRenameFolder={handleRenameFolder}
                     onDeleteFolder={setDeleteFolderTarget}
                 />
             </aside>

--- a/frontendv2/components/cloud-drive/file-viewer.tsx
+++ b/frontendv2/components/cloud-drive/file-viewer.tsx
@@ -7,20 +7,41 @@
  * Next 16 async-params dance, same convention as the shared-note page).
  *
  * Fetches a presigned MinIO GET URL (plus inline text for text-like types)
- * from /cloud/video/:uuid/raw and renders the file natively:
- *  - video / audio / image / pdf -> browser element with the presigned URL
- *  - html / markdown / text       -> inline content (no CORS fetch)
+ * from /cloud/video/:uuid/raw and renders the file:
+ *  - pdf                         -> auto-open in a NEW browser tab; the
+ *                                   browser's native PDF viewer takes over
+ *  - video / audio / image       -> browser element with the presigned URL
+ *  - html / markdown / text      -> inline content (no CORS fetch)
  *  - anything else                -> download link
  *
  * Layout: sticky frosted header (back + icon + name + size + download) + a
  * centered reading column.
  */
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import { Markdown } from "@/components/markdown";
 import { ArrowLeft, Loader2, AlertCircle, Download, FileText } from "lucide-react";
 import { cloudApi, formatBytes, type CloudRawFileResponse } from "@/lib/api/cloud";
 import { FileIconTile } from "./file-icon";
+
+/**
+ * Normalize the presigned MinIO URL to a same-origin path when it goes
+ * through the nginx /minio-proxy prefix. Embedding the absolute proxy URL
+ * (e.g. http://localhost/minio-proxy/...) in an <iframe> trips nginx's
+ * X-Frame-Options: SAMEORIGIN whenever the page origin differs (page on
+ * :3000, proxy on :80). next.config.ts proxies the identical path through
+ * the Next server, so the relative form stays same-origin for every media
+ * element below. Non-proxy URLs (custom MINIO__PUBLIC_ENDPOINT) are kept.
+ */
+function toSameOriginUrl(url: string): string {
+    try {
+        const u = new URL(url, window.location.origin);
+        if (u.pathname.startsWith("/minio-proxy/")) return u.pathname + u.search;
+        return url;
+    } catch {
+        return url;
+    }
+}
 
 export function FileViewer() {
     const pathname = usePathname();
@@ -31,6 +52,18 @@ export function FileViewer() {
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
 
+    // PDF: open the file in a NEW tab and let the browser's native viewer
+    // take over; this page stays as a status card with manual links in case
+    // the popup is blocked. The ref guard keeps React StrictMode's dev
+    // double-invoke from opening two tabs.
+    const pdfAutoOpened = useRef(false);
+    useEffect(() => {
+        if (raw?.viewMode === "pdf" && raw.url && !pdfAutoOpened.current) {
+            pdfAutoOpened.current = true;
+            window.open(raw.url, "_blank");
+        }
+    }, [raw?.viewMode, raw?.url]);
+
     useEffect(() => {
         if (!uuid) return;
         let cancelled = false;
@@ -38,7 +71,7 @@ export function FileViewer() {
             try {
                 const r = await cloudApi.getRawFile(uuid);
                 if (!cancelled) {
-                    setRaw(r);
+                    setRaw({ ...r, url: toSameOriginUrl(r.url) });
                     setLoading(false);
                 }
             } catch (e) {
@@ -159,12 +192,31 @@ function RawContent({ raw }: { raw: CloudRawFileResponse }) {
                 />
             );
         case "pdf":
+            // The auto-open effect opened a new tab (native PDF viewer); this
+            // card covers the popup-blocked case with a real anchor link.
             return (
-                <iframe
-                    src={raw.url}
-                    title={raw.fileName}
-                    className="h-[80vh] w-full rounded-2xl border border-border-subtle"
-                />
+                <div className="flex flex-col items-center justify-center py-24 text-center">
+                    <span className="grid h-14 w-14 place-items-center rounded-2xl bg-border-subtle text-secondary">
+                        <FileText className="h-6 w-6" />
+                    </span>
+                    <p className="mt-4 text-[15px] font-medium text-foreground">PDF 已在新标签页打开</p>
+                    <p className="mt-1.5 max-w-xs text-[13px] text-secondary">
+                        由浏览器内置查看器展示；若新标签页未出现，点击下方链接手动打开。
+                    </p>
+                    <a
+                        href={raw.url}
+                        target="_blank"
+                        rel="noopener"
+                        className="btn-pill btn-primary mt-5 h-9 px-5 text-[13px]"
+                    >
+                        <FileText className="h-4 w-4" />
+                        在新标签页打开 PDF
+                    </a>
+                    <a href={raw.url} download={raw.fileName} className="btn-pill btn-ghost mt-2 h-9 px-5 text-[13px]">
+                        <Download className="h-4 w-4" />
+                        下载原文件
+                    </a>
+                </div>
             );
         case "html":
             if (raw.content == null) return <TooLargeDownload raw={raw} />;

--- a/frontendv2/components/cloud-drive/folder-sidebar.tsx
+++ b/frontendv2/components/cloud-drive/folder-sidebar.tsx
@@ -1,14 +1,20 @@
 "use client";
 
 /**
- * Folder sidebar - recursive folder tree + inline create + delete.
+ * Folder sidebar - recursive folder tree with full CRUD.
  *
  * Apple Finder sidebar feel: a "全部文件" root entry, then a collapsible
- * nested tree. Active folder = accent-soft + accent text; hover reveals a
- * delete affordance. Creating a folder shows an inline input at the top of
- * the tree. A footer shows the total file count across all folders.
+ * nested tree. Active folder = accent-soft + accent text; hover reveals the
+ * action group (new subfolder / rename / delete). Creating shows an inline
+ * input under the target node (or at the tree top for the root); renaming
+ * swaps the row's name for an inline input.
+ *
+ * State ownership:
+ *  - expanded/collapsed: lifted here (persisted to localStorage); selection
+ *    changes auto-expand the ancestor chain and scroll the row into view.
+ *  - drafts (create/rename input text): local to the node rendering them.
  */
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useCallback } from "react";
 import {
     Cloud,
     Folder,
@@ -16,11 +22,15 @@ import {
     ChevronRight,
     ChevronDown,
     Trash2,
+    Pencil,
     Loader2,
     X,
+    FolderOpen,
 } from "lucide-react";
 import type { CloudFolderTreeItem } from "@/lib/api/cloud";
 import { cn } from "@/lib/utils";
+
+const COLLAPSED_KEY = "cloud-drive:collapsed-folders";
 
 interface FolderSidebarProps {
     folders: CloudFolderTreeItem[];
@@ -28,8 +38,37 @@ interface FolderSidebarProps {
     selectedFolderId: number | null;
     totalCount: number;
     onSelect: (id: number | null) => void;
-    onCreateFolder: (name: string) => Promise<void>;
+    onCreateFolder: (name: string, parentId: number | null) => Promise<void>;
+    onRenameFolder: (id: number, name: string) => Promise<void>;
     onDeleteFolder: (folder: CloudFolderTreeItem) => void;
+}
+
+function readCollapsed(): Set<number> {
+    if (typeof window === "undefined") return new Set();
+    try {
+        const raw = window.localStorage.getItem(COLLAPSED_KEY);
+        const arr = raw ? (JSON.parse(raw) as number[]) : [];
+        return new Set(Array.isArray(arr) ? arr : []);
+    } catch {
+        return new Set();
+    }
+}
+
+/** Ancestor ids on the path to targetId (empty when target not found). */
+function findAncestors(
+    folders: CloudFolderTreeItem[],
+    targetId: number,
+    trail: number[] = []
+): number[] {
+    for (const folder of folders) {
+        if (folder.id === targetId) return trail;
+        const hit = findAncestors(folder.children, targetId, [...trail, folder.id]);
+        if (hit.length > 0 || folder.children.some((c) => c.id === targetId)) {
+            if (hit.length > 0) return hit;
+            return [...trail, folder.id];
+        }
+    }
+    return [];
 }
 
 export function FolderSidebar({
@@ -39,31 +78,55 @@ export function FolderSidebar({
     totalCount,
     onSelect,
     onCreateFolder,
+    onRenameFolder,
     onDeleteFolder,
 }: FolderSidebarProps) {
-    const [creating, setCreating] = useState(false);
-    const [draftName, setDraftName] = useState("");
-    const [busy, setBusy] = useState(false);
-    const inputRef = useRef<HTMLInputElement>(null);
+    const [collapsed, setCollapsed] = useState<Set<number>>(() => readCollapsed());
+    // null = none; { parentId: null } = root-level create.
+    const [createTarget, setCreateTarget] = useState<{ parentId: number | null } | null>(null);
+    const [renamingId, setRenamingId] = useState<number | null>(null);
+    const navRef = useRef<HTMLElement>(null);
+
+    // Persist collapsed ids.
+    useEffect(() => {
+        try {
+            window.localStorage.setItem(COLLAPSED_KEY, JSON.stringify([...collapsed]));
+        } catch {
+            // Storage unavailable - expansion just won't persist.
+        }
+    }, [collapsed]);
+
+    // Selection (including a restored one from localStorage) must reveal its
+    // folder: expand ancestors and scroll the row into view.
+    useEffect(() => {
+        if (selectedFolderId == null) return;
+        const ancestors = findAncestors(folders, selectedFolderId);
+        if (ancestors.length === 0) return;
+        setCollapsed((prev) => {
+            const next = new Set(prev);
+            let changed = false;
+            for (const id of ancestors) {
+                if (next.delete(id)) changed = true;
+            }
+            return changed ? next : prev;
+        });
+    }, [selectedFolderId, folders]);
 
     useEffect(() => {
-        if (creating) inputRef.current?.focus();
-    }, [creating]);
+        if (selectedFolderId == null || loading) return;
+        navRef.current
+            ?.querySelector(`[data-folder-id="${selectedFolderId}"]`)
+            ?.scrollIntoView({ block: "nearest" });
+    }, [selectedFolderId, folders, loading, collapsed]);
 
-    const submitCreate = async () => {
-        const name = draftName.trim();
-        if (!name || busy) return;
-        setBusy(true);
-        try {
-            await onCreateFolder(name);
-            setCreating(false);
-            setDraftName("");
-        } catch {
-            // Keep the input open so the error is visible.
-        } finally {
-            setBusy(false);
-        }
-    };
+    const toggle = useCallback((id: number) => {
+        setCollapsed((prev) => {
+            const next = new Set(prev);
+            if (next.has(id)) next.delete(id);
+            else next.add(id);
+            return next;
+        });
+    }, []);
 
     return (
         <div className="flex h-full flex-col">
@@ -72,7 +135,10 @@ export function FolderSidebar({
                 <h2 className="text-[13px] font-semibold text-foreground">位置</h2>
                 <button
                     type="button"
-                    onClick={() => setCreating((v) => !v)}
+                    onClick={() => {
+                        setRenamingId(null);
+                        setCreateTarget({ parentId: null });
+                    }}
                     title="新建文件夹"
                     aria-label="新建文件夹"
                     className="grid h-7 w-7 place-items-center rounded-full text-secondary transition-colors hover:bg-border-subtle hover:text-foreground"
@@ -82,7 +148,7 @@ export function FolderSidebar({
             </div>
 
             {/* Tree */}
-            <nav className="flex-1 overflow-y-auto px-2 pb-2">
+            <nav ref={navRef} className="flex-1 overflow-y-auto px-2 pb-2">
                 {/* All files root */}
                 <button
                     type="button"
@@ -98,39 +164,16 @@ export function FolderSidebar({
                     <span className="truncate">全部文件</span>
                 </button>
 
-                {/* Inline create input */}
-                {creating && (
-                    <div className="mt-0.5 flex items-center gap-2 rounded-[10px] bg-accent-soft px-2.5 py-1.5">
-                        <Folder className="h-4 w-4 shrink-0 text-accent" />
-                        <input
-                            ref={inputRef}
-                            value={draftName}
-                            onChange={(e) => setDraftName(e.target.value)}
-                            onKeyDown={(e) => {
-                                if (e.key === "Enter") void submitCreate();
-                                if (e.key === "Escape") {
-                                    setCreating(false);
-                                    setDraftName("");
-                                }
-                            }}
-                            placeholder="文件夹名称"
-                            className="min-w-0 flex-1 bg-transparent text-[13px] text-foreground outline-none placeholder:text-tertiary"
-                        />
-                        {busy ? (
-                            <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin text-accent" />
-                        ) : (
-                            <button
-                                type="button"
-                                onClick={() => {
-                                    setCreating(false);
-                                    setDraftName("");
-                                }}
-                                className="shrink-0 text-tertiary hover:text-foreground"
-                            >
-                                <X className="h-3.5 w-3.5" />
-                            </button>
-                        )}
-                    </div>
+                {/* Root-level inline create input */}
+                {createTarget?.parentId === null && (
+                    <InlineCreateInput
+                        depth={0}
+                        onCancel={() => setCreateTarget(null)}
+                        onSubmit={async (name) => {
+                            await onCreateFolder(name, null);
+                            setCreateTarget(null);
+                        }}
+                    />
                 )}
 
                 {/* Loading */}
@@ -145,6 +188,18 @@ export function FolderSidebar({
                     </div>
                 )}
 
+                {/* Empty state */}
+                {!loading && folders.length === 0 && (
+                    <div className="flex flex-col items-center gap-1.5 px-3 pt-6 text-center">
+                        <FolderOpen className="h-6 w-6 text-tertiary" />
+                        <p className="text-[12px] text-tertiary">
+                            还没有文件夹
+                            <br />
+                            点击右上角新建
+                        </p>
+                    </div>
+                )}
+
                 {/* Recursive tree */}
                 {!loading &&
                     folders.map((folder) => (
@@ -152,8 +207,16 @@ export function FolderSidebar({
                             key={folder.id}
                             folder={folder}
                             depth={0}
+                            collapsed={collapsed}
+                            onToggle={toggle}
                             selectedFolderId={selectedFolderId}
                             onSelect={onSelect}
+                            createTarget={createTarget}
+                            setCreateTarget={setCreateTarget}
+                            renamingId={renamingId}
+                            setRenamingId={setRenamingId}
+                            onCreateFolder={onCreateFolder}
+                            onRenameFolder={onRenameFolder}
                             onDeleteFolder={onDeleteFolder}
                         />
                     ))}
@@ -167,26 +230,138 @@ export function FolderSidebar({
     );
 }
 
+/** Indented inline input used for both root-level and in-folder creation. */
+function InlineCreateInput({
+    depth,
+    onCancel,
+    onSubmit,
+}: {
+    depth: number;
+    onCancel: () => void;
+    onSubmit: (name: string) => Promise<void>;
+}) {
+    const [draftName, setDraftName] = useState("");
+    const [busy, setBusy] = useState(false);
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    useEffect(() => {
+        inputRef.current?.focus();
+    }, []);
+
+    const submit = async () => {
+        const name = draftName.trim();
+        if (!name || busy) return;
+        setBusy(true);
+        try {
+            await onSubmit(name);
+        } catch {
+            // Keep the input open so the error is visible.
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    return (
+        <div
+            className="mt-0.5 flex items-center gap-2 rounded-[10px] bg-accent-soft px-2.5 py-1.5"
+            style={{ marginLeft: depth * 12 + 4 }}
+        >
+            <Folder className="h-4 w-4 shrink-0 text-accent" />
+            <input
+                ref={inputRef}
+                value={draftName}
+                onChange={(e) => setDraftName(e.target.value)}
+                onKeyDown={(e) => {
+                    if (e.key === "Enter") void submit();
+                    if (e.key === "Escape") onCancel();
+                }}
+                maxLength={80}
+                placeholder="文件夹名称"
+                className="min-w-0 flex-1 bg-transparent text-[13px] text-foreground outline-none placeholder:text-tertiary"
+            />
+            {busy ? (
+                <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin text-accent" />
+            ) : (
+                <button
+                    type="button"
+                    onClick={onCancel}
+                    className="shrink-0 text-tertiary hover:text-foreground"
+                    aria-label="取消"
+                >
+                    <X className="h-3.5 w-3.5" />
+                </button>
+            )}
+        </div>
+    );
+}
+
 function FolderNode({
     folder,
     depth,
+    collapsed,
+    onToggle,
     selectedFolderId,
     onSelect,
+    createTarget,
+    setCreateTarget,
+    renamingId,
+    setRenamingId,
+    onCreateFolder,
+    onRenameFolder,
     onDeleteFolder,
 }: {
     folder: CloudFolderTreeItem;
     depth: number;
+    collapsed: Set<number>;
+    onToggle: (id: number) => void;
     selectedFolderId: number | null;
     onSelect: (id: number | null) => void;
+    createTarget: { parentId: number | null } | null;
+    setCreateTarget: (t: { parentId: number | null } | null) => void;
+    renamingId: number | null;
+    setRenamingId: (id: number | null) => void;
+    onCreateFolder: (name: string, parentId: number | null) => Promise<void>;
+    onRenameFolder: (id: number, name: string) => Promise<void>;
     onDeleteFolder: (folder: CloudFolderTreeItem) => void;
 }) {
-    const [open, setOpen] = useState(true);
     const hasChildren = folder.children.length > 0;
     const active = selectedFolderId === folder.id;
+    const open = !collapsed.has(folder.id);
+    const renaming = renamingId === folder.id;
+    const creatingHere = createTarget?.parentId === folder.id;
+    const [renameDraft, setRenameDraft] = useState("");
+    const [renameBusy, setRenameBusy] = useState(false);
+    const renameInputRef = useRef<HTMLInputElement>(null);
+
+    useEffect(() => {
+        if (renaming) {
+            setRenameDraft(folder.name);
+            renameInputRef.current?.focus();
+            renameInputRef.current?.select();
+        }
+    }, [renaming, folder.name]);
+
+    const submitRename = async () => {
+        const name = renameDraft.trim();
+        if (!name || renameBusy || name === folder.name) {
+            setRenamingId(null);
+            return;
+        }
+        setRenameBusy(true);
+        try {
+            await onRenameFolder(folder.id, name);
+            setRenamingId(null);
+        } catch {
+            // Keep the input open so the error is visible.
+        } finally {
+            setRenameBusy(false);
+        }
+    };
 
     return (
         <div>
             <div
+                data-folder-id={folder.id}
                 className={cn(
                     "group flex items-center gap-1 rounded-[10px] pr-1 transition-colors",
                     active ? "bg-accent-soft" : "hover:bg-border-subtle/70"
@@ -195,9 +370,10 @@ function FolderNode({
             >
                 <button
                     type="button"
-                    onClick={() => hasChildren && setOpen((v) => !v)}
+                    onClick={() => hasChildren && onToggle(folder.id)}
+                    aria-expanded={hasChildren ? open : undefined}
                     className={cn(
-                        "grid h-6 w-5 shrink-0 place-items-center text-tertiary",
+                        "grid h-6 w-5 shrink-0 place-items-center text-tertiary transition-transform",
                         !hasChildren && "invisible"
                     )}
                 >
@@ -207,43 +383,119 @@ function FolderNode({
                         <ChevronRight className="h-3.5 w-3.5" />
                     )}
                 </button>
-                <button
-                    type="button"
-                    onClick={() => onSelect(folder.id)}
-                    className={cn(
-                        "flex min-w-0 flex-1 items-center gap-2 py-1.5 text-[13px]",
-                        active ? "font-medium text-accent" : "text-foreground"
-                    )}
-                >
-                    <Folder
-                        className={cn(
-                            "h-4 w-4 shrink-0",
-                            active ? "text-accent" : "text-secondary"
+
+                {renaming ? (
+                    <div className="flex min-w-0 flex-1 items-center gap-2 py-1.5">
+                        <Folder className="h-4 w-4 shrink-0 text-accent" />
+                        <input
+                            ref={renameInputRef}
+                            value={renameDraft}
+                            disabled={renameBusy}
+                            onChange={(e) => setRenameDraft(e.target.value)}
+                            onKeyDown={(e) => {
+                                if (e.key === "Enter") void submitRename();
+                                if (e.key === "Escape") setRenamingId(null);
+                            }}
+                            maxLength={80}
+                            className="min-w-0 flex-1 bg-transparent text-[13px] text-foreground outline-none"
+                        />
+                        {renameBusy ? (
+                            <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin text-accent" />
+                        ) : (
+                            <button
+                                type="button"
+                                onClick={() => setRenamingId(null)}
+                                className="shrink-0 text-tertiary hover:text-foreground"
+                                aria-label="取消重命名"
+                            >
+                                <X className="h-3.5 w-3.5" />
+                            </button>
                         )}
-                    />
-                    <span className="truncate">{folder.name}</span>
-                    {folder.videoCount > 0 && (
-                        <span className="ml-auto shrink-0 text-[11px] tabular-nums text-tertiary">
-                            {folder.videoCount}
-                        </span>
-                    )}
-                </button>
-                <button
-                    type="button"
-                    onClick={(e) => {
-                        e.stopPropagation();
-                        onDeleteFolder(folder);
-                    }}
-                    title="删除文件夹"
-                    aria-label="删除文件夹"
-                    className={cn(
-                        "grid h-6 w-6 shrink-0 place-items-center rounded-full text-tertiary transition-colors hover:bg-danger/10 hover:text-danger",
-                        active ? "opacity-100" : "opacity-0 group-hover:opacity-100"
-                    )}
-                >
-                    <Trash2 className="h-3.5 w-3.5" />
-                </button>
+                    </div>
+                ) : (
+                    <>
+                        <button
+                            type="button"
+                            onClick={() => onSelect(folder.id)}
+                            className={cn(
+                                "flex min-w-0 flex-1 items-center gap-2 py-1.5 text-[13px]",
+                                active ? "font-medium text-accent" : "text-foreground"
+                            )}
+                        >
+                            <Folder
+                                className={cn(
+                                    "h-4 w-4 shrink-0",
+                                    active ? "text-accent" : "text-secondary"
+                                )}
+                            />
+                            <span className="truncate">{folder.name}</span>
+                            {folder.videoCount > 0 && (
+                                <span className="ml-auto shrink-0 text-[11px] tabular-nums text-tertiary">
+                                    {folder.videoCount}
+                                </span>
+                            )}
+                        </button>
+                        {/* Hover action group: create subfolder / rename / delete */}
+                        <div
+                            className={cn(
+                                "flex shrink-0 items-center",
+                                active ? "opacity-100" : "opacity-0 group-hover:opacity-100"
+                            )}
+                        >
+                            <button
+                                type="button"
+                                onClick={(e) => {
+                                    e.stopPropagation();
+                                    setRenamingId(null);
+                                    setCreateTarget({ parentId: folder.id });
+                                }}
+                                title="新建子文件夹"
+                                aria-label={`在 ${folder.name} 中新建文件夹`}
+                                className="grid h-6 w-6 place-items-center rounded-full text-tertiary transition-colors hover:bg-accent-soft hover:text-accent"
+                            >
+                                <FolderPlus className="h-3.5 w-3.5" />
+                            </button>
+                            <button
+                                type="button"
+                                onClick={(e) => {
+                                    e.stopPropagation();
+                                    setCreateTarget(null);
+                                    setRenamingId(folder.id);
+                                }}
+                                title="重命名"
+                                aria-label={`重命名 ${folder.name}`}
+                                className="grid h-6 w-6 place-items-center rounded-full text-tertiary transition-colors hover:bg-border-subtle hover:text-foreground"
+                            >
+                                <Pencil className="h-3.5 w-3.5" />
+                            </button>
+                            <button
+                                type="button"
+                                onClick={(e) => {
+                                    e.stopPropagation();
+                                    onDeleteFolder(folder);
+                                }}
+                                title="删除文件夹"
+                                aria-label={`删除 ${folder.name}`}
+                                className="grid h-6 w-6 place-items-center rounded-full text-tertiary transition-colors hover:bg-danger/10 hover:text-danger"
+                            >
+                                <Trash2 className="h-3.5 w-3.5" />
+                            </button>
+                        </div>
+                    </>
+                )}
             </div>
+
+            {/* Inline create input for a subfolder of THIS node */}
+            {creatingHere && (
+                <InlineCreateInput
+                    depth={depth + 1}
+                    onCancel={() => setCreateTarget(null)}
+                    onSubmit={async (name) => {
+                        await onCreateFolder(name, folder.id);
+                    }}
+                />
+            )}
+
             {hasChildren && open && (
                 <div>
                     {folder.children.map((child) => (
@@ -251,8 +503,16 @@ function FolderNode({
                             key={child.id}
                             folder={child}
                             depth={depth + 1}
+                            collapsed={collapsed}
+                            onToggle={onToggle}
                             selectedFolderId={selectedFolderId}
                             onSelect={onSelect}
+                            createTarget={createTarget}
+                            setCreateTarget={setCreateTarget}
+                            renamingId={renamingId}
+                            setRenamingId={setRenamingId}
+                            onCreateFolder={onCreateFolder}
+                            onRenameFolder={onRenameFolder}
                             onDeleteFolder={onDeleteFolder}
                         />
                     ))}

--- a/frontendv2/next.config.ts
+++ b/frontendv2/next.config.ts
@@ -1,14 +1,26 @@
 import type { NextConfig } from "next";
 
 const APISIX_HOST = process.env.NEXT_PUBLIC_APISIX_HOST || "localhost:9080";
+// MinIO 同源代理目标（Next 服务器可达的 nginx 地址）
+const MINIO_PROXY_DEST = process.env.MINIO_PROXY_DEST || "http://localhost";
 
 const nextConfig: NextConfig = {
   output: "standalone",
-  // 开发模式代理：将 API 请求转发到 APISIX
-  // 生产环境由 nginx 处理，此 rewrite 不生效（NEXT_PUBLIC_API_URL 设值时跳过）
+  // 开发模式代理：将 API 请求转发到 APISIX。
+  // 生产环境（NEXT_PUBLIC_API_URL 设值）跳过 API rewrite（由 nginx 处理），
+  // 但 MinIO 同源代理 rewrite 两种模式都保留（媒体元素需要同源嵌入）。
   async rewrites() {
     const backend = process.env.NEXT_PUBLIC_API_URL;
-    if (backend) return []; // 生产模式：nginx 代理，不需要 rewrite
+    // MinIO 同源代理：后端把 presigned URL 改写到 nginx 的 /minio-proxy 前缀
+    // （浏览器可达），但页面源与该前缀不同源时（页面 :3000 vs 代理 :80），
+    // nginx 的 X-Frame-Options: SAMEORIGIN 会拒绝 <iframe>/<video> 嵌入。
+    // 前端把 raw.url 归一化成同源相对路径，由 Next 服务端转发，媒体元素即可
+    // 保持同源。前后端约定：只要路径带 /minio-proxy/ 前缀就走此代理。
+    const minioProxy = {
+      source: "/minio-proxy/:path*",
+      destination: `${MINIO_PROXY_DEST}/minio-proxy/:path*`,
+    };
+    if (backend) return { beforeFiles: [minioProxy] }; // 生产模式：仅保留 minio 代理
     // dev: /tasks/* 和 /task-quiz/* 既是 Next.js 页面路由又是后端 API 路径。
     // fallback rewrites 在页面路由之后，会让 API fetch 命中页面返回 HTML（JSON parse 失败）。
     // 用 beforeFiles + X-Requested-With header 区分：
@@ -16,6 +28,7 @@ const nextConfig: NextConfig = {
     //   页面导航（无 header）-> Next.js 页面路由
     return {
       beforeFiles: [
+        minioProxy,
         {
           source: "/tasks",
           destination: `http://${APISIX_HOST}/tasks`,


### PR DESCRIPTION
Closes #92

## 改动总览（4 commits，按模块拆分）

### 1. [frontend] PDF 同源代理 + 新标签页原生预览
- `frontendv2/next.config.ts`：新增 `/minio-proxy/:path*` beforeFiles rewrite（Next 服务端转发 nginx→MinIO），生产模式（`NEXT_PUBLIC_API_URL` 设值）也保留；**rewrites 在构建时固化进 routes-manifest，destination 必须走 build arg**（`MINIO_PROXY_DEST`，运行时 env 无效——本次踩坑实证）。
- `frontendv2/components/cloud-drive/file-viewer.tsx`：presigned URL 归一化为同源相对路径（带 `/minio-proxy/` 前缀时），PDF 改为 `window.open` 新标签页交给浏览器原生查看器（带弹窗拦截兜底卡片 + 下载链接），video/audio/image 不变。
- `frontendv2/Dockerfile`：npm registry 切 npmmirror（musl swc 二进制不在 Windows 锁文件，next build 现场下载直连必断）；healthcheck 改 `wget 127.0.0.1`（busybox localhost→IPv6 vs Next 只绑 IPv4，unhealthy 误报根因）。

### 2. [backend] presign 注入真实 MIME + 构建加固
- `app/infra/minio.py`：`presigned_get` 支持 `response_headers`（签名进 query）。
- `app/routers/cloud.py`：`/raw` 对 pdf/video/audio/image 注入 `response-content-type=file.mime_type`——解决 octet-stream+nosniff 拒嗅探，**对存量对象同样生效**。
- `Dockerfile`：FROM digest 固定（buildkit 联网解析 tag 国内反复失败，digest 离线命中本地镜像）；pip `--timeout 120 --retries 5`（默认 15s 清华源大包必超时）。

### 3. [docker] compose 传 `MINIO_PROXY_DEST` build arg

### 4. [frontend] 侧边目录增强
- 任意层级新建子文件夹（hover `+`，内嵌输入框）；
- 重命名（`PATCH /cloud/folders/{id}` 前端首次接线）；
- 展开/折叠状态持久化 localStorage；
- 选中深层文件夹自动展开祖先链 + scrollIntoView；
- 无文件夹空状态。

## 验证

- [x] `tsc --noEmit` + `next build` 通过
- [x] 同一 presigned URL：直连 nginx 200；经 `:3000` 同源代理 200 + `Content-Type: application/pdf`（211KB PDF 完整）
- [x] 容器内 SDK 签名 + GET 实测 MIME 注入生效
- [x] 侧边目录新代码已确认在容器产物中，页面 200
- [x] 本地 Docker Desktop 全栈手工回归：上传→入库→预览→新标签页原生渲染

## 影响范围

- 不触碰 chat/RAG/session 链路；`/raw` 响应结构不变（仅 URL 查询串多签名参数）
- 兼容自定义 `MINIO__PUBLIC_ENDPOINT`（非 /minio-proxy 路径时前端保持绝对 URL 不改写）