### PR TITLE
[desktop] feat: OCR 模型配置（云端 provider 槽位 + 本地 RapidOCR 模型管理）

### DIFF
--- a/mind-base-desktop/package.json
+++ b/mind-base-desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mind-base-desktop",
   "private": true,
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/mind-base-desktop/src-tauri/Cargo.toml
+++ b/mind-base-desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mind-base-desktop"
-version = "0.1.2"
+version = "0.1.3"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/mind-base-desktop/src-tauri/src/api_keys.rs
+++ b/mind-base-desktop/src-tauri/src/api_keys.rs
@@ -18,7 +18,7 @@
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-use rusqlite::{Connection, params};
+use rusqlite::{params, Connection};
 use serde::Serialize;
 use tauri::{AppHandle, State};
 
@@ -27,7 +27,14 @@ use crate::db::Db;
 /// Providers that may hold a stored configuration. `asr` / `embedding` are
 /// purpose slots: they override the conversational DashScope key for their
 /// specific pipeline and fall back to it when unset.
-const KNOWN_PROVIDERS: [&str; 5] = ["dashscope", "openrouter", "deepseek", "asr", "embedding"];
+const KNOWN_PROVIDERS: [&str; 6] = [
+    "dashscope",
+    "openrouter",
+    "deepseek",
+    "asr",
+    "embedding",
+    "ocr",
+];
 
 /// Upper bound for any accepted key; real provider keys stay far below this.
 const MAX_KEY_LEN: usize = 256;
@@ -48,12 +55,21 @@ const MASK_TAIL: usize = 4;
 const MASK_MIN_LEN: usize = MASK_HEAD + MASK_TAIL + 4;
 
 /// Official OpenAI-compatible endpoints used when no custom Base URL is set.
-const DEFAULT_ENDPOINTS: [(&str, &str); 5] = [
-    ("dashscope", "https://dashscope.aliyuncs.com/compatible-mode/v1"),
+const DEFAULT_ENDPOINTS: [(&str, &str); 6] = [
+    (
+        "dashscope",
+        "https://dashscope.aliyuncs.com/compatible-mode/v1",
+    ),
     ("openrouter", "https://openrouter.ai/api/v1"),
     ("deepseek", "https://api.deepseek.com/v1"),
     ("asr", "https://dashscope.aliyuncs.com/api/v1"),
-    ("embedding", "https://dashscope.aliyuncs.com/compatible-mode/v1"),
+    (
+        "embedding",
+        "https://dashscope.aliyuncs.com/compatible-mode/v1",
+    ),
+    // OCR 走 DashScope 兼容模式的多模态端点（qwen-vl-ocr 系列模型），
+    // /models 探针与其他兼容模式提供方一致。
+    ("ocr", "https://dashscope.aliyuncs.com/compatible-mode/v1"),
 ];
 
 /// Path appended to an endpoint to reach its cheap auth-check resource;
@@ -162,9 +178,7 @@ fn validate_base_url(url: &str) -> Result<String, String> {
         || trimmed.starts_with("ws://")
         || trimmed.starts_with("wss://"))
     {
-        return Err(
-            "Base URL 必须以 http://、https://、ws:// 或 wss:// 开头".to_string(),
-        );
+        return Err("Base URL 必须以 http://、https://、ws:// 或 wss:// 开头".to_string());
     }
     Ok(trimmed.to_string())
 }
@@ -368,9 +382,10 @@ fn describe_status(status: u16, model_count: Option<usize>) -> (bool, String) {
         401 | 403 => (false, "鉴权失败：API Key 无效或已过期".to_string()),
         404 => (false, "端点不存在：请检查 Base URL 是否正确".to_string()),
         429 => (false, "请求过于频繁或额度受限（HTTP 429）".to_string()),
-        code if (500..600).contains(&code) => {
-            (false, format!("提供方服务端错误（HTTP {code}），请稍后重试"))
-        }
+        code if (500..600).contains(&code) => (
+            false,
+            format!("提供方服务端错误（HTTP {code}），请稍后重试"),
+        ),
         code => (false, format!("意外的 HTTP 状态码 {code}")),
     }
 }
@@ -404,9 +419,8 @@ fn proxy_from_env() -> Option<String> {
 fn http_agent(timeout: Duration, proxy_url: Option<&str>) -> Result<ureq::Agent, String> {
     let builder = ureq::AgentBuilder::new().timeout(timeout);
     let builder = match proxy_url {
-        Some(url) => builder.proxy(
-            ureq::Proxy::new(url).map_err(|err| format!("invalid proxy url {url}: {err}"))?,
-        ),
+        Some(url) => builder
+            .proxy(ureq::Proxy::new(url).map_err(|err| format!("invalid proxy url {url}: {err}"))?),
         None => builder,
     };
     Ok(builder.build())
@@ -437,7 +451,11 @@ pub(crate) fn proxied_agent(timeout: Duration) -> Result<Option<ureq::Agent>, St
 /// Returns the HTTP status plus the advertised model count when the body was
 /// parseable JSON. Transport failures (DNS / connect / timeout) become `Err`;
 /// the key never appears in any error text.
-fn request_models(agent: &ureq::Agent, url: &str, key: &str) -> Result<(u16, Option<usize>), String> {
+fn request_models(
+    agent: &ureq::Agent,
+    url: &str,
+    key: &str,
+) -> Result<(u16, Option<usize>), String> {
     let response = agent
         .get(url)
         .set("Authorization", &format!("Bearer {key}"))
@@ -705,16 +723,14 @@ fn run_asr_e2e(
     model: String,
     ffmpeg_path: Option<PathBuf>,
 ) -> Result<ProviderTestResult, String> {
-    use crate::asr::{AsrClient, AsrMode, detect_mode};
+    use crate::asr::{detect_mode, AsrClient, AsrMode};
     let mut result = base;
 
-    let mode = detect_mode(
-        &if base_url.trim().is_empty() {
-            crate::asr::resolve_default_base()
-        } else {
-            base_url.clone()
-        },
-    );
+    let mode = detect_mode(&if base_url.trim().is_empty() {
+        crate::asr::resolve_default_base()
+    } else {
+        base_url.clone()
+    });
 
     // Model-existence check against the advertised `/models` list. This is
     // only meaningful for OpenAI-compatible endpoints: DashScope ASR models
@@ -761,13 +777,22 @@ fn run_asr_e2e(
                 let model_check = if mode == AsrMode::OpenAICompatible {
                     format!(
                         "模型 {} 校验{} · ",
-                        if model.trim().is_empty() { "(默认)" } else { &model },
-                        if model_ok { "通过" } else { "未找到（仍尝试）" },
+                        if model.trim().is_empty() {
+                            "(默认)"
+                        } else {
+                            &model
+                        },
+                        if model_ok {
+                            "通过"
+                        } else {
+                            "未找到（仍尝试）"
+                        },
                     )
                 } else {
                     String::new()
                 };
-                result.detail = format!("连接成功 · {model_list_part}{model_check}真实转写：{note}");
+                result.detail =
+                    format!("连接成功 · {model_list_part}{model_check}真实转写：{note}");
                 result.asr_note = Some(note);
                 // A successful real transcription probe confirms the endpoint
                 // + key + model all work end-to-end.
@@ -965,7 +990,10 @@ pub fn save_provider_config(
 
 /// Clear one provider's stored key, keeping base URL / model; idempotent.
 #[tauri::command]
-pub fn clear_provider_key(provider: String, db: State<'_, Db>) -> Result<Vec<ProviderStatus>, String> {
+pub fn clear_provider_key(
+    provider: String,
+    db: State<'_, Db>,
+) -> Result<Vec<ProviderStatus>, String> {
     let provider = validate_provider(&provider)?;
 
     let conn = db
@@ -997,8 +1025,14 @@ mod tests {
 
     #[test]
     fn provider_allowlist_normalizes_case_and_space() {
-        assert_eq!(validate_provider(" DashScope "), Ok("dashscope".to_string()));
-        assert_eq!(validate_provider("OPENROUTER"), Ok("openrouter".to_string()));
+        assert_eq!(
+            validate_provider(" DashScope "),
+            Ok("dashscope".to_string())
+        );
+        assert_eq!(
+            validate_provider("OPENROUTER"),
+            Ok("openrouter".to_string())
+        );
     }
 
     #[test]
@@ -1042,7 +1076,10 @@ mod tests {
     #[test]
     fn model_accepts_common_identifiers_and_empty() {
         assert_eq!(validate_model(" qwen-max "), Ok("qwen-max".to_string()));
-        assert_eq!(validate_model("openai/gpt-4o"), Ok("openai/gpt-4o".to_string()));
+        assert_eq!(
+            validate_model("openai/gpt-4o"),
+            Ok("openai/gpt-4o".to_string())
+        );
         assert_eq!(validate_model(""), Ok(String::new()));
     }
 
@@ -1073,10 +1110,7 @@ mod tests {
     fn asr_probe_url_rewrites_transcription_endpoint() {
         // OpenRouter transcription base → strip the resource, probe the models list.
         assert_eq!(
-            build_models_url(
-                "https://openrouter.ai/api/v1/audio/transcriptions",
-                "asr",
-            ),
+            build_models_url("https://openrouter.ai/api/v1/audio/transcriptions", "asr",),
             Some("https://openrouter.ai/api/v1/models".to_string())
         );
         // DashScope async base → compatible-mode models list.
@@ -1111,11 +1145,23 @@ mod tests {
         let conn = Connection::open_in_memory().expect("in-memory db");
         conn.execute_batch(crate::db::SCHEMA_SQL).expect("schema");
 
-        upsert_config(&conn, "dashscope", Some("sk-abcdef1234567890"), "", "qwen-max")
-            .expect("initial save");
+        upsert_config(
+            &conn,
+            "dashscope",
+            Some("sk-abcdef1234567890"),
+            "",
+            "qwen-max",
+        )
+        .expect("initial save");
         // Config-only edit: key=None must keep the stored credential.
-        upsert_config(&conn, "dashscope", None, "https://proxy.local/v1", "qwen-plus")
-            .expect("config-only save");
+        upsert_config(
+            &conn,
+            "dashscope",
+            None,
+            "https://proxy.local/v1",
+            "qwen-plus",
+        )
+        .expect("config-only save");
 
         let status = read_status(&conn, "dashscope").expect("read back");
         assert!(status.has_key, "key must survive a config-only save");

--- a/mind-base-desktop/src-tauri/src/config.rs
+++ b/mind-base-desktop/src-tauri/src/config.rs
@@ -118,6 +118,41 @@ impl Default for LocalAsrConfig {
     }
 }
 
+/// Local OCR settings. Mirrors the local-ASR block: when enabled, text
+/// recognition (images / screenshots / PDF pages) routes to a locally
+/// provisioned RapidOCR (PP-OCRv4 ONNX) pipeline instead of a cloud
+/// provider. The model bundle is downloaded via the `local_ocr_model_*`
+/// commands into `<data_dir>/ocr-models/<bundle>`; the inference wiring is
+/// delivered separately, the block exists so stored configs already carry it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct LocalOcrConfig {
+    /// When true, OCR workloads prefer the local model over the cloud slot.
+    pub enabled: bool,
+    /// Model bundle id (see `ocr_server::KNOWN_MODELS`, default `pp-ocrv4-mobile`).
+    pub model: String,
+    /// Extra arguments reserved for the future OCR pipeline launch.
+    pub extra_args: String,
+    /// Compute device for the future OCR runtime: `auto` (prefer GPU when
+    /// detected, fall back CPU), `cpu`, or `cuda` (NVIDIA, requires
+    /// onnxruntime-gpu + CUDA/cuDNN; runtime falls back when unavailable).
+    pub device: String,
+    /// Wall-clock cap for waiting on pipeline readiness (seconds).
+    pub ready_timeout_secs: u64,
+}
+
+impl Default for LocalOcrConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            model: "pp-ocrv4-mobile".to_string(),
+            extra_args: String::new(),
+            device: "auto".to_string(),
+            ready_timeout_secs: 300,
+        }
+    }
+}
+
 /// Typed application configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -140,6 +175,9 @@ pub struct AppConfig {
     /// 本地 faster-whisper-server 设置（方案 A）。缺省反序列化为默认值。
     #[serde(default)]
     pub local_asr: LocalAsrConfig,
+    /// 本地 OCR（RapidOCR / PP-OCRv4）设置。缺省反序列化为默认值。
+    #[serde(default)]
+    pub local_ocr: LocalOcrConfig,
     /// 媒体缓存（下载的音频/视频 + 抽出的 WAV）LRU 配额上限，单位 MB。
     /// 0 = 禁用清理。每次入库结束后按文件 mtime 从旧到新删除直到总量达标。
     #[serde(default = "default_media_cache_max_mb")]
@@ -156,6 +194,7 @@ impl Default for AppConfig {
             ffmpeg_path_override: None,
             default_chat_provider: None,
             local_asr: LocalAsrConfig::default(),
+            local_ocr: LocalOcrConfig::default(),
             media_cache_max_mb: default_media_cache_max_mb(),
         }
     }
@@ -187,10 +226,14 @@ fn read_stored_payload(conn: &rusqlite::Connection) -> Result<Option<String>, St
 /// Real database errors still propagate as `Err`.
 pub fn load(conn: &rusqlite::Connection) -> Result<AppConfig, String> {
     match read_stored_payload(conn)? {
-        Some(payload) => Ok(serde_json::from_str::<AppConfig>(&payload).unwrap_or_else(|err| {
-            eprintln!("[config] stored config is invalid ({err}); using defaults until next save");
-            AppConfig::default()
-        })),
+        Some(payload) => Ok(
+            serde_json::from_str::<AppConfig>(&payload).unwrap_or_else(|err| {
+                eprintln!(
+                    "[config] stored config is invalid ({err}); using defaults until next save"
+                );
+                AppConfig::default()
+            }),
+        ),
         None => Ok(AppConfig::default()),
     }
 }
@@ -230,13 +273,35 @@ fn normalize_local_asr(mut local_asr: LocalAsrConfig) -> LocalAsrConfig {
     local_asr
 }
 
+/// Normalize the local OCR block: an unknown/empty bundle id falls back to
+/// the default, an unknown/empty device to `auto`, and a zero readiness
+/// timeout to 300s.
+fn normalize_local_ocr(mut local_ocr: LocalOcrConfig) -> LocalOcrConfig {
+    let known = crate::ocr_server::KNOWN_MODELS
+        .iter()
+        .any(|(id, _, _, _)| *id == local_ocr.model);
+    if local_ocr.model.trim().is_empty() || !known {
+        local_ocr.model = LocalOcrConfig::default().model;
+    }
+    let device = local_ocr.device.trim().to_ascii_lowercase();
+    if !matches!(device.as_str(), "auto" | "cpu" | "cuda") {
+        local_ocr.device = LocalOcrConfig::default().device;
+    } else {
+        local_ocr.device = device;
+    }
+    if local_ocr.ready_timeout_secs == 0 {
+        local_ocr.ready_timeout_secs = LocalOcrConfig::default().ready_timeout_secs;
+    }
+    local_ocr
+}
+
 /// Return the current application configuration.
 #[tauri::command]
 pub fn get_config(db: State<'_, Db>) -> Result<AppConfig, String> {
-    let conn =
-        db.conn
-            .lock()
-            .map_err(|err| format!("failed to acquire database lock: {err}"))?;
+    let conn = db
+        .conn
+        .lock()
+        .map_err(|err| format!("failed to acquire database lock: {err}"))?;
     load(&conn)
 }
 
@@ -249,6 +314,7 @@ pub fn set_config(config: AppConfig, db: State<'_, Db>) -> Result<AppConfig, Str
     let config = AppConfig {
         update_repo,
         local_asr: normalize_local_asr(config.local_asr),
+        local_ocr: normalize_local_ocr(config.local_ocr),
         ..config
     };
     crate::logging::info(
@@ -259,10 +325,10 @@ pub fn set_config(config: AppConfig, db: State<'_, Db>) -> Result<AppConfig, Str
         ),
     );
 
-    let conn =
-        db.conn
-            .lock()
-            .map_err(|err| format!("failed to acquire database lock: {err}"))?;
+    let conn = db
+        .conn
+        .lock()
+        .map_err(|err| format!("failed to acquire database lock: {err}"))?;
     save(&conn, &config)?;
     Ok(config)
 }
@@ -330,5 +396,42 @@ mod tests {
         assert_eq!(normalized.model, "medium");
         assert_eq!(normalized.ready_timeout_secs, 120);
         assert_eq!(normalized.extra_args, "--device cpu");
+    }
+
+    #[test]
+    fn local_ocr_defaults_and_normalization() {
+        let cfg = LocalOcrConfig::default();
+        assert!(!cfg.enabled);
+        assert_eq!(cfg.model, "pp-ocrv4-mobile");
+        assert_eq!(cfg.ready_timeout_secs, 300);
+
+        // Unknown bundle ids fall back to the default (guards against stale
+        // stored configs pointing at a removed model).
+        let unknown = normalize_local_ocr(LocalOcrConfig {
+            enabled: true,
+            model: "pp-ocrv9".to_string(),
+            extra_args: String::new(),
+            device: "auto".to_string(),
+            ready_timeout_secs: 0,
+        });
+        assert_eq!(unknown.model, "pp-ocrv4-mobile");
+        assert_eq!(unknown.ready_timeout_secs, 300);
+
+        // A known bundle id is kept as-is.
+        let known = normalize_local_ocr(LocalOcrConfig {
+            model: "pp-ocrv4-server".to_string(),
+            ..LocalOcrConfig::default()
+        });
+        assert_eq!(known.model, "pp-ocrv4-server");
+
+        // Device normalizes: empty/unknown → auto, known values kept (trimmed,
+        // lowercased).
+        for (raw, expected) in [("", "auto"), ("CUDA", "cuda"), ("  cpu  ", "cpu"), ("tpu", "auto")] {
+            let got = normalize_local_ocr(LocalOcrConfig {
+                device: raw.to_string(),
+                ..LocalOcrConfig::default()
+            });
+            assert_eq!(got.device, expected, "device {raw:?}");
+        }
     }
 }

--- a/mind-base-desktop/src-tauri/src/lib.rs
+++ b/mind-base-desktop/src-tauri/src/lib.rs
@@ -15,6 +15,7 @@ mod llm_chat;
 mod logging;
 mod media_cache;
 mod notes;
+mod ocr_server;
 mod python_runtime;
 mod quiz;
 mod skills;
@@ -144,6 +145,8 @@ pub fn run() {
             bilibili::favorites::bili_video_pages,
             whisper_server::local_asr_model_status,
             whisper_server::local_asr_model_download,
+            ocr_server::local_ocr_model_status,
+            ocr_server::local_ocr_model_download,
             ingest::ingest_video,
             ingest::delete_document,
             ingest::list_documents,

--- a/mind-base-desktop/src-tauri/src/ocr_server.rs
+++ b/mind-base-desktop/src-tauri/src/ocr_server.rs
@@ -1,0 +1,351 @@
+//! Local OCR model management (download + status).
+//!
+//! The local OCR pipeline is RapidOCR over PP-OCRv4 ONNX models. A "model"
+//! here is a *bundle*: detection + recognition + classification ONNX files
+//! that together make a usable OCR pipeline. Bundles are downloaded from the
+//! RapidAI/RapidOCR repo on ModelScope (mainland-friendly CDN, no proxy
+//! needed) into `<data_dir>/ocr-models/<bundle>/` as `det.onnx`, `rec.onnx`,
+//! `cls.onnx`.
+//!
+//! This module intentionally mirrors the local-ASR model card mechanics in
+//! `whisper_server.rs` (global progress registry + background download
+//! thread + resumable file fetch). The inference/runtime wiring that
+//! *consumes* these bundles ships separately; `resolve_model_dir` is the
+//! handoff point.
+
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+
+use tauri::State;
+
+use crate::db::Db;
+use crate::logging;
+use crate::whisper_server::{download_agents, download_file};
+
+/// Base URL for all bundle files (ModelScope repo raw-file endpoint).
+const REPO_BASE: &str = "https://www.modelscope.cn/models/RapidAI/RapidOCR/resolve/master/";
+
+/// The OCR model bundles offered in the API-设置 model card.
+///
+/// Tuple: (id, label, approx total download bytes, files). Each file entry
+/// is (repo-relative path, local file name inside the bundle dir). `cls` is
+/// shared by both bundles — it is a direction classifier, not a weight-heavy
+/// det/rec model.
+pub(crate) const KNOWN_MODELS: &[(&str, &str, u64, &[(&str, &str)])] = &[
+    (
+        "pp-ocrv4-mobile",
+        "PP-OCRv4 Mobile（推荐，CPU 快）",
+        16_500_000,
+        &[
+            ("onnx/PP-OCRv4/det/ch_PP-OCRv4_det_mobile.onnx", "det.onnx"),
+            ("onnx/PP-OCRv4/rec/ch_PP-OCRv4_rec_mobile.onnx", "rec.onnx"),
+            (
+                "onnx/PP-OCRv4/cls/ch_ppocr_mobile_v2.0_cls_mobile.onnx",
+                "cls.onnx",
+            ),
+        ],
+    ),
+    (
+        "pp-ocrv4-server",
+        "PP-OCRv4 Server（更准，较慢）",
+        205_000_000,
+        &[
+            ("onnx/PP-OCRv4/det/ch_PP-OCRv4_det_server.onnx", "det.onnx"),
+            ("onnx/PP-OCRv4/rec/ch_PP-OCRv4_rec_server.onnx", "rec.onnx"),
+            (
+                "onnx/PP-OCRv4/cls/ch_ppocr_mobile_v2.0_cls_mobile.onnx",
+                "cls.onnx",
+            ),
+        ],
+    ),
+];
+
+/// Where the OCR model bundles live (one sub-directory per bundle).
+pub(crate) fn models_dir(data_dir: &Path) -> PathBuf {
+    data_dir.join("ocr-models")
+}
+
+fn bundle_dir(data_dir: &Path, model: &str) -> PathBuf {
+    models_dir(data_dir).join(model)
+}
+
+/// Resolve the local directory holding a fully downloaded bundle, `None`
+/// when any bundle file is missing (a partial download does not count).
+pub(crate) fn resolve_model_dir(data_dir: &Path, model: &str) -> Option<PathBuf> {
+    let (_, _, _, files) = KNOWN_MODELS.iter().find(|(id, _, _, _)| *id == model)?;
+    let dir = bundle_dir(data_dir, model);
+    files
+        .iter()
+        .all(|(_, name)| dir.join(name).is_file())
+        .then_some(dir)
+}
+
+/// Per-bundle download progress, polled by the settings UI.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LocalOcrModelStatus {
+    pub model: String,
+    pub label: String,
+    /// Approximate full-download size for display before totals are known.
+    pub approx_size_bytes: u64,
+    pub downloaded: bool,
+    pub downloading: bool,
+    pub downloaded_bytes: u64,
+    pub total_bytes: u64,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct DownloadState {
+    downloaded_bytes: u64,
+    total_bytes: u64,
+    error: Option<String>,
+}
+
+/// Process-global download progress registry (keyed by bundle id).
+static DOWNLOADS: OnceLock<Mutex<std::collections::HashMap<String, DownloadState>>> =
+    OnceLock::new();
+
+fn downloads_slot() -> &'static Mutex<std::collections::HashMap<String, DownloadState>> {
+    DOWNLOADS.get_or_init(|| Mutex::new(std::collections::HashMap::new()))
+}
+
+/// Status of every known bundle (downloaded? progress? error?).
+pub fn model_status_list(data_dir: &Path) -> Vec<LocalOcrModelStatus> {
+    let downloads = downloads_slot()
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
+    KNOWN_MODELS
+        .iter()
+        .map(|(id, label, approx, _)| {
+            let state = downloads.get(*id);
+            LocalOcrModelStatus {
+                model: id.to_string(),
+                label: label.to_string(),
+                approx_size_bytes: *approx,
+                downloaded: resolve_model_dir(data_dir, id).is_some(),
+                downloading: state.is_some() && state.unwrap().error.is_none(),
+                downloaded_bytes: state.map(|s| s.downloaded_bytes).unwrap_or(0),
+                total_bytes: state.map(|s| s.total_bytes).unwrap_or(0),
+                error: state.and_then(|s| s.error.clone()),
+            }
+        })
+        .collect()
+}
+
+/// Kick off a background download for `model`. Idempotent: a completed
+/// bundle is a no-op, an in-flight one is not duplicated.
+pub fn start_model_download(data_dir: PathBuf, model: String) -> Result<(), String> {
+    let entry = KNOWN_MODELS
+        .iter()
+        .find(|(id, _, _, _)| *id == model)
+        .ok_or_else(|| format!("未知模型：{model}"))?;
+    if resolve_model_dir(&data_dir, &model).is_some() {
+        return Ok(()); // already downloaded
+    }
+    {
+        let mut downloads = downloads_slot()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        match downloads.get(&model) {
+            // In-flight (no error yet): don't spawn a second downloader.
+            Some(state) if state.error.is_none() => return Ok(()),
+            _ => {
+                downloads.insert(
+                    model.clone(),
+                    DownloadState {
+                        downloaded_bytes: 0,
+                        total_bytes: 0,
+                        error: None,
+                    },
+                );
+            }
+        }
+    }
+    logging::info(
+        "ocr",
+        &format!("开始下载本地 OCR 模型：{model}（{}）", entry.1),
+    );
+    std::thread::spawn(move || {
+        let outcome = download_model(&data_dir, &model);
+        let mut downloads = downloads_slot()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        match outcome {
+            Ok(()) => {
+                logging::info("ocr", &format!("本地 OCR 模型下载完成：{model}"));
+                downloads.remove(&model); // downloaded=true now covers it
+            }
+            Err(err) => {
+                logging::error("ocr", &format!("本地 OCR 模型下载失败 {model}：{err}"));
+                downloads.insert(
+                    model.clone(),
+                    DownloadState {
+                        downloaded_bytes: 0,
+                        total_bytes: 0,
+                        error: Some(err),
+                    },
+                );
+            }
+        }
+    });
+    Ok(())
+}
+
+/// Download one bundle into `ocr-models/<model>/`, tracking progress in the
+/// global registry. Runs on a worker thread. Progress accounting centers on
+/// the recognition weights (`rec.onnx`, the largest file); the smaller det /
+/// cls files only shift the reported bar by a few MB.
+fn download_model(data_dir: &Path, model: &str) -> Result<(), String> {
+    let (_, _, _, files) = KNOWN_MODELS
+        .iter()
+        .find(|(id, _, _, _)| *id == model)
+        .ok_or_else(|| format!("未知模型：{model}"))?;
+    let dir = bundle_dir(data_dir, model);
+    std::fs::create_dir_all(&dir)
+        .map_err(|err| format!("无法创建模型目录 {}：{err}", dir.display()))?;
+    let agents = download_agents()?;
+
+    let update = |file_downloaded: u64, file_total: u64| {
+        let mut downloads = downloads_slot()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        if let Some(state) = downloads.get_mut(model) {
+            state.downloaded_bytes = file_downloaded;
+            state.total_bytes = file_total;
+        }
+    };
+
+    for (remote, name) in files.iter() {
+        let dest = dir.join(name);
+        if dest.is_file() {
+            continue;
+        }
+        let url = format!("{REPO_BASE}{remote}");
+        let is_rec = *name == "rec.onnx";
+        let mut local = 0u64;
+        download_file(&agents, &url, &dest, &mut |have, total| {
+            local = have;
+            // Only the biggest file drives the visible bar; smaller files
+            // report (0, 0) so they don't jump the progress around.
+            if is_rec {
+                update(have, total);
+            }
+        })
+        .map_err(|err| format!("下载 {remote} 失败：{err}"))?;
+        logging::info(
+            "ocr",
+            &format!("模型文件完成：{model}/{name}（{local} 字节）"),
+        );
+    }
+
+    // Sanity: the dir must now hold a complete bundle.
+    if resolve_model_dir(data_dir, model).is_none() {
+        return Err("下载完成但模型目录不完整（缺 det/rec/cls 之一）".to_string());
+    }
+    Ok(())
+}
+
+/// Status of every known local OCR bundle for the API-设置 model card. The
+/// UI polls this while downloads are active.
+#[tauri::command]
+pub fn local_ocr_model_status(db: State<'_, Db>) -> Result<Vec<LocalOcrModelStatus>, String> {
+    let data_dir = db
+        .data_dir
+        .lock()
+        .map(|dir| dir.clone())
+        .map_err(|_| "failed to read data dir".to_string())?;
+    Ok(model_status_list(&data_dir))
+}
+
+/// Start a background download for one known bundle (no-op when already
+/// downloaded or in flight). Progress is observed via `local_ocr_model_status`.
+#[tauri::command]
+pub fn local_ocr_model_download(db: State<'_, Db>, model: String) -> Result<(), String> {
+    let data_dir = db
+        .data_dir
+        .lock()
+        .map(|dir| dir.clone())
+        .map_err(|_| "failed to read data dir".to_string())?;
+    start_model_download(data_dir, model)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn unknown_bundle_is_rejected() {
+        let dir = std::env::temp_dir().join(format!("mb-ocr-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        assert!(start_model_download(dir.clone(), "nope".to_string()).is_err());
+        assert!(resolve_model_dir(&dir, "nope").is_none());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn bundle_layout_detection() {
+        let dir = std::env::temp_dir().join(format!("mb-ocr-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let bundle = bundle_dir(&dir, "pp-ocrv4-mobile");
+        std::fs::create_dir_all(&bundle).unwrap();
+        assert!(
+            resolve_model_dir(&dir, "pp-ocrv4-mobile").is_none(),
+            "empty dir"
+        );
+        std::fs::write(bundle.join("det.onnx"), b"x").unwrap();
+        std::fs::write(bundle.join("rec.onnx"), b"x").unwrap();
+        assert!(
+            resolve_model_dir(&dir, "pp-ocrv4-mobile").is_none(),
+            "missing cls"
+        );
+        std::fs::write(bundle.join("cls.onnx"), b"x").unwrap();
+        assert_eq!(
+            resolve_model_dir(&dir, "pp-ocrv4-mobile"),
+            Some(bundle.clone()),
+            "complete bundle resolves"
+        );
+        // Status list reflects the completed download.
+        let status = model_status_list(&dir);
+        assert_eq!(status.len(), KNOWN_MODELS.len());
+        let mobile = status
+            .iter()
+            .find(|s| s.model == "pp-ocrv4-mobile")
+            .unwrap();
+        assert!(mobile.downloaded && !mobile.downloading && mobile.error.is_none());
+        let server = status
+            .iter()
+            .find(|s| s.model == "pp-ocrv4-server")
+            .unwrap();
+        assert!(!server.downloaded);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Real network download of the mobile bundle (~16MB), exercising the
+    /// shared resumable downloader + ModelScope URLs end-to-end. Opt-in:
+    /// `cargo test --lib ocr_server -- --ignored`.
+    #[test]
+    #[ignore]
+    fn downloads_mobile_bundle_end_to_end() {
+        let dir = std::env::temp_dir().join("mindbase-ocr-dl-test");
+        std::fs::create_dir_all(&dir).unwrap();
+        start_model_download(dir.clone(), "pp-ocrv4-mobile".to_string()).unwrap();
+        for _ in 0..600 {
+            if resolve_model_dir(&dir, "pp-ocrv4-mobile").is_some() {
+                break;
+            }
+            std::thread::sleep(Duration::from_secs(1));
+        }
+        let path = resolve_model_dir(&dir, "pp-ocrv4-mobile").expect("bundle should download");
+        let rec = std::fs::metadata(path.join("rec.onnx")).unwrap().len();
+        assert!(rec > 10_000_000, "rec.onnx implausibly small: {rec}");
+        let status = model_status_list(&dir);
+        let mobile = status
+            .iter()
+            .find(|s| s.model == "pp-ocrv4-mobile")
+            .unwrap();
+        assert!(mobile.downloaded && !mobile.downloading && mobile.error.is_none());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/mind-base-desktop/src-tauri/src/whisper_server.rs
+++ b/mind-base-desktop/src-tauri/src/whisper_server.rs
@@ -276,12 +276,19 @@ pub fn start_model_download(data_dir: PathBuf, model: String) -> Result<(), Stri
             _ => {
                 downloads.insert(
                     model.clone(),
-                    DownloadState { downloaded_bytes: 0, total_bytes: 0, error: None },
+                    DownloadState {
+                        downloaded_bytes: 0,
+                        total_bytes: 0,
+                        error: None,
+                    },
                 );
             }
         }
     }
-    logging::info("whisper", &format!("开始下载本地 ASR 模型：{model}（{label}）"));
+    logging::info(
+        "whisper",
+        &format!("开始下载本地 ASR 模型：{model}（{label}）"),
+    );
     std::thread::spawn(move || {
         let outcome = download_model(&data_dir, &model);
         let mut downloads = downloads_slot()
@@ -296,7 +303,11 @@ pub fn start_model_download(data_dir: PathBuf, model: String) -> Result<(), Stri
                 logging::error("whisper", &format!("本地 ASR 模型下载失败 {model}：{err}"));
                 downloads.insert(
                     model.clone(),
-                    DownloadState { downloaded_bytes: 0, total_bytes: 0, error: Some(err) },
+                    DownloadState {
+                        downloaded_bytes: 0,
+                        total_bytes: 0,
+                        error: Some(err),
+                    },
                 );
             }
         }
@@ -307,13 +318,14 @@ pub fn start_model_download(data_dir: PathBuf, model: String) -> Result<(), Stri
 /// Direct (no-proxy) and optional proxied agents for model downloads. The
 /// hf-mirror + HF CDN hosts answer fine directly on mainland networks while
 /// an overseas-exit proxy stalls the big files, so direct is preferred; the
-/// proxy is the fallback for networks that need it.
-struct DownloadAgents {
-    direct: ureq::Agent,
-    via_proxy: Option<ureq::Agent>,
+/// proxy is the fallback for networks that need it. Also reused by the
+/// local-OCR model downloader (`ocr_server`).
+pub(crate) struct DownloadAgents {
+    pub(crate) direct: ureq::Agent,
+    pub(crate) via_proxy: Option<ureq::Agent>,
 }
 
-fn download_agents() -> Result<DownloadAgents, String> {
+pub(crate) fn download_agents() -> Result<DownloadAgents, String> {
     // Read timeouts must be per-read (streaming a multi-GB body), not overall.
     let builder = || {
         ureq::AgentBuilder::new()
@@ -329,8 +341,9 @@ fn download_agents() -> Result<DownloadAgents, String> {
 }
 
 /// Download one repo file into `dest` with resume support (`.part` suffix).
-/// `on_progress` receives (downloaded, total) for the whole file.
-fn download_file(
+/// `on_progress` receives (downloaded, total) for the whole file. Shared
+/// with the local-OCR model downloader.
+pub(crate) fn download_file(
     agents: &DownloadAgents,
     url: &str,
     dest: &Path,
@@ -362,8 +375,7 @@ fn download_file(
             Ok(resp) => resp,
             Err(ureq::Error::Status(416, _)) => {
                 // Range not satisfiable = the .part already holds everything.
-                std::fs::rename(&part, dest)
-                    .map_err(|err| format!("完成文件重命名失败：{err}"))?;
+                std::fs::rename(&part, dest).map_err(|err| format!("完成文件重命名失败：{err}"))?;
                 return Ok(());
             }
             Err(ureq::Error::Status(code, resp)) => {
@@ -432,7 +444,10 @@ fn download_file(
                 }
             }
         }
-        last_err = format!("下载中断：{}", io_err.map(|e| e.to_string()).unwrap_or_default());
+        last_err = format!(
+            "下载中断：{}",
+            io_err.map(|e| e.to_string()).unwrap_or_default()
+        );
     }
     Err(format!("下载失败（{max_attempts} 次尝试后）：{last_err}"))
 }
@@ -441,7 +456,8 @@ fn download_file(
 /// tracking progress in the global registry. Runs on a worker thread.
 fn download_model(data_dir: &Path, model: &str) -> Result<(), String> {
     let dir = model_dir(data_dir, model);
-    std::fs::create_dir_all(&dir).map_err(|err| format!("无法创建模型目录 {}：{err}", dir.display()))?;
+    std::fs::create_dir_all(&dir)
+        .map_err(|err| format!("无法创建模型目录 {}：{err}", dir.display()))?;
     let agents = download_agents()?;
     let base = format!("https://hf-mirror.com/Systran/faster-whisper-{model}/resolve/main");
 
@@ -471,7 +487,10 @@ fn download_model(data_dir: &Path, model: &str) -> Result<(), String> {
             local = have;
         });
         match result {
-            Ok(()) => logging::info("whisper", &format!("模型文件完成：{model}/{name}（{local} 字节）")),
+            Ok(()) => logging::info(
+                "whisper",
+                &format!("模型文件完成：{model}/{name}（{local} 字节）"),
+            ),
             Err(err) => {
                 // Optional file (404-style failures after retries): skip it.
                 logging::warn("whisper", &format!("模型文件跳过：{model}/{name}（{err}）"));
@@ -497,11 +516,7 @@ fn download_model(data_dir: &Path, model: &str) -> Result<(), String> {
 /// Launch command for the server script. Exposed for tests. The `--model`
 /// argument is the **local model directory** when the model has been
 /// downloaded (faster-whisper accepts a dir directly), else the bare name.
-fn server_command(
-    exe: &Path,
-    cfg: &LocalAsrConfig,
-    data_dir: &Path,
-) -> StdCommand {
+fn server_command(exe: &Path, cfg: &LocalAsrConfig, data_dir: &Path) -> StdCommand {
     let script = script_path();
     let model_arg = resolve_model_path(data_dir, &cfg.model)
         .map(|p| p.to_string_lossy().to_string())
@@ -549,9 +564,12 @@ fn script_path() -> PathBuf {
 /// The model id the local server on `port` reports via `/health`, `None`
 /// when it is not reachable or the field is missing.
 fn health_model(port: u16) -> Option<String> {
-    health_snapshot(port)
-        .ok()
-        .and_then(|value| value.get("model").and_then(|m| m.as_str()).map(String::from))
+    health_snapshot(port).ok().and_then(|value| {
+        value
+            .get("model")
+            .and_then(|m| m.as_str())
+            .map(String::from)
+    })
 }
 
 /// Ensure a local ASR server is running and ready, returning its base URL
@@ -595,7 +613,10 @@ pub fn ensure_running(cfg: &LocalAsrConfig, data_dir: &Path) -> Result<String, S
                         );
                     }
                 }
-                logging::info("whisper", &format!("本地 ASR 服务已在运行，直接复用端口 {port}"));
+                logging::info(
+                    "whisper",
+                    &format!("本地 ASR 服务已在运行，直接复用端口 {port}"),
+                );
                 return Ok(local_base_url(port));
             }
             Some(other_model) => {
@@ -611,7 +632,10 @@ pub fn ensure_running(cfg: &LocalAsrConfig, data_dir: &Path) -> Result<String, S
                 if ours {
                     logging::info(
                         "whisper",
-                        &format!("模型已切换为 {}，重启本地 ASR 服务（原 {}）", cfg.model, other_model),
+                        &format!(
+                            "模型已切换为 {}，重启本地 ASR 服务（原 {}）",
+                            cfg.model, other_model
+                        ),
                     );
                     kill_managed();
                 } else {
@@ -622,7 +646,10 @@ pub fn ensure_running(cfg: &LocalAsrConfig, data_dir: &Path) -> Result<String, S
             }
             None => {
                 // /health reachable but no model field: treat as compatible.
-                logging::info("whisper", &format!("本地 ASR 服务已在运行，直接复用端口 {port}"));
+                logging::info(
+                    "whisper",
+                    &format!("本地 ASR 服务已在运行，直接复用端口 {port}"),
+                );
                 return Ok(local_base_url(port));
             }
         },
@@ -699,7 +726,11 @@ pub fn ensure_running(cfg: &LocalAsrConfig, data_dir: &Path) -> Result<String, S
         let mut guard = child_slot()
             .lock()
             .unwrap_or_else(|poison| poison.into_inner());
-        *guard = Some(ManagedChild { port, model: cfg.model.clone(), child });
+        *guard = Some(ManagedChild {
+            port,
+            model: cfg.model.clone(),
+            child,
+        });
         drop(guard);
     }
 
@@ -796,11 +827,12 @@ pub fn startup_spawn(app: &tauri::AppHandle) {
     }
     // Off the startup path: provisioning (download + pip) can take minutes.
     let cfg = cfg.local_asr.clone();
-    std::thread::spawn(move || {
-        match ensure_running(&cfg, &data_dir) {
-            Ok(base) => logging::info("whisper", &format!("启动时本地 ASR 已就绪：{base}")),
-            Err(err) => logging::warn("whisper", &format!("启动本地 ASR 未成功（入库时会重试）：{err}")),
-        }
+    std::thread::spawn(move || match ensure_running(&cfg, &data_dir) {
+        Ok(base) => logging::info("whisper", &format!("启动时本地 ASR 已就绪：{base}")),
+        Err(err) => logging::warn(
+            "whisper",
+            &format!("启动本地 ASR 未成功（入库时会重试）：{err}"),
+        ),
     });
 }
 
@@ -899,8 +931,12 @@ mod tests {
             .get_args()
             .map(|a| a.to_string_lossy().to_string())
             .collect();
-        assert!(args.windows(2).any(|w| w[0] == "--device" && w[1] == "cuda"));
-        assert!(args.windows(2).any(|w| w[0] == "--beam-size" && w[1] == "5"));
+        assert!(args
+            .windows(2)
+            .any(|w| w[0] == "--device" && w[1] == "cuda"));
+        assert!(args
+            .windows(2)
+            .any(|w| w[0] == "--beam-size" && w[1] == "5"));
     }
 
     #[test]
@@ -922,7 +958,10 @@ mod tests {
         std::fs::write(plain.join("model.bin.part"), b"y").unwrap();
         assert!(resolve_model_path(&dir, "small").is_some());
         // Legacy HF-hub layout resolves via refs/main -> snapshots/<sha>.
-        let repo = dir.join("whisper-models").join("hub").join("models--Systran--faster-whisper-tiny");
+        let repo = dir
+            .join("whisper-models")
+            .join("hub")
+            .join("models--Systran--faster-whisper-tiny");
         let snap = repo.join("snapshots").join("abc123");
         std::fs::create_dir_all(&snap).unwrap();
         std::fs::create_dir_all(repo.join("refs")).unwrap();
@@ -958,7 +997,10 @@ mod tests {
         }
         let path = resolve_model_path(&dir, "tiny").expect("tiny model should download");
         let size = std::fs::metadata(path.join("model.bin")).unwrap().len();
-        assert!(size > 60_000_000, "tiny model.bin implausibly small: {size}");
+        assert!(
+            size > 60_000_000,
+            "tiny model.bin implausibly small: {size}"
+        );
         let status = model_status_list(&dir);
         let tiny = status.iter().find(|s| s.model == "tiny").unwrap();
         assert!(tiny.downloaded && !tiny.downloading && tiny.error.is_none());

--- a/mind-base-desktop/src-tauri/tauri.conf.json
+++ b/mind-base-desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "mind-base-desktop",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "identifier": "io.github.atoncooper.mindbase",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/mind-base-desktop/src/components/ApiSettings.tsx
+++ b/mind-base-desktop/src/components/ApiSettings.tsx
@@ -19,12 +19,17 @@ import {
 } from "../lib/api-keys";
 import type { ProviderStatus } from "../lib/api-keys";
 import { getConfig, setConfig as persistConfig } from "../lib/config";
-import type { AppConfig, LocalAsrConfig } from "../lib/config";
+import type { AppConfig, LocalAsrConfig, LocalOcrConfig } from "../lib/config";
 import {
   getLocalAsrModelStatus,
   downloadLocalAsrModel,
 } from "../lib/local-asr";
 import type { LocalAsrModelStatus } from "../lib/local-asr";
+import {
+  getLocalOcrModelStatus,
+  downloadLocalOcrModel,
+} from "../lib/local-ocr";
+import type { LocalOcrModelStatus } from "../lib/local-ocr";
 import { toErrorMessage } from "../lib/updater";
 import BiliAccountCard from "./BiliAccountCard";
 import type { ItemState, Feedback } from "../lib/ui-state";
@@ -36,6 +41,7 @@ const PROVIDER_LABELS: Record<string, string> = {
   deepseek: "DeepSeek（深度求索）",
   asr: "ASR 语音转写",
   embedding: "向量化 Embedding",
+  ocr: "OCR 文字识别",
 };
 
 function providerLabel(provider: string): string {
@@ -49,6 +55,7 @@ const DEFAULT_BASE_URLS: Record<string, string> = {
   deepseek: "https://api.deepseek.com/v1",
   asr: "https://dashscope.aliyuncs.com/api/v1",
   embedding: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+  ocr: "https://dashscope.aliyuncs.com/compatible-mode/v1",
 };
 
 /** Well-known model suggestions per provider (free-text is allowed). */
@@ -70,6 +77,7 @@ const MODEL_SUGGESTIONS: Record<string, string[]> = {
     "openai/text-embedding-3-small",
     "openai/text-embedding-3-large",
   ],
+  ocr: ["qwen-vl-ocr", "qwen-vl-ocr-latest"],
 };
 
 /** Human-readable byte size (模型卡片与选择器共用). */
@@ -103,6 +111,11 @@ const PROVIDER_GROUPS: Array<{
     title: "向量化 Embedding",
     hint: "知识库入库与检索的向量化；支持任意 OpenAI 兼容 Embedding 端点（DashScope/OpenRouter/OpenAI 等）。Base URL 留空用 DashScope 默认，未配置时回退 DashScope 密钥",
     providers: ["embedding"],
+  },
+  {
+    title: "OCR 文字识别",
+    hint: "图片 / 截图 / PDF 页面的文字识别；云端走 OpenAI 兼容多模态端点（DashScope qwen-vl-ocr 等），Base URL 留空用 DashScope 默认，未配置时回退 DashScope 密钥",
+    providers: ["ocr"],
   },
 ];
 
@@ -155,6 +168,15 @@ const LOCAL_ASR_DEFAULTS: LocalAsrConfig = {
   readyTimeoutSecs: 300,
 };
 
+/** Fallback local-OCR defaults mirroring the Rust `LocalOcrConfig::default`. */
+const LOCAL_OCR_DEFAULTS: LocalOcrConfig = {
+  enabled: false,
+  model: "pp-ocrv4-mobile",
+  extraArgs: "",
+  device: "auto",
+  readyTimeoutSecs: 300,
+};
+
 interface ApiSettingsProps {
   /** Visibility is owned by the parent tab switcher; state stays mounted. */
   hidden: boolean;
@@ -172,16 +194,23 @@ function ApiSettings({ hidden }: ApiSettingsProps) {
   const [openProvider, setOpenProvider] = useState<string | null>(null);
   // 操作结果按提供方行内显示，不共享一条全局提示。
   const [rowFeedback, setRowFeedback] = useState<Record<string, Feedback>>({});
-  // App config (for the ASR provider-mode switch); loaded alongside providers.
+  // App config (for the ASR/OCR provider-mode switches); loaded alongside providers.
   const [appConfig, setAppConfig] = useState<ItemState<AppConfig>>({ status: "loading" });
   const [localAsrFeedback, setLocalAsrFeedback] = useState<Feedback>(null);
   // 自动保存去抖定时器（本地 ASR 文本输入 500ms 合并写库；切换即时保存）。
   const localAsrTimer = useRef<number | null>(null);
+  const [localOcrFeedback, setLocalOcrFeedback] = useState<Feedback>(null);
+  const localOcrTimer = useRef<number | null>(null);
   // 本地 ASR 模型下载状态（面板可见时每 2s 轮询，驱动进度条）。
   const [modelStatuses, setModelStatuses] = useState<ItemState<LocalAsrModelStatus[]>>({
     status: "loading",
   });
   const [downloadingModel, setDownloadingModel] = useState<string | null>(null);
+  // 本地 OCR 模型下载状态（与 ASR 模型卡片同一轮询节奏）。
+  const [ocrModelStatuses, setOcrModelStatuses] = useState<ItemState<LocalOcrModelStatus[]>>({
+    status: "loading",
+  });
+  const [downloadingOcrModel, setDownloadingOcrModel] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -268,10 +297,52 @@ function ApiSettings({ hidden }: ApiSettingsProps) {
     }
   }
 
+  /** Persist the whole local-OCR block (enabled + model) and surface the
+   *  save result on the OCR row's feedback line. */
+  async function persistLocalOcr(next: LocalOcrConfig): Promise<void> {
+    setLocalOcrFeedback(null);
+    try {
+      const base =
+        appConfig.status === "ok"
+          ? appConfig.value
+          : await getConfig();
+      const saved = await persistConfig({
+        ...base,
+        localOcr: next,
+      });
+      setAppConfig({ status: "ok", value: saved });
+      setLocalOcrFeedback({ kind: "ok", text: "✓ 已保存" });
+    } catch (err) {
+      setLocalOcrFeedback({ kind: "error", text: `保存失败：${toErrorMessage(err)}` });
+    }
+  }
+
+  /** Patch one field of the local OCR config; the enable switch saves
+   *  immediately, other inputs debounce 500ms. */
+  function patchLocalOcr(patch: Partial<LocalOcrConfig>, immediate = false): void {
+    if (appConfig.status !== "ok") return;
+    const current = appConfig.value.localOcr ?? LOCAL_OCR_DEFAULTS;
+    const next: LocalOcrConfig = {
+      ...current,
+      ...patch,
+      // model falls back to the default bundle when emptied (backend
+      // normalizes too).
+      model: (patch.model ?? current.model).trim() || LOCAL_OCR_DEFAULTS.model,
+    };
+    setAppConfig({ status: "ok", value: { ...appConfig.value, localOcr: next } });
+    if (localOcrTimer.current !== null) window.clearTimeout(localOcrTimer.current);
+    if (immediate) {
+      void persistLocalOcr(next);
+    } else {
+      localOcrTimer.current = window.setTimeout(() => void persistLocalOcr(next), 500);
+    }
+  }
+
   // 卸载时清理未触发的去抖定时器。
   useEffect(() => {
     return () => {
       if (localAsrTimer.current !== null) window.clearTimeout(localAsrTimer.current);
+      if (localOcrTimer.current !== null) window.clearTimeout(localOcrTimer.current);
     };
   }, []);
 
@@ -290,6 +361,16 @@ function ApiSettings({ hidden }: ApiSettingsProps) {
         () => {
           if (cancelled) return;
           setModelStatuses({ status: "error" });
+        },
+      );
+      void getLocalOcrModelStatus().then(
+        (list) => {
+          if (cancelled) return;
+          setOcrModelStatuses({ status: "ok", value: list });
+        },
+        () => {
+          if (cancelled) return;
+          setOcrModelStatuses({ status: "error" });
         },
       );
     };
@@ -529,6 +610,216 @@ function ApiSettings({ hidden }: ApiSettingsProps) {
     );
   }
 
+  /** 启动一个本地 OCR 模型包的后台下载；进度由 2s 轮询的 status 驱动。 */
+  async function handleDownloadOcrModel(model: string): Promise<void> {
+    setDownloadingOcrModel(model);
+    try {
+      await downloadLocalOcrModel(model);
+    } catch (err) {
+      setRowFeedback((prev) => ({
+        ...prev,
+        __localOcrModel: { kind: "error", text: `下载启动失败：${toErrorMessage(err)}` },
+      }));
+    } finally {
+      setDownloadingOcrModel(null);
+    }
+  }
+
+  /** OCR 提供方切换：云端 API / 本地部署（与 ASR 模式切换同构）。 */
+  function renderOcrModeSwitch(): React.JSX.Element | null {
+    if (appConfig.status !== "ok") return null;
+    const localOcr = appConfig.value.localOcr ?? LOCAL_OCR_DEFAULTS;
+    const ocrStatus = providers.status === "ok"
+      ? providers.value.find((entry) => entry.provider === "ocr")
+      : undefined;
+    const hasCloudKey = ocrStatus?.hasKey ?? false;
+
+    return (
+      <div className="asr-mode-switch">
+        <div className="asr-mode-switch__options" role="radiogroup" aria-label="OCR 提供方">
+          <button
+            type="button"
+            role="radio"
+            aria-checked={!localOcr.enabled}
+            className={`asr-mode-switch__option${!localOcr.enabled ? " is-active" : ""}`}
+            onClick={() => patchLocalOcr({ enabled: false }, true)}
+          >
+            云端 API（DashScope）
+          </button>
+          <button
+            type="button"
+            role="radio"
+            aria-checked={localOcr.enabled}
+            className={`asr-mode-switch__option${localOcr.enabled ? " is-active" : ""}`}
+            onClick={() => patchLocalOcr({ enabled: true }, true)}
+          >
+            本地部署（RapidOCR）
+          </button>
+        </div>
+
+        {localOcr.enabled ? (
+          <div className="asr-mode-switch__local">
+            <div className="cfg-row">
+              <span className="cfg-label" id="label-local-ocr-model">
+                模型
+              </span>
+              {(() => {
+                const statuses = ocrModelStatuses.status === "ok" ? ocrModelStatuses.value : [];
+                const downloaded = statuses.filter((s) => s.downloaded).map((s) => s.model);
+                const current = localOcr.model;
+                // 只允许选择已下载的模型包；当前配置的模型尚未下载时保留展示
+                // （标注「未下载」），推理接入后后端也会拦截并给出明确提示。
+                const options =
+                  current !== "" && !downloaded.includes(current)
+                    ? [current, ...downloaded]
+                    : downloaded;
+                const hints: Record<string, string> = {
+                  "pp-ocrv4-mobile": "推荐，CPU 快",
+                  "pp-ocrv4-server": "更准，较慢",
+                };
+                return (
+                  <select
+                    className="cfg-input"
+                    aria-labelledby="label-local-ocr-model"
+                    value={options.includes(current) ? current : ""}
+                    onChange={(event) => patchLocalOcr({ model: event.target.value }, true)}
+                  >
+                    {options.length === 0 && <option value="">（尚无已下载模型）</option>}
+                    {options.map((model) => {
+                      const isDownloaded = downloaded.includes(model);
+                      const hint = hints[model] ?? "";
+                      return (
+                        <option value={model} key={model}>
+                          {model}
+                          {isDownloaded ? "" : "（未下载）"}
+                          {hint !== "" ? ` · ${hint}` : ""}
+                        </option>
+                      );
+                    })}
+                  </select>
+                );
+              })()}
+            </div>
+            <div className="cfg-row">
+              <span className="cfg-label" id="label-local-ocr-device">
+                计算设备
+              </span>
+              <select
+                className="cfg-input"
+                aria-labelledby="label-local-ocr-device"
+                value={localOcr.device || "auto"}
+                onChange={(event) => patchLocalOcr({ device: event.target.value }, true)}
+              >
+                <option value="auto">自动（检测到 GPU 则优先）</option>
+                <option value="cpu">CPU</option>
+                <option value="cuda">CUDA（NVIDIA）</option>
+              </select>
+            </div>
+            <p className="hint-text">
+              仅可选择已下载的模型包，模型在下方「本地
+              OCR 模型」卡片中下载，无需任何云端 API Key。CUDA 需要本机装有
+              NVIDIA 驱动与 CUDA 环境，不可用时运行时会自动回退 CPU。
+            </p>
+            {localOcrFeedback !== null && (
+              <p className={localOcrFeedback.kind === "error" ? "error-text" : "hint-text"}>
+                {localOcrFeedback.text}
+              </p>
+            )}
+          </div>
+        ) : (
+          !hasCloudKey && (
+            <p className="hint-text">
+              尚未配置云端 OCR 的 API Key。填写下方 Key，或切换到「本地部署」用本地模型识别。
+            </p>
+          )
+        )}
+      </div>
+    );
+  }
+
+  /** 「本地 OCR 模型」卡片：每个模型包一行，与本地 ASR 模型卡片同构。 */
+  function renderLocalOcrModelCard(): React.JSX.Element {
+    const downloadNote = rowFeedback["__localOcrModel"] ?? null;
+    return (
+      <section className="card">
+        <h2 className="card__title">
+          <span className="card__index">04</span>本地 OCR 模型
+        </h2>
+        {ocrModelStatuses.status !== "ok" ? (
+          <p className="placeholder">
+            {ocrModelStatuses.status === "loading" ? "加载中…" : "模型状态读取失败"}
+          </p>
+        ) : (
+          <>
+            <p className="card-hint">
+              RapidOCR（PP-OCRv4）模型包，包含识别 / 检测 / 分类三个 ONNX 文件，下载到本机数据目录后供本地
+              OCR 使用（推理接入在后续版本提供）。下载支持断点续传，失败后可重新点击。
+            </p>
+            <div className="model-list">
+              {ocrModelStatuses.value.map((entry) => {
+                const busy = downloadingOcrModel !== null || entry.downloading;
+                const percent =
+                  entry.downloading && entry.totalBytes > 0
+                    ? Math.min(100, Math.round((entry.downloadedBytes / entry.totalBytes) * 100))
+                    : null;
+                return (
+                  <div className="model-item" key={entry.model}>
+                    <div className="model-item__info">
+                      <span className="model-item__name">{entry.model}</span>
+                      <span className="model-item__meta">
+                        {entry.label} · 约 {formatBytes(entry.approxSizeBytes)}
+                      </span>
+                    </div>
+                    <div className="model-item__state">
+                      {entry.downloaded ? (
+                        <span className="status status--ok">已下载</span>
+                      ) : entry.downloading ? (
+                        <span className="status status--info">
+                          {percent !== null ? `下载中 ${percent}%` : "下载中…"}
+                        </span>
+                      ) : (
+                        <button
+                          type="button"
+                          className="button"
+                          disabled={busy}
+                          onClick={() => void handleDownloadOcrModel(entry.model)}
+                        >
+                          下载
+                        </button>
+                      )}
+                    </div>
+                    {entry.downloading && (
+                      <div
+                        className="model-item__progress"
+                        role="progressbar"
+                        aria-valuemin={0}
+                        aria-valuemax={100}
+                        aria-valuenow={percent ?? undefined}
+                      >
+                        <div
+                          className="model-item__progress-fill"
+                          style={{ width: `${percent ?? 0}%` }}
+                        />
+                      </div>
+                    )}
+                    {entry.error !== null && !entry.downloading && (
+                      <p className="error-text">上次下载失败：{entry.error}（可重试）</p>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+            {downloadNote !== null && (
+              <p className={downloadNote.kind === "error" ? "error-text" : "hint-text"}>
+                {downloadNote.text}
+              </p>
+            )}
+          </>
+        )}
+      </section>
+    );
+  }
+
   /** ASR 提供方切换：云端 API / 本地部署。 */
   function renderAsrModeSwitch(): React.JSX.Element | null {
     if (appConfig.status !== "ok") return null;
@@ -653,7 +944,12 @@ function ApiSettings({ hidden }: ApiSettingsProps) {
     const headId = `ledger-head-${entry.provider}`;
     const panelId = `ledger-panel-${entry.provider}`;
     const isAsr = entry.provider === "asr";
+    const isOcr = entry.provider === "ocr";
     const localEnabled = appConfig.status === "ok" && (appConfig.value.localAsr?.enabled ?? false);
+    const ocrLocalEnabled =
+      appConfig.status === "ok" && (appConfig.value.localOcr?.enabled ?? false);
+    // 本地模式（ASR / OCR）下行内隐藏云端 Key 表单与保存/测试动作。
+    const hideCloudForm = (isAsr && localEnabled) || (isOcr && ocrLocalEnabled);
 
     return (
       <div key={entry.provider} className={open ? "ledger-row is-open" : "ledger-row"}>
@@ -673,9 +969,15 @@ function ApiSettings({ hidden }: ApiSettingsProps) {
             {group !== "" && <span className="ledger-row__group">{group}</span>}
           </span>
           <span className="ledger-row__state">
-            {isAsr && (
-              <span className={localEnabled ? "status status--ok" : "status status--info"}>
-                {localEnabled ? "本地部署" : "云端"}
+            {(isAsr || isOcr) && (
+              <span
+                className={
+                  (isAsr ? localEnabled : ocrLocalEnabled)
+                    ? "status status--ok"
+                    : "status status--info"
+                }
+              >
+                {(isAsr ? localEnabled : ocrLocalEnabled) ? "本地部署" : "云端"}
               </span>
             )}
             {modelText !== "" && (
@@ -683,7 +985,7 @@ function ApiSettings({ hidden }: ApiSettingsProps) {
                 {modelText}
               </span>
             )}
-            {isAsr && localEnabled ? (
+            {(isAsr || isOcr) && (isAsr ? localEnabled : ocrLocalEnabled) ? (
               <span className="ledger-row__unset">无需 Key</span>
             ) : entry.hasKey ? (
               <code className="ledger-row__mask">{entry.maskedKey ?? "已配置"}</code>
@@ -700,8 +1002,9 @@ function ApiSettings({ hidden }: ApiSettingsProps) {
         <div className="ledger-row__panel" id={panelId} role="region" aria-labelledby={headId}>
           <div className="ledger-row__panel-inner">
             {isAsr && renderAsrModeSwitch()}
+            {isOcr && renderOcrModeSwitch()}
 
-            {!isAsr || !localEnabled ? (
+            {!hideCloudForm ? (
               <>
                 <div className="cfg-row">
                   <span className="cfg-label" id={`label-key-${entry.provider}`}>
@@ -774,7 +1077,7 @@ function ApiSettings({ hidden }: ApiSettingsProps) {
             ) : null}
 
             <div className="cfg-actions">
-              {!isAsr || !localEnabled ? (
+              {!hideCloudForm ? (
                 <>
                   <button
                     type="button"
@@ -811,7 +1114,7 @@ function ApiSettings({ hidden }: ApiSettingsProps) {
                 </button>
               )}
               <span className="cfg-actions__spacer" />
-              {!isAsr || !localEnabled ? (
+              {!hideCloudForm ? (
                 entry.hasKey ? (
                   <button
                     type="button"
@@ -861,6 +1164,7 @@ function ApiSettings({ hidden }: ApiSettingsProps) {
       </section>
 
       {renderLocalAsrModelCard()}
+      {renderLocalOcrModelCard()}
     </div>
   );
 }

--- a/mind-base-desktop/src/lib/config.ts
+++ b/mind-base-desktop/src/lib/config.ts
@@ -20,6 +20,8 @@ export interface AppConfig {
   defaultChatProvider?: string | null;
   /** 本地 faster-whisper-server（方案 A）设置。 */
   localAsr?: LocalAsrConfig;
+  /** 本地 OCR（RapidOCR / PP-OCRv4）设置。 */
+  localOcr?: LocalOcrConfig;
 }
 
 /** 本地 whisper 服务设置（与 Rust `LocalAsrConfig` 对齐）。服务由应用通过
@@ -37,6 +39,20 @@ export interface LocalAsrConfig {
   /** 追加的额外启动参数（空格分隔）。 */
   extraArgs: string;
   /** 等待服务就绪的超时（秒）。 */
+  readyTimeoutSecs: number;
+}
+
+/** 本地 OCR 设置（与 Rust `LocalOcrConfig` 对齐）。模型包（det/rec/cls
+ *  ONNX）在「API 设置 → 本地 OCR 模型」卡片中下载；推理接入由后续版本提供。 */export interface LocalOcrConfig {
+  /** 启用后 OCR 工作负载优先走本地模型（当前版本先提供配置与模型管理）。 */
+  enabled: boolean;
+  /** 模型包 id（pp-ocrv4-mobile / pp-ocrv4-server）。 */
+  model: string;
+  /** 预留的额外启动参数。 */
+  extraArgs: string;
+  /** 计算设备：auto（检测到 GPU 则优先）/ cpu / cuda（需 onnxruntime-gpu + CUDA 环境）。 */
+  device: string;
+  /** 等待流水线就绪的超时（秒）。 */
   readyTimeoutSecs: number;
 }
 

--- a/mind-base-desktop/src/lib/local-ocr.ts
+++ b/mind-base-desktop/src/lib/local-ocr.ts
@@ -1,0 +1,37 @@
+/**
+ * 本地 OCR 模型管理：状态查询与下载（对应 Rust `ocr_server.rs` 的
+ * `local_ocr_model_status` / `local_ocr_model_download` 命令）。
+ * 一个"模型"是一个 bundle：det + rec + cls 三个 ONNX 文件。
+ */
+
+import { invoke } from "@tauri-apps/api/core";
+
+/** 一个已知 OCR 模型包的下载状态（前端每 ~2s 轮询一次）。 */
+export interface LocalOcrModelStatus {
+  /** 模型包 id（pp-ocrv4-mobile / pp-ocrv4-server）。 */
+  model: string;
+  /** 展示标签（含速度/精度提示）。 */
+  label: string;
+  /** 近似完整下载体积（下载开始前用于展示）。 */
+  approxSizeBytes: number;
+  /** 本地目录中已有完整模型包。 */
+  downloaded: boolean;
+  /** 后台正在下载。 */
+  downloading: boolean;
+  /** 已下载字节（rec.onnx；仅 downloading 时有意义）。 */
+  downloadedBytes: number;
+  /** 总字节（rec.onnx Content-Length；未知为 0）。 */
+  totalBytes: number;
+  /** 上次下载失败的错误信息（可重试）。 */
+  error: string | null;
+}
+
+/** 查询全部已知模型包的状态。 */
+export function getLocalOcrModelStatus(): Promise<LocalOcrModelStatus[]> {
+  return invoke<LocalOcrModelStatus[]>("local_ocr_model_status");
+}
+
+/** 启动一个模型包的后台下载（已下载或在下载中时为无操作）。 */
+export function downloadLocalOcrModel(model: string): Promise<void> {
+  return invoke<void>("local_ocr_model_download", { model });
+}


### PR DESCRIPTION
## 变更内容

为 MindBase Desktop 增加 OCR 模型配置，分两层：

### 云端 OCR provider 槽位
- `api_keys.rs`：`KNOWN_PROVIDERS` 新增 `ocr`，默认端点指向 DashScope 兼容模式（`qwen-vl-ocr` / `qwen-vl-ocr-latest`），未配置时回退 DashScope 密钥；「测试连接」复用现有 `/models` 探针。
- 前端 API 设置新增「OCR 文字识别」提供方行（标签 / 默认 Base URL / 模型建议 / 分组说明）。

### 本地 OCR 模型管理（与本地 ASR 同构）
- 新增 `ocr_server.rs`：模型以「包」为单位（det + rec + cls 三个 ONNX），提供 `pp-ocrv4-mobile`（约 16.5MB，推荐）与 `pp-ocrv4-server`（约 205MB）两档，自 ModelScope（RapidAI/RapidOCR）下载，断点续传 + 进度查询 + 完整性校验；复用 whisper_server 开放为 `pub(crate)` 的下载器。
- 新增 Tauri 命令 `local_ocr_model_status` / `local_ocr_model_download`。
- `config.rs` 新增 `LocalOcrConfig`（enabled / model / device / extraArgs / readyTimeoutSecs），`set_config` 归一化未知模型 id 与 device（空/未知 → `auto`，`cpu`/`cuda` 保留）。
- 前端：`src/lib/local-ocr.ts` + 「04 本地 OCR 模型」下载卡片（2s 轮询进度）；OCR 行内「云端 API / 本地部署」模式切换，本地模式可选已下载模型包与计算设备（自动 / CPU / CUDA）。

### 版本
- 版本号升至 **0.1.3**（package.json / tauri.conf.json / Cargo.toml）。

### 范围说明
本版交付配置与模型下载管理；**OCR 推理运行时接入**（扫描版 PDF / 图片入库回退、表格结构还原）为后续 PR，接入口为 `ocr_server::resolve_model_dir` 与 `LocalOcrConfig.device`（auto/cpu/cuda，运行时做 CUDA→CPU 回退）。

## 测试
- `cargo test --lib`：新增 bundle 目录检测 / 未知模型拒绝 / OCR 配置归一化用例全部通过（唯一失败为预存的 `logging::tests::epoch_civil_conversion_is_correct`，main 上同样失败）。
- `npm run build`（tsc + vite）通过。
- ModelScope 模型直链已实测可达；另留 `--ignored` 真实网络端到端下载测试（`cargo test --lib ocr_server -- --ignored`）。