### PR TITLE
[desktop] feat: 媒体缓存 LRU 配额清理 + 版本 0.1.2

### DIFF
--- a/mind-base-desktop/package.json
+++ b/mind-base-desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mind-base-desktop",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/mind-base-desktop/src-tauri/Cargo.lock
+++ b/mind-base-desktop/src-tauri/Cargo.lock
@@ -1032,6 +1032,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2161,8 +2171,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mind-base-desktop"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
+ "filetime",
  "futures-util",
  "http",
  "md-5",

--- a/mind-base-desktop/src-tauri/Cargo.toml
+++ b/mind-base-desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mind-base-desktop"
-version = "0.1.1"
+version = "0.1.2"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"
@@ -42,6 +42,11 @@ tokio = { version = "1", features = ["rt", "net", "time", "io-util"] }
 tokio-tungstenite = "0.24"
 futures-util = "0.3"
 http = "1"
+
+# Test-only: backdate mtimes to exercise LRU eviction order and the grace window.
+# (cross-platform mtime setting isn't exposed by std)
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+filetime = "0.2"
 
 
 # Read the optimization guideline for more details: https://tauri.app/concept/size/#cargo-configuration

--- a/mind-base-desktop/src-tauri/src/config.rs
+++ b/mind-base-desktop/src-tauri/src/config.rs
@@ -140,6 +140,10 @@ pub struct AppConfig {
     /// 本地 faster-whisper-server 设置（方案 A）。缺省反序列化为默认值。
     #[serde(default)]
     pub local_asr: LocalAsrConfig,
+    /// 媒体缓存（下载的音频/视频 + 抽出的 WAV）LRU 配额上限，单位 MB。
+    /// 0 = 禁用清理。每次入库结束后按文件 mtime 从旧到新删除直到总量达标。
+    #[serde(default = "default_media_cache_max_mb")]
+    pub media_cache_max_mb: u32,
 }
 
 impl Default for AppConfig {
@@ -152,8 +156,14 @@ impl Default for AppConfig {
             ffmpeg_path_override: None,
             default_chat_provider: None,
             local_asr: LocalAsrConfig::default(),
+            media_cache_max_mb: default_media_cache_max_mb(),
         }
     }
+}
+
+/// Default media-cache quota: 2 GiB, enough to inspect several recent runs.
+fn default_media_cache_max_mb() -> u32 {
+    2048
 }
 
 /// Read the raw JSON payload stored under [`CONFIG_KEY`], if any.

--- a/mind-base-desktop/src-tauri/src/ingest.rs
+++ b/mind-base-desktop/src-tauri/src/ingest.rs
@@ -493,6 +493,28 @@ fn run_ingestion(
         }
     }
 
+    // Enforce the media-cache LRU quota after the run. The downloaded
+    // audio/video + WAV are kept for inspection but must not grow without
+    // bound; a cleanup failure must never fail the ingestion itself, so the
+    // quota degrades to the built-in default when config is unreadable.
+    let quota_bytes = match db.conn.lock() {
+        Ok(conn) => crate::config::load(&conn)
+            .map(|cfg| u64::from(cfg.media_cache_max_mb) * 1024 * 1024)
+            .unwrap_or(crate::media_cache::DEFAULT_FALLBACK_QUOTA_BYTES),
+        Err(_) => crate::media_cache::DEFAULT_FALLBACK_QUOTA_BYTES,
+    };
+    match crate::media_cache::evict_to_quota(&media_dir, quota_bytes) {
+        Ok(report) if report.removed_files > 0 => crate::logging::info(
+            "ingest",
+            &format!(
+                "media cache evicted files={} freed_bytes={}",
+                report.removed_files, report.freed_bytes
+            ),
+        ),
+        Ok(_) => {}
+        Err(err) => crate::logging::warn("ingest", &format!("media cache eviction failed: {err}")),
+    }
+
     emit(&IngestEvent::Done { ok, failed }, channel);
     Ok(IngestSummary { ok, failed })
 }

--- a/mind-base-desktop/src-tauri/src/lib.rs
+++ b/mind-base-desktop/src-tauri/src/lib.rs
@@ -13,6 +13,7 @@ mod harness;
 mod ingest;
 mod llm_chat;
 mod logging;
+mod media_cache;
 mod notes;
 mod python_runtime;
 mod quiz;

--- a/mind-base-desktop/src-tauri/src/media_cache.rs
+++ b/mind-base-desktop/src-tauri/src/media_cache.rs
@@ -1,0 +1,192 @@
+//! LRU size-quota eviction for the persisted media cache.
+//!
+//! Downloaded audio/video and extracted WAVs are deliberately kept under the
+//! app data dir (see `ingest.rs`) so failures can be inspected; this module
+//! bounds their total size instead of letting them grow without limit.
+//!
+//! LRU key is the file mtime: every file is written once by an ingest run, so
+//! "most recently used" is "most recently downloaded/extracted". Eviction runs
+//! after each ingestion run (not on a timer) and deletes oldest-first until
+//! the directory total fits the quota. Files touched within the grace window
+//! are never deleted — a concurrent ingest run may still be uploading them.
+
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+/// Files modified within this window are treated as actively in use by a
+/// concurrent ingest run and are skipped by eviction.
+const ACTIVE_GRACE: Duration = Duration::from_secs(10 * 60);
+
+/// Quota used when the stored config can't be read at eviction time (2 GiB,
+/// matching [`crate::config::default_media_cache_max_mb`]).
+pub const DEFAULT_FALLBACK_QUOTA_BYTES: u64 = 2048 * 1024 * 1024;
+
+/// One eviction pass outcome, in bytes freed and files removed.
+#[derive(Debug, Default)]
+pub struct EvictionReport {
+    pub freed_bytes: u64,
+    pub removed_files: usize,
+}
+
+/// Enforce `max_bytes` on everything under `media_dir` (recursive, so the
+/// extracted-WAV naming scheme can change without updating this module).
+/// `max_bytes == 0` disables eviction entirely. Returns the eviction report;
+/// individual deletion failures are logged and skipped, never propagated.
+pub fn evict_to_quota(media_dir: &Path, max_bytes: u64) -> Result<EvictionReport, String> {
+    let mut report = EvictionReport::default();
+    if max_bytes == 0 {
+        return Ok(report);
+    }
+
+    let mut files: Vec<(PathBuf, u64, SystemTime)> = Vec::new();
+    let mut stack = vec![media_dir.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let entries = match std::fs::read_dir(&dir) {
+            Ok(entries) => entries,
+            // A missing media dir just means nothing was ingested yet.
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(err) => {
+                return Err(format!(
+                    "无法读取媒体缓存目录 {}：{err}",
+                    dir.display()
+                ))
+            }
+        };
+        for entry in entries {
+            let entry = match entry {
+                Ok(entry) => entry,
+                Err(err) => {
+                    crate::logging::warn(
+                        "media_cache",
+                        &format!("skip unreadable entry in {}: {err}", dir.display()),
+                    );
+                    continue;
+                }
+            };
+            let path = entry.path();
+            let meta = match entry.metadata() {
+                Ok(meta) => meta,
+                Err(err) => {
+                    crate::logging::warn(
+                        "media_cache",
+                        &format!("skip unreadable file {}: {err}", path.display()),
+                    );
+                    continue;
+                }
+            };
+            if meta.is_dir() {
+                stack.push(path);
+            } else if meta.is_file() {
+                files.push((path, meta.len(), meta.modified().unwrap_or(SystemTime::now())));
+            }
+        }
+    }
+
+    let total: u64 = files.iter().map(|(_, size, _)| *size).sum();
+    if total <= max_bytes {
+        return Ok(report);
+    }
+
+    // Oldest first: evict least-recently-used until the total fits.
+    files.sort_by_key(|(_, _, mtime)| *mtime);
+    let cutoff = SystemTime::now()
+        .checked_sub(ACTIVE_GRACE)
+        .unwrap_or(SystemTime::UNIX_EPOCH);
+    let mut remaining = total;
+    for (path, size, mtime) in files {
+        if remaining <= max_bytes {
+            break;
+        }
+        if mtime > cutoff {
+            continue;
+        }
+        match std::fs::remove_file(&path) {
+            Ok(()) => {
+                remaining = remaining.saturating_sub(size);
+                report.freed_bytes += size;
+                report.removed_files += 1;
+                crate::logging::info(
+                    "media_cache",
+                    &format!("evicted path={} bytes={}", path.display(), size),
+                );
+            }
+            Err(err) => {
+                crate::logging::warn(
+                    "media_cache",
+                    &format!("failed to evict {}: {err}", path.display()),
+                );
+            }
+        }
+    }
+
+    if report.removed_files > 0 {
+        crate::logging::info(
+            "media_cache",
+            &format!(
+                "quota={}MB total_before={}MB freed={}MB removed={} (still over quota: {})",
+                max_bytes / (1024 * 1024),
+                total / (1024 * 1024),
+                report.freed_bytes / (1024 * 1024),
+                report.removed_files,
+                remaining > max_bytes,
+            ),
+        );
+    }
+    Ok(report)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    fn write(path: &Path, len: usize, age_secs: u64) {
+        std::fs::write(path, vec![0u8; len]).unwrap();
+        let mtime = SystemTime::now() - Duration::from_secs(age_secs);
+        filetime::set_file_mtime(path, filetime::FileTime::from_system_time(mtime)).unwrap();
+    }
+
+    #[test]
+    fn evicts_oldest_first_and_respects_grace() {
+        let dir = std::env::temp_dir().join(format!("mb-media-lru-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        write(&dir.join("old.m4s"), 1000, 3600);
+        // Within the 10-minute grace window: must survive even though
+        // deleting it would be the only way to reach the quota.
+        write(&dir.join("mid.m4s"), 1000, 120);
+        write(&dir.join("young.m4s"), 1000, 0);
+
+        let report = evict_to_quota(&dir, 1500).unwrap();
+        assert_eq!(report.removed_files, 1);
+        assert_eq!(report.freed_bytes, 1000);
+        assert!(!dir.join("old.m4s").exists());
+        assert!(dir.join("mid.m4s").exists());
+        assert!(dir.join("young.m4s").exists());
+
+        // Once the grace expires, a second pass evicts `mid` too.
+        write(&dir.join("mid.m4s"), 1000, 3600);
+        let report = evict_to_quota(&dir, 1500).unwrap();
+        assert_eq!(report.removed_files, 1);
+        assert!(!dir.join("mid.m4s").exists());
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn under_quota_is_noop_and_zero_disables() {
+        let dir = std::env::temp_dir().join(format!("mb-media-noop-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        write(&dir.join("a.m4s"), 100, 3600);
+
+        assert_eq!(evict_to_quota(&dir, 10_000).unwrap().removed_files, 0);
+        assert!(dir.join("a.m4s").exists());
+
+        // max_bytes == 0 disables eviction entirely.
+        assert_eq!(evict_to_quota(&dir, 0).unwrap().removed_files, 0);
+        assert!(dir.join("a.m4s").exists());
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+}

--- a/mind-base-desktop/src-tauri/tauri.conf.json
+++ b/mind-base-desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "mind-base-desktop",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "identifier": "io.github.atoncooper.mindbase",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## 背景

入库链路会把下载的音频（`.m4s`）、兜底下载的完整视频（`_comb.mp4`）和 ffmpeg 抽出的 WAV（`mb-extract-*.wav`）持久化在数据目录 `media/` 下，便于转写失败时排查。但此前**没有任何清理机制**（`delete_document` 只删 DB 行和向量），删除文档、重复入库也不会清理，磁盘占用无限增长。

## 方案：LRU 配额清理

- **新模块 `src-tauri/src/media_cache.rs`**：`evict_to_quota()` 递归扫描媒体目录，按 mtime（最近入库即最近使用）从旧到新删除，直到总量 ≤ 配额。
- **触发点**：每次 `run_ingestion` 结束（无论成败）执行一次；不新增常驻线程。
- **保护窗口**：mtime 距今 10 分钟内的文件永不删除，防止并发入库任务误删正在上传的音频/WAV。
- **配额配置**：新增 `mediaCacheMaxMb`（AppConfig，serde 默认 2048 MB；`0` = 禁用）。旧配置自动补默认值，前端无需改动。
- **容错**：清理失败 / 配额读取失败只记日志并退回内置默认 2 GiB，绝不影响入库结果。

## 测试

- 新增 2 个单测（`filetime` dev-dependency 回拨 mtime）：
  - LRU 删除顺序 + 保护窗生效（保护窗内的文件即使删它才能达标也不删）
  - 未超额 no-op + `max_bytes=0` 禁用
- `cargo test --lib media_cache` 通过；`cargo build` 无新增警告。

## 变更清单

- `media_cache.rs`（新增）：LRU 清理逻辑 + 单测
- `ingest.rs`：入库结束后触发清理
- `config.rs`：`media_cache_max_mb` 配置项（默认 2048）
- `Cargo.toml` / `Cargo.lock`：dev-dependency `filetime`
- 版本号 0.1.1 → 0.1.2（`tauri.conf.json` / `Cargo.toml` / `package.json` / `Cargo.lock`）

## 更新日志（v0.1.2）

- 修复：媒体缓存（下载的音频/视频/提取的 WAV）无限增长的问题——新增 LRU 配额清理，默认上限 2 GiB，每次入库结束后自动清理最旧的文件；可在配置中将 `mediaCacheMaxMb` 设为 0 关闭。