### PR TITLE
[desktop][config] chore: Cargo.lock 版本同步 + gitignore 根目录 reports/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,5 @@ _tmp2/
 
 #zcode
 .zcode/
+# 根目录 reports/ 为一次性评测产物，不入库
+reports/

--- a/mind-base-desktop/src-tauri/Cargo.lock
+++ b/mind-base-desktop/src-tauri/Cargo.lock
@@ -2161,7 +2161,7 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mind-base-desktop"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "futures-util",
  "http",


### PR DESCRIPTION
## 内容（2 commits，均为独立小修）

1. **[desktop]** `mind-base-desktop/src-tauri/Cargo.lock` 版本号 0.1.0→0.1.1——此前 c0d36d5 提升版本时遗漏了锁文件
2. **[config]** `.gitignore` 增加 `reports/`——根目录 reports/ 是一次性评测产物（上下文压缩质量报告），不应入库

## 说明

- 单模块小修，按规范不开 issue
- gitignore 生效后工作区那两个 reports/ 文件转为本地保留、不再出现在 git status