### PR TITLE
[desktop] feat: OCR 接入文件入库 + 入库 UI 优化 + macOS 发布适配

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -1,9 +1,13 @@
 name: Desktop Release
 
 # 推送 mind-base-desktop-v* 形式的 tag 时自动：拉取 ffmpeg sidecar →
-# 前端 + Rust 编译 → 创建 GitHub Release 并上传 NSIS/MSI 安装包。
+# 前端 + Rust 编译 → 创建 GitHub Release 并上传安装包。
 # 应用内更新器按该前缀识别版本（strip 后与 tauri.conf.json 的 version 比较），
 # 附件文件名保持 tauri 默认命名（含 x64、以 -setup.exe 结尾）即可被识别。
+#
+# 平台矩阵：Windows（NSIS/MSI，Windows job 创建 Release）与 macOS（Apple
+# Silicon .dmg，Beta）。macOS job 等待 Release 出现后上传附件，避免与
+# Windows job 的创建竞争。
 
 on:
   push:
@@ -15,7 +19,15 @@ permissions:
 
 jobs:
   build:
-    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            platform: windows
+          - os: macos-14
+            platform: macos
+    runs-on: ${{ matrix.os }}
     defaults:
       run:
         working-directory: mind-base-desktop
@@ -34,19 +46,41 @@ jobs:
         with:
           workspaces: mind-base-desktop/src-tauri
 
-      - name: Provision FFmpeg sidecar
+      - name: Provision FFmpeg sidecar (Windows)
+        if: matrix.platform == 'windows'
         run: powershell -NoProfile -ExecutionPolicy Bypass -File scripts/fetch-ffmpeg.ps1
 
-      - name: Verify tag matches app version
-        shell: pwsh
+      # evermeet.cx 静态构建（GPL，同 gyan.dev 的许可注意项）。下载两个
+      # 单二进制 zip 并按 Tauri externalBin 要求以 target triple 命名。
+      - name: Provision FFmpeg sidecar (macOS)
+        if: matrix.platform == 'macos'
         run: |
-          $tag = $env:GITHUB_REF_NAME              # mind-base-desktop-v0.1.0
-          $expected = $tag -replace '^mind-base-desktop-v', ''
-          $conf = Get-Content src-tauri/tauri.conf.json -Raw | ConvertFrom-Json
-          if ($conf.version -ne $expected) {
-            Write-Error "tag 版本($expected) 与 tauri.conf.json 版本($($conf.version)) 不一致，请先改版本号再打 tag"
+          set -euo pipefail
+          mkdir -p src-tauri/binaries
+          triple="aarch64-apple-darwin"
+          for tool in ffmpeg ffprobe; do
+            case "$tool" in
+              ffmpeg)  url="https://evermeet.cx/ffmpeg/getrelease/zip" ;;
+              ffprobe) url="https://evermeet.cx/ffmpeg/getrelease/ffprobe/zip" ;;
+            esac
+            curl -fL --retry 3 -o "${tool}.zip" "$url"
+            unzip -o -j "${tool}.zip" "${tool}"
+            mv "${tool}" "src-tauri/binaries/${tool}-${triple}"
+            rm "${tool}.zip"
+            chmod +x "src-tauri/binaries/${tool}-${triple}"
+          done
+
+      - name: Verify tag matches app version
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME}"                          # mind-base-desktop-v0.1.0
+          expected="${tag#mind-base-desktop-v}"
+          actual=$(node -p "require('./src-tauri/tauri.conf.json').version")
+          if [ "$actual" != "$expected" ]; then
+            echo "tag 版本($expected) 与 tauri.conf.json 版本($actual) 不一致，请先改版本号再打 tag"
             exit 1
-          }
+          fi
 
       - name: Install frontend deps
         run: npm ci
@@ -54,7 +88,8 @@ jobs:
       - name: Build Tauri app
         run: npm run tauri build
 
-      - name: Publish GitHub Release
+      - name: Publish GitHub Release (Windows)
+        if: matrix.platform == 'windows'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: pwsh
@@ -67,3 +102,20 @@ jobs:
           gh release create $env:GITHUB_REF_NAME @files `
             --title "MindBase Desktop $env:GITHUB_REF_NAME" `
             --generate-notes
+
+      - name: Upload macOS artifacts
+        if: matrix.platform == 'macos'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          files=$(ls src-tauri/target/release/bundle/dmg/*.dmg)
+          if [ -z "$files" ]; then echo "未找到构建产物"; exit 1; fi
+          # Windows job 负责创建 Release；这里轮询等待它出现（最多 ~40 分钟）。
+          for i in $(seq 1 40); do
+            if gh release view "$GITHUB_REF_NAME" > /dev/null 2>&1; then break; fi
+            echo "waiting for release to be created by the Windows job... ($i/40)"
+            sleep 60
+          done
+          gh release view "$GITHUB_REF_NAME" > /dev/null 2>&1 || { echo "Release 仍未创建"; exit 1; }
+          gh release upload "$GITHUB_REF_NAME" $files --clobber

--- a/mind-base-desktop/package.json
+++ b/mind-base-desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mind-base-desktop",
   "private": true,
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/mind-base-desktop/src-tauri/Cargo.lock
+++ b/mind-base-desktop/src-tauri/Cargo.lock
@@ -2171,7 +2171,7 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mind-base-desktop"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "filetime",
  "futures-util",

--- a/mind-base-desktop/src-tauri/Cargo.lock
+++ b/mind-base-desktop/src-tauri/Cargo.lock
@@ -2171,7 +2171,7 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mind-base-desktop"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "filetime",
  "futures-util",

--- a/mind-base-desktop/src-tauri/Cargo.toml
+++ b/mind-base-desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mind-base-desktop"
-version = "0.1.3"
+version = "0.1.4"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/mind-base-desktop/src-tauri/scripts/ocr_extract.py
+++ b/mind-base-desktop/src-tauri/scripts/ocr_extract.py
@@ -1,0 +1,226 @@
+"""ocr_extract.py — local OCR text extraction for 文件入库 (RapidOCR).
+
+Usage:
+    python ocr_extract.py <path> <model_dir> <device>
+
+`model_dir` holds a downloaded bundle (det.onnx / rec.onnx / cls.onnx, see
+`ocr_server.rs`); `device` is one of auto / cpu / cuda (auto picks GPU when
+the installed onnxruntime exposes a GPU execution provider).
+
+Prints exactly one JSON object on stdout:
+    {"ok": true,  "title": "...", "text": "...", "ext": "pdf"}
+    {"ok": false, "error": "..."}
+
+Two extraction modes:
+  - images (jpg / jpeg / png / bmp / webp): one OCR pass over the picture;
+  - pdf: per page, the text layer is used when present, pages without one are
+    rendered to bitmaps and OCR'd (scanned-document fallback).
+
+Anything on stderr is diagnostics only — the Rust caller reads stdout and
+must never mix the two streams.
+"""
+
+import json
+import os
+import sys
+
+MAX_CHARS = 2_000_000  # keep in sync with doc_extract.py
+TITLE_MAX_CHARS = 120
+# A page with fewer characters than this is treated as having no usable text
+# layer and gets OCR'd (covers scanned pages and header-only pages).
+PAGE_TEXT_MIN_CHARS = 32
+IMAGE_EXTS = {"jpg", "jpeg", "png", "bmp", "webp"}
+PDF_EXTS = {"pdf"}
+
+
+class ScriptError(Exception):
+    """Fatal extraction problem; the message is user-facing."""
+
+
+def _ocr_engine(model_dir, device):
+    """Build a RapidOCR engine from the local bundle, preferring GPU when asked.
+
+    auto/cuda try the GPU execution providers the installed onnxruntime
+    actually exposes (CUDA for onnxruntime-gpu, DML for onnxruntime-directml);
+    any failure at engine construction degrades to CPU instead of failing the
+    whole extraction.
+    """
+    for name in ("det.onnx", "rec.onnx", "cls.onnx"):
+        if not os.path.isfile(os.path.join(model_dir, name)):
+            raise ScriptError(
+                f"本地 OCR 模型不完整（缺 {name}）：请在「API 设置 → 本地 OCR 模型」卡片重新下载"
+            )
+    try:
+        from rapidocr_onnxruntime import RapidOCR
+    except ImportError as exc:
+        raise ScriptError("缺少 OCR 依赖（rapidocr-onnxruntime），请重启应用让其自动安装") from exc
+
+    kwargs = {
+        "det_model_path": os.path.join(model_dir, "det.onnx"),
+        "rec_model_path": os.path.join(model_dir, "rec.onnx"),
+        "cls_model_path": os.path.join(model_dir, "cls.onnx"),
+    }
+
+    def gpu_providers():
+        try:
+            import onnxruntime
+
+            return set(onnxruntime.get_available_providers())
+        except Exception:  # noqa: BLE001 — probing must never kill extraction
+            return set()
+
+    providers = gpu_providers()
+    attempts = [kwargs.copy()]
+    if device == "cuda" or (device == "auto" and "CUDAExecutionProvider" in providers):
+        gpu = kwargs.copy()
+        gpu.update({"det_use_cuda": True, "rec_use_cuda": True, "cls_use_cuda": True})
+        attempts.insert(0, gpu)
+    elif device == "auto" and "DmlExecutionProvider" in providers:
+        dml = kwargs.copy()
+        dml.update({"det_use_dml": True, "rec_use_dml": True, "cls_use_dml": True})
+        attempts.insert(0, dml)
+
+    last_err = None
+    for attempt in attempts:
+        try:
+            return RapidOCR(**attempt)
+        except Exception as exc:  # noqa: BLE001 — GPU setup can fail late
+            last_err = exc
+            if attempt is attempts[-1]:
+                break
+            print(f"[ocr] GPU 初始化失败，回退 CPU：{exc}", file=sys.stderr)
+    raise ScriptError(f"OCR 引擎初始化失败：{last_err}")
+
+
+def _ocr_image_data(engine, data):
+    """OCR one RGB numpy image (h, w, 3); returns the recognized lines."""
+    import numpy as np
+
+    rgb = np.asarray(data)
+    # RapidOCR follows the cv2 convention: ndarray input is BGR.
+    bgr = rgb[..., ::-1]
+    result, _ = engine(bgr)
+    lines = []
+    for item in result or []:
+        try:
+            _box, text, score = item
+        except (TypeError, ValueError):
+            continue
+        text = str(text).strip()
+        if text and float(score) >= 0.5:
+            lines.append(text)
+    return lines
+
+
+def _ocr_image_file(engine, path):
+    from PIL import Image
+
+    try:
+        with Image.open(path) as image:
+            rgb = image.convert("RGB")
+    except Exception as exc:  # noqa: BLE001 — corrupt images are user data
+        raise ScriptError(f"无法读取图片：{exc}") from exc
+    return _ocr_image_data(engine, __import__("numpy").array(rgb))
+
+
+def ocr_pdf(engine, path):
+    """Extract text from a PDF, OCR-ing pages without a usable text layer."""
+    try:
+        import pymupdf as fitz
+    except ImportError:
+        try:
+            import fitz  # legacy shim, pymupdf < 1.26
+        except ImportError as exc:
+            raise ScriptError("缺少 PDF 解析依赖（pymupdf），请重启应用让其自动安装") from exc
+    try:
+        doc = fitz.open(path)
+    except Exception as exc:
+        raise ScriptError(f"无法打开 PDF：{exc}") from exc
+
+    import numpy as np
+
+    pages = []
+    ocr_page_count = 0
+    try:
+        meta_title = ""
+        try:
+            meta_title = (doc.metadata or {}).get("title") or ""
+        except Exception:
+            pass
+        for page in doc:
+            text = page.get_text("text").strip()
+            if len(text) >= PAGE_TEXT_MIN_CHARS:
+                pages.append(text)
+                continue
+            # No usable text layer: render ~2x zoom and OCR the bitmap.
+            pix = page.get_pixmap(matrix=fitz.Matrix(2, 2), alpha=False)
+            rgb = np.frombuffer(pix.samples, dtype=np.uint8).reshape(
+                pix.height, pix.width, 3
+            )
+            lines = _ocr_image_data(engine, rgb)
+            ocr_page_count += 1
+            pages.append("\n".join(lines))
+    finally:
+        doc.close()
+
+    body = "\n\n".join(part.strip() for part in pages if part and part.strip())
+    if not body.strip():
+        raise ScriptError("该 PDF 经 OCR 后仍未识别到文字")
+    if ocr_page_count:
+        print(f"[ocr] {os.path.basename(path)}: OCR 页数 {ocr_page_count}", file=sys.stderr)
+    title = meta_title.strip() or ""
+    if not title:
+        for line in body.splitlines():
+            stripped = line.strip()
+            if stripped:
+                title = stripped[:TITLE_MAX_CHARS]
+                break
+    return title or os.path.splitext(os.path.basename(path))[0][:TITLE_MAX_CHARS], body
+
+
+def ocr_image(engine, path):
+    lines = _ocr_image_file(engine, path)
+    text = "\n".join(lines).strip()
+    if not text:
+        raise ScriptError("图片中未识别到文字")
+    title = lines[0][:TITLE_MAX_CHARS] if lines else ""
+    return title or os.path.splitext(os.path.basename(path))[0][:TITLE_MAX_CHARS], text
+
+
+def main():
+    # Windows pipes default to the console codepage; always emit UTF-8.
+    try:
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    except Exception:  # noqa: BLE001 — older/odd stdio wrappers
+        pass
+    if len(sys.argv) != 4:
+        print(json.dumps({"ok": False, "error": "参数错误：需要 <path> <model_dir> <device>"}, ensure_ascii=False))
+        return 2
+    path, model_dir, device = sys.argv[1], sys.argv[2], sys.argv[3].strip().lower() or "auto"
+    try:
+        if not os.path.isfile(path):
+            raise ScriptError(f"文件不存在：{path}")
+        ext = os.path.splitext(path)[1].lower().lstrip(".")
+        if ext in IMAGE_EXTS:
+            engine = _ocr_engine(model_dir, device)
+            title, text = ocr_image(engine, path)
+        elif ext in PDF_EXTS:
+            engine = _ocr_engine(model_dir, device)
+            title, text = ocr_pdf(engine, path)
+        else:
+            raise ScriptError(f"OCR 不支持的文件类型：{ext or '(无扩展名)'}")
+        text = text[:MAX_CHARS]
+        if not text.strip():
+            raise ScriptError("未提取到任何文本内容")
+        print(json.dumps({"ok": True, "title": title, "text": text, "ext": ext}, ensure_ascii=False))
+        return 0
+    except ScriptError as exc:
+        print(json.dumps({"ok": False, "error": str(exc)}, ensure_ascii=False))
+        return 1
+    except Exception as exc:  # noqa: BLE001 — the boundary must never crash raw
+        print(json.dumps({"ok": False, "error": f"OCR 解析失败：{exc}"}, ensure_ascii=False))
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/mind-base-desktop/src-tauri/src/file_ingest.rs
+++ b/mind-base-desktop/src-tauri/src/file_ingest.rs
@@ -21,8 +21,14 @@ use crate::db::Db;
 use crate::embeddings::{embed_client_from_conn, EmbedClient};
 use crate::vectors;
 
-/// Extensions accepted for ingestion (lowercase, without the dot).
-const ALLOWED_EXT: &[&str] = &["txt", "md", "markdown", "pdf", "docx", "html", "htm"];
+/// Extensions accepted for ingestion (lowercase, without the dot). Images
+/// are ingested through local OCR (`scripts/ocr_extract.py`); scanned PDFs
+/// fall back to it when their text layer is empty.
+const ALLOWED_EXT: &[&str] = &[
+    "txt", "md", "markdown", "pdf", "docx", "html", "htm", "jpg", "jpeg", "png", "bmp", "webp",
+];
+/// Extensions ingested purely through local OCR.
+const IMAGE_EXT: &[&str] = &["jpg", "jpeg", "png", "bmp", "webp"];
 /// Per-file size cap — a bigger file is almost certainly data, not prose.
 const MAX_FILE_BYTES: u64 = 50 * 1024 * 1024;
 /// Batch cap so a folder pick can't enqueue the whole disk.
@@ -377,6 +383,22 @@ fn script_path() -> PathBuf {
         .to_path_buf()
 }
 
+/// Parse the one-JSON-line verdict printed by `doc_extract.py` /
+/// `ocr_extract.py` (the verdict is the LAST non-empty stdout line — libs
+/// like pymupdf may print warnings above it).
+fn parse_extract_payload(stdout: &str) -> Result<ExtractPayload, String> {
+    let line = stdout
+        .lines()
+        .rev()
+        .map(str::trim)
+        .find(|text| !text.is_empty())
+        .unwrap_or("");
+    serde_json::from_str(line).map_err(|err| {
+        let snippet: String = line.chars().take(120).collect();
+        format!("解析器输出无法读取：{err}（输出片段：{snippet}）")
+    })
+}
+
 /// Run `doc_extract.py` on one file and parse its JSON verdict.
 fn extract_text(exe: &Path, file: &Path) -> Result<Extracted, String> {
     let script = script_path();
@@ -405,23 +427,113 @@ fn extract_text(exe: &Path, file: &Path) -> Result<Extracted, String> {
     if !output.status.success() && output.stdout.is_empty() {
         return Err(format!("解析器异常退出（退出码 {}）", output.status));
     }
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    // The extractor prints exactly one JSON line on stdout, but libraries it
-    // loads may emit warnings to stdout as well (pymupdf's `fitz` shim does)
-    // — the verdict is therefore the LAST non-empty line, never the first.
-    let line = stdout
-        .lines()
-        .rev()
-        .map(str::trim)
-        .find(|text| !text.is_empty())
-        .unwrap_or("");
-    let payload: ExtractPayload = serde_json::from_str(line).map_err(|err| {
-        let snippet: String = line.chars().take(120).collect();
-        format!("解析器输出无法读取：{err}（输出片段：{snippet}）")
-    })?;
+    let payload = parse_extract_payload(&String::from_utf8_lossy(&output.stdout))?;
     if !payload.ok {
         return Err(if payload.error.is_empty() {
             "解析失败（未知原因）".to_string()
+        } else {
+            payload.error
+        });
+    }
+    Ok(Extracted {
+        title: payload.title,
+        text: payload.text,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// OCR fallback (local RapidOCR, see `ocr_server.rs` + `scripts/ocr_extract.py`)
+// ---------------------------------------------------------------------------
+
+/// Availability of the local OCR runtime for one ingestion run.
+enum OcrStatus {
+    /// Everything needed to run `ocr_extract.py` is in place.
+    Ready {
+        exe: PathBuf,
+        model_dir: PathBuf,
+        device: String,
+    },
+    /// The user has not switched OCR to 本地部署.
+    Disabled,
+    /// Local OCR is on but the configured bundle is not downloaded.
+    NoModel { model: String },
+    /// Local OCR is on but the environment could not be provisioned.
+    Failed(String),
+}
+
+impl OcrStatus {
+    /// The user-facing reason OCR cannot run right now.
+    fn unavailable_reason(&self, for_image: bool) -> String {
+        let subject = if for_image {
+            "图片入库走本地 OCR 识别"
+        } else {
+            "该 PDF 是扫描版（无文本层），需要 OCR 识别"
+        };
+        match self {
+            OcrStatus::Ready { .. } => String::new(),
+            OcrStatus::Disabled => format!(
+                "{subject}。请到「API 设置 → OCR 文字识别」切换到本地部署并下载模型后重试"
+            ),
+            OcrStatus::NoModel { model } => format!(
+                "{subject}。本地 OCR 模型「{model}」尚未下载：请在「API 设置 → 本地 OCR 模型」卡片下载"
+            ),
+            OcrStatus::Failed(err) => format!("{subject}，但本地 OCR 环境不可用：{err}"),
+        }
+    }
+}
+
+/// `true` when the extractor error is the scanned-PDF verdict (no text
+/// layer) that should trigger the OCR fallback.
+fn is_scanned_pdf_error(error: &str) -> bool {
+    error.contains("没有可提取的文本层")
+}
+
+/// Path of the OCR script, shipped as a resource next to the binary.
+fn ocr_script_path() -> PathBuf {
+    let dev = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("scripts")
+        .join("ocr_extract.py");
+    if dev.exists() {
+        return dev;
+    }
+    std::path::Path::new("scripts").join("ocr_extract.py").to_path_buf()
+}
+
+/// Run `ocr_extract.py` on one image / scanned PDF and parse its verdict.
+fn ocr_extract(ctx: (&Path, &Path, &str), file: &Path) -> Result<Extracted, String> {
+    let (exe, model_dir, device) = ctx;
+    let script = ocr_script_path();
+    if !script.is_file() {
+        return Err(format!("OCR 脚本缺失：{}", script.display()));
+    }
+    #[cfg(windows)]
+    let mut cmd = {
+        use std::os::windows::process::CommandExt;
+        let mut c = StdCommand::new(exe);
+        c.creation_flags(0x0800_0000); // CREATE_NO_WINDOW
+        c
+    };
+    #[cfg(not(windows))]
+    let mut cmd = StdCommand::new(exe);
+    let output = cmd
+        .env("PYTHONUTF8", "1")
+        .env("PYTHONIOENCODING", "utf-8")
+        .arg(&script)
+        .arg(file)
+        .arg(model_dir)
+        .arg(device)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .output()
+        .map_err(|err| format!("无法运行 OCR（{}）：{err}", exe.display()))?;
+    if !output.status.success() && output.stdout.is_empty() {
+        return Err(format!("OCR 异常退出（退出码 {}）", output.status));
+    }
+    let payload = parse_extract_payload(&String::from_utf8_lossy(&output.stdout))?;
+    if !payload.ok {
+        return Err(if payload.error.is_empty() {
+            "OCR 识别失败（未知原因）".to_string()
         } else {
             payload.error
         });
@@ -500,9 +612,10 @@ pub async fn ingest_files(
             .map(|dir| dir.clone())
             .map_err(|err| format!("failed to acquire data dir lock: {err}"))?
     };
+    let data_dir_for_doc = data_dir.clone();
     let python_exe = tauri::async_runtime::spawn_blocking(move || {
         crate::python_runtime::ensure_doc_extract_python(
-            &data_dir,
+            &data_dir_for_doc,
             need_pdf,
             need_docx,
             need_readability,
@@ -511,12 +624,57 @@ pub async fn ingest_files(
     .await
     .map_err(|err| format!("解析环境准备任务失败：{err}"))??;
 
+    // Local OCR state for this run: images always OCR, scanned PDFs fall
+    // back to it. Provisioning (embedded Python + rapidocr) happens only
+    // when local OCR is enabled and the batch can actually use it. The DB
+    // lock is read in a scoped block and released before any await.
+    let ocr = {
+        let (ocr_cfg, any_image, any_pdf) = {
+            let db = app.state::<Db>();
+            let conn = db
+                .conn
+                .lock()
+                .map_err(|err| format!("failed to acquire database lock: {err}"))?;
+            let config = crate::config::load(&conn)?;
+            (
+                config.local_ocr.clone(),
+                files.iter().any(|file| IMAGE_EXT.contains(&file.ext.as_str())),
+                files.iter().any(|file| file.ext == "pdf"),
+            )
+        };
+        if !ocr_cfg.enabled || (!any_image && !any_pdf) {
+            OcrStatus::Disabled
+        } else if crate::ocr_server::resolve_model_dir(&data_dir, &ocr_cfg.model).is_none() {
+            OcrStatus::NoModel { model: ocr_cfg.model.clone() }
+        } else {
+            let data_dir2 = data_dir.clone();
+            let device = ocr_cfg.device.clone();
+            match tauri::async_runtime::spawn_blocking(move || {
+                crate::python_runtime::ensure_ocr_python(&data_dir2, any_pdf, &device)
+            })
+            .await
+            .map_err(|err| format!("OCR 环境准备任务失败：{err}"))?
+            {
+                Ok(exe) => OcrStatus::Ready {
+                    exe,
+                    model_dir: crate::ocr_server::resolve_model_dir(
+                        &data_dir,
+                        &ocr_cfg.model,
+                    )
+                    .unwrap_or_default(),
+                    device: ocr_cfg.device,
+                },
+                Err(err) => OcrStatus::Failed(err),
+            }
+        }
+    };
+
     // `State` borrows the app; the blocking worker re-resolves it from a
     // cloned handle instead of moving the borrow into a 'static closure.
     let handle = app.clone();
     tauri::async_runtime::spawn_blocking(move || {
         let db = handle.state::<Db>();
-        run_file_ingestion(&files, &python_exe, &embed_client, &on_event, &db)
+        run_file_ingestion(&files, &python_exe, &embed_client, &ocr, &on_event, &db)
     })
     .await
     .map_err(|err| format!("task failed: {err}"))?
@@ -526,6 +684,7 @@ fn run_file_ingestion(
     files: &[ScannedFile],
     python_exe: &Path,
     embed_client: &EmbedClient,
+    ocr: &OcrStatus,
     channel: &Channel<FileIngestEvent>,
     db: &State<'_, Db>,
 ) -> Result<FileIngestSummary, String> {
@@ -613,7 +772,7 @@ fn run_file_ingestion(
             )?;
         }
 
-        match ingest_one_file(&path, file, python_exe, embed_client, index, channel) {
+        match ingest_one_file(&path, file, python_exe, embed_client, ocr, index, channel) {
             Ok(outcome) => {
                 // Single short-lock transaction: vectors + documents flip together.
                 let conn = db
@@ -697,6 +856,7 @@ fn ingest_one_file(
     file: &ScannedFile,
     python_exe: &Path,
     embed_client: &EmbedClient,
+    ocr: &OcrStatus,
     index: i64,
     channel: &Channel<FileIngestEvent>,
 ) -> Result<FileOutcome, String> {
@@ -711,7 +871,51 @@ fn ingest_one_file(
         "file_ingest",
         &format!("parse start path={} ext={}", file.path, file.ext),
     );
-    let extracted = extract_text(python_exe, path)?;
+    let extracted = if IMAGE_EXT.contains(&file.ext.as_str()) {
+        // Images have no text layer to parse — OCR is the only path.
+        match ocr {
+            OcrStatus::Ready { exe, model_dir, device } => {
+                emit(
+                    &FileIngestEvent::FileStep {
+                        index,
+                        step: "ocr".to_string(),
+                    },
+                    channel,
+                );
+                crate::logging::info(
+                    "file_ingest",
+                    &format!("ocr start (image) path={}", file.path),
+                );
+                ocr_extract((exe, model_dir, device), path)?
+            }
+            other => return Err(other.unavailable_reason(true)),
+        }
+    } else {
+        match extract_text(python_exe, path) {
+            Ok(extracted) => extracted,
+            Err(error) if file.ext == "pdf" && is_scanned_pdf_error(&error) => {
+                // Scanned PDF: no text layer — try the local OCR fallback.
+                match ocr {
+                    OcrStatus::Ready { exe, model_dir, device } => {
+                        emit(
+                            &FileIngestEvent::FileStep {
+                                index,
+                                step: "ocr".to_string(),
+                            },
+                            channel,
+                        );
+                        crate::logging::info(
+                            "file_ingest",
+                            &format!("ocr fallback (scanned pdf) path={}", file.path),
+                        );
+                        ocr_extract((exe, model_dir, device), path)?
+                    }
+                    other => return Err(other.unavailable_reason(false)),
+                }
+            }
+            Err(error) => return Err(error),
+        }
+    };
     if extracted.text.trim().is_empty() {
         return Err("未提取到任何文本内容".to_string());
     }
@@ -796,8 +1000,32 @@ mod tests {
         assert!(is_allowed("pdf"));
         // `ext_of` lowercases before filtering, so only lowercase reaches here.
         assert!(is_allowed("md"));
+        // Images are OCR-ingestible.
+        assert!(is_allowed("png"));
+        assert!(is_allowed("jpeg"));
         assert!(!is_allowed("exe"));
         assert!(!is_allowed(""));
+    }
+
+    #[test]
+    fn scanned_pdf_errors_are_recognized() {
+        assert!(is_scanned_pdf_error(
+            "该 PDF 没有可提取的文本层（可能是扫描件），暂不支持 OCR"
+        ));
+        assert!(!is_scanned_pdf_error("无法打开 PDF：corrupt"));
+        assert!(!is_scanned_pdf_error("该 DOCX 没有可提取的正文"));
+    }
+
+    #[test]
+    fn ocr_unavailable_reasons_distinguish_states() {
+        let disabled = OcrStatus::Disabled;
+        let msg = disabled.unavailable_reason(false);
+        assert!(msg.contains("API 设置"), "disabled should point at settings: {msg}");
+        let no_model = OcrStatus::NoModel { model: "pp-ocrv4-mobile".to_string() };
+        let msg = no_model.unavailable_reason(true);
+        assert!(msg.contains("pp-ocrv4-mobile") && msg.contains("下载"), "{msg}");
+        let failed = OcrStatus::Failed("boom".to_string());
+        assert!(failed.unavailable_reason(false).contains("boom"));
     }
 
     #[test]

--- a/mind-base-desktop/src-tauri/src/python_runtime.rs
+++ b/mind-base-desktop/src-tauri/src/python_runtime.rs
@@ -106,7 +106,10 @@ pub(crate) fn ensure_server_deps(data_dir: &Path) -> Result<PathBuf, String> {
     ensure_python_base(data_dir)?;
     let exe = python_exe(data_dir);
     if !REQUIRED.iter().all(|m| can_import(&exe, m)) {
-        crate::logging::info("python", "安装本地 ASR 服务依赖（faster-whisper / FastAPI）…");
+        crate::logging::info(
+            "python",
+            "安装本地 ASR 服务依赖（faster-whisper / FastAPI）…",
+        );
         install_packages(&exe, &python_dir(data_dir), PACKAGES)?;
         crate::logging::info("python", "本地 ASR 服务依赖安装完成");
     }
@@ -181,10 +184,117 @@ pub(crate) fn ensure_doc_extract_python(
     Ok(python_exe(data_dir))
 }
 
+/// Whether the installed onnxruntime exposes the CUDA execution provider.
+fn onnxruntime_has_cuda(exe: &Path) -> bool {
+    Command::new(exe)
+        .args([
+            "-c",
+            "import onnxruntime; print('CUDAExecutionProvider' in onnxruntime.get_available_providers())",
+        ])
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .output()
+        .map(|out| String::from_utf8_lossy(&out.stdout).trim() == "True")
+        .unwrap_or(false)
+}
+
+/// Swap the CPU onnxruntime for the GPU build when the OCR device setting
+/// asks for CUDA. CPU and GPU builds must not coexist in one environment
+/// (double registration), and the GPU build alone still serves CPU — so the
+/// swap is one-way. A failed swap is not fatal: the OCR script degrades to
+/// CPU at runtime.
+fn ensure_onnxruntime_gpu(exe: &Path, py_dir: &Path) {
+    if onnxruntime_has_cuda(exe) {
+        return;
+    }
+    crate::logging::info("python", "OCR 设备为 CUDA：安装 onnxruntime-gpu…");
+    let uninstall = Command::new(exe)
+        .args(["-m", "pip", "uninstall", "-y", "onnxruntime"])
+        .current_dir(py_dir)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    if !uninstall {
+        crate::logging::warn("python", "卸载 CPU onnxruntime 失败，CUDA 可能不可用");
+    }
+    if let Err(err) = install_packages(exe, py_dir, &["onnxruntime-gpu"]) {
+        crate::logging::warn(
+            "python",
+            &format!("onnxruntime-gpu 安装失败（将回退 CPU）：{err}"),
+        );
+        // Restore a CPU build so OCR keeps working.
+        let _ = install_packages(exe, py_dir, &["onnxruntime"]);
+        return;
+    }
+    if !onnxruntime_has_cuda(exe) {
+        crate::logging::warn(
+            "python",
+            "onnxruntime-gpu 已安装但 CUDA 提供方不可用（驱动/CUDA 环境？），运行时将回退 CPU",
+        );
+    }
+}
+
+/// Ensure an interpreter able to run `scripts/ocr_extract.py`: the embedded
+/// runtime with rapidocr-onnxruntime (+ pymupdf when a PDF may need page
+/// rendering). Returns the interpreter path.
+pub(crate) fn ensure_ocr_python(
+    data_dir: &Path,
+    need_pdf: bool,
+    device: &str,
+) -> Result<PathBuf, String> {
+    let mut required: Vec<&str> = vec!["rapidocr_onnxruntime"];
+    let mut packages: Vec<&str> = vec!["rapidocr-onnxruntime"];
+    if need_pdf {
+        required.push("fitz");
+        packages.push("pymupdf");
+    }
+    let exe = python_exe(data_dir);
+    if exe.is_file() && required.iter().all(|m| can_import(&exe, m)) {
+        if device == "cuda" {
+            ensure_onnxruntime_gpu(&exe, &python_dir(data_dir));
+        }
+        return Ok(exe);
+    }
+    ensure_python_base(data_dir)?;
+    let exe = python_exe(data_dir);
+    if !required.iter().all(|m| can_import(&exe, m)) {
+        crate::logging::info(
+            "python",
+            "安装本地 OCR 依赖（rapidocr-onnxruntime / pymupdf）…",
+        );
+        install_packages(&exe, &python_dir(data_dir), &packages)?;
+        crate::logging::info("python", "本地 OCR 依赖安装完成");
+    }
+    if device == "cuda" {
+        ensure_onnxruntime_gpu(&exe, &python_dir(data_dir));
+    }
+    if !required.iter().all(|m| can_import(&exe, m)) {
+        return Err("嵌入式 Python 已就绪但本地 OCR 依赖不可用".to_string());
+    }
+    Ok(exe)
+}
+
 /// Provision the embedded runtime skeleton (download, .pth, pip bootstrap)
 /// without installing any extra package. Shared by the dashscope (cloud ASR)
 /// and whisper-server (local ASR) paths. Returns the interpreter path.
-fn ensure_python_base(data_dir: &Path) -> Result<PathBuf, String> {    let exe = python_exe(data_dir);
+///
+/// Windows-only for now: the embeddable distribution and the pip bootstrap
+/// layout are Windows-specific. On macOS the caller degrades to a system
+/// `python3` where possible (plain text extraction) and the local ASR / OCR
+/// features report this error instead of a cryptic download failure.
+fn ensure_python_base(data_dir: &Path) -> Result<PathBuf, String> {
+    if cfg!(not(windows)) {
+        return Err(
+            "本地 Python 运行时暂未适配 macOS（本地 ASR / 本地 OCR / 带依赖的文档解析不可用），\
+             请使用云端模式"
+                .to_string(),
+        );
+    }
+    let exe = python_exe(data_dir);
     let py_dir = python_dir(data_dir);
     if !exe.is_file() {
         std::fs::create_dir_all(&py_dir)
@@ -202,11 +312,13 @@ fn ensure_python_base(data_dir: &Path) -> Result<PathBuf, String> {    let exe =
         crate::logging::info("python", "引导 pip…");
         let get_pip = download_bytes(GET_PIP_URLS)?;
         let tmp = py_dir.join("get-pip.py");
-        std::fs::write(&tmp, &get_pip)
-            .map_err(|err| format!("写入 get-pip.py 失败：{err}"))?;
+        std::fs::write(&tmp, &get_pip).map_err(|err| format!("写入 get-pip.py 失败：{err}"))?;
         let run_result = run_python(
             &exe,
-            &[tmp.to_string_lossy().to_string(), "--no-warn-script-location".to_string()],
+            &[
+                tmp.to_string_lossy().to_string(),
+                "--no-warn-script-location".to_string(),
+            ],
             &py_dir,
         );
         let _ = std::fs::remove_file(&tmp);
@@ -318,8 +430,7 @@ fn download_one(url: &str) -> Result<Vec<u8>, String> {
 /// Extract a zip archive into `target_dir` with a zip-slip guard.
 fn extract_zip(target_dir: &Path, bytes: &[u8]) -> Result<(), String> {
     let cursor = std::io::Cursor::new(bytes);
-    let mut archive =
-        zip::ZipArchive::new(cursor).map_err(|err| format!("zip 解析失败：{err}"))?;
+    let mut archive = zip::ZipArchive::new(cursor).map_err(|err| format!("zip 解析失败：{err}"))?;
     for i in 0..archive.len() {
         let mut file = archive
             .by_index(i)

--- a/mind-base-desktop/src-tauri/tauri.conf.json
+++ b/mind-base-desktop/src-tauri/tauri.conf.json
@@ -25,7 +25,7 @@
     "active": true,
     "targets": "all",
     "externalBin": ["binaries/ffmpeg", "binaries/ffprobe"],
-    "resources": ["scripts/whisper_server.py", "scripts/doc_extract.py"],
+    "resources": ["scripts/whisper_server.py", "scripts/doc_extract.py", "scripts/ocr_extract.py"],
     "windows": {
       "nsis": {
         "installMode": "currentUser",

--- a/mind-base-desktop/src-tauri/tauri.conf.json
+++ b/mind-base-desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "mind-base-desktop",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "identifier": "io.github.atoncooper.mindbase",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/mind-base-desktop/src/App.css
+++ b/mind-base-desktop/src/App.css
@@ -4575,3 +4575,33 @@ body {
   display: flex;
   justify-content: flex-end;
 }
+
+/* ---------------------------------------------------------------------------
+   文件入库页：拖拽高亮、OCR 扩展名徽章、记录搜索。
+--------------------------------------------------------------------------- */
+
+/* Dropping files anywhere on the import page is supported; the selection
+   card lights up while a drag is over the window. */
+.dropzone.is-active {
+  border-color: var(--line-strong);
+  box-shadow: 0 0 0 2px var(--user-bubble), var(--shadow-lift);
+}
+
+/* Small pill marking image files that go through local OCR. */
+.ext-tag {
+  display: inline-block;
+  margin-left: 6px;
+  padding: 0 6px;
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 16px;
+  border: 1px solid var(--line-strong);
+  border-radius: 999px;
+  color: var(--ink-2);
+  vertical-align: 1px;
+}
+
+/* Search box for the 入库记录 list. */
+.import-filter {
+  margin-bottom: 10px;
+}

--- a/mind-base-desktop/src/components/import-view/ImportView.tsx
+++ b/mind-base-desktop/src/components/import-view/ImportView.tsx
@@ -7,8 +7,9 @@
  * 与视频入库一致为单 flight：运行期间锁定所有入口按钮。
  */
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { open } from "@tauri-apps/plugin-dialog";
+import { getCurrentWebview } from "@tauri-apps/api/webview";
 import {
   IMPORT_EXTENSIONS,
   captureUrls,
@@ -30,6 +31,7 @@ import { KNOWLEDGE_HASH, navigate } from "../../lib/router";
 /** Per-file step labels, matching the video pipeline's vocabulary. */
 const STEP_LABELS: Record<string, string> = {
   parse: "解析文本",
+  ocr: "OCR 识别",
   chunk: "语义分块",
   embed: "向量化",
   store: "写入向量库",
@@ -90,6 +92,53 @@ const RECORD_STATUS_LABELS: Record<DocumentRow["status"], string> = {
   pending: "等待",
 };
 
+/** Extensions ingested through local OCR (keep in sync with file_ingest.rs). */
+const OCR_IMAGE_EXTS: ReadonlySet<string> = new Set(["jpg", "jpeg", "png", "bmp", "webp"]);
+
+/** One parsed line of the URL textarea. */
+interface ParsedUrl {
+  /** Normalized URL (missing https:// is added automatically). */
+  url: string;
+  /** The raw line it came from, for pointing out invalid input. */
+  raw: string;
+}
+
+/**
+ * Parse the URL textarea: whitespace-separated (one per line recommended),
+ * scheme auto-completed, deduped. Lines that cannot become a plausible URL
+ * are returned separately so the UI can point at them.
+ */
+function parseUrlLines(text: string): { valid: ParsedUrl[]; invalid: string[] } {
+  const valid: ParsedUrl[] = [];
+  const invalid: string[] = [];
+  const seen = new Set<string>();
+  for (const raw of text.split(/\s+/).map((line) => line.trim()).filter((line) => line !== "")) {
+    const candidate = /^[a-z][a-z0-9+.-]*:\/\//i.test(raw) ? raw : `https://${raw}`;
+    let host = "";
+    try {
+      host = new URL(candidate).hostname;
+    } catch {
+      host = "";
+    }
+    if (host.includes(".")) {
+      if (!seen.has(candidate)) {
+        seen.add(candidate);
+        valid.push({ url: candidate, raw });
+      }
+    } else {
+      invalid.push(raw);
+    }
+  }
+  return { valid, invalid };
+}
+
+/** Per-URL capture outcome for the status list under the textarea. */
+interface CaptureResult {
+  url: string;
+  state: "pending" | "ok" | "failed";
+  error?: string;
+}
+
 function ImportView() {
   const [files, setFiles] = useState<ScannedFile[] | null>(null);
   const [scanning, setScanning] = useState(false);
@@ -97,6 +146,9 @@ function ImportView() {
   const [urlText, setUrlText] = useState("");
   const [capturing, setCapturing] = useState(false);
   const [captureNote, setCaptureNote] = useState("");
+  // Per-URL outcomes of the latest capture run (pending rows tick over to
+  // ok/failed as events arrive). Cleared when the textarea is edited.
+  const [captureResults, setCaptureResults] = useState<CaptureResult[]>([]);
   const [running, setRunning] = useState(false);
   // Per-file live state keyed by queue index.
   const [runStates, setRunStates] = useState<Map<number, FileRunState>>(new Map());
@@ -109,7 +161,41 @@ function ImportView() {
   const [busyRecordId, setBusyRecordId] = useState("");
   // docId of the record currently being re-ingested (inline retry).
   const [retryingId, setRetryingId] = useState("");
+  // Drag & drop: dropping files/folders anywhere feeds the same scanner as
+  // the picker buttons. `dragging` highlights the selection card.
+  const [dragging, setDragging] = useState(false);
+  // Latest busy state for the drop handler (avoids a stale closure inside
+  // the once-registered drag listener).
+  const busyRef = useRef(false);
+  // Filter query for the 入库记录 list (matches title or path).
+  const [recordQuery, setRecordQuery] = useState("");
   const toast = useToast();
+
+  useEffect(() => {
+    let cancelled = false;
+    let unlisten: (() => void) | undefined;
+    void getCurrentWebview()
+      .onDragDropEvent((event) => {
+        if (event.payload.type === "enter" || event.payload.type === "over") {
+          setDragging(true);
+        } else if (event.payload.type === "leave") {
+          setDragging(false);
+        } else if (event.payload.type === "drop") {
+          setDragging(false);
+          if (busyRef.current) return;
+          if (event.payload.paths.length > 0) void scan(event.payload.paths);
+        }
+      })
+      .then((dispose) => {
+        if (cancelled) dispose();
+        else unlisten = dispose;
+      });
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -172,27 +258,36 @@ function ImportView() {
    */
   async function captureWebpages(): Promise<void> {
     if (capturing || running) return;
-    const urls = urlText
-      .split(/\s+/)
-      .map((line) => line.trim())
-      .filter((line) => line !== "");
-    if (urls.length === 0) {
-      setScanError("请输入至少一个网址（每行一个）");
+    const { valid } = parseUrlLines(urlText);
+    if (valid.length === 0) {
+      setScanError("请输入至少一个有效网址（每行一个）");
       return;
     }
     setCapturing(true);
     setScanError("");
     setCaptureNote("");
+    setCaptureResults(valid.map((entry) => ({ url: entry.url, state: "pending" as const })));
     const failures: string[] = [];
     const captured: ScannedFile[] = [];
     try {
-      const summary = await captureUrls(urls, (event: WebCaptureEvent) => {
-        if (event.type === "urlDone") {
-          captured.push({ path: event.path, name: event.name, size: event.bytes, ext: "html" });
-        } else if (event.type === "urlFailed") {
-          failures.push(`${event.index + 1}. ${event.error}`);
-        }
-      });
+      const summary = await captureUrls(
+        valid.map((entry) => entry.url),
+        (event: WebCaptureEvent) => {
+          if (event.type === "urlDone") {
+            captured.push({ path: event.path, name: event.name, size: event.bytes, ext: "html" });
+            setCaptureResults((prev) =>
+              prev.map((item, i) => (i === event.index ? { ...item, state: "ok" as const } : item)),
+            );
+          } else if (event.type === "urlFailed") {
+            failures.push(`${event.index + 1}. ${event.error}`);
+            setCaptureResults((prev) =>
+              prev.map((item, i) =>
+                i === event.index ? { ...item, state: "failed" as const, error: event.error } : item,
+              ),
+            );
+          }
+        },
+      );
       if (captured.length > 0) {
         setFiles((prev) => {
           const seen = new Set((prev ?? []).map((file) => file.path));
@@ -369,17 +464,31 @@ function ImportView() {
   const pct = total > 0 ? Math.round((finished / total) * 100) : 0;
   const totalBytes = (files ?? []).reduce((sum, file) => sum + file.size, 0);
   const anyStartable = files !== null && files.length > 0;
+  busyRef.current = scanning || running || capturing;
+  // Records filtered by the search box (title or path substring match).
+  const query = recordQuery.trim().toLowerCase();
+  const filteredRecords =
+    records === null || query === ""
+      ? records
+      : records.filter(
+          (row) =>
+            row.videoTitle.toLowerCase().includes(query) ||
+            row.filePath.toLowerCase().includes(query),
+        );
 
   return (
     <>
-      <section className="card">
+      <section className={dragging ? "card dropzone is-active" : "card dropzone"}>
         <h2 className="card__title">
           <span className="card__index">01</span>选择要入库的内容
         </h2>
 
         <p className="hint-text">
-        支持本机文档：txt / md / pdf / docx / html。可选择多个文件或整个文件夹（递归扫描，
-        跳过隐藏目录，单文件上限 50MB、单批上限 500 个）。入库后在「知识库」页检索、提问、出题。
+        支持本机文档：txt / md / pdf / docx / html，以及图片 jpg / jpeg / png / bmp /
+        webp（走本地 OCR 识别，需在「API 设置」中启用本地 OCR 并下载模型；扫描版
+        PDF 无文本层时也会自动回退 OCR）。可选择多个文件或整个文件夹（递归扫描，
+        跳过隐藏目录，单文件上限 50MB、单批上限 500 个），也可以直接把文件或文件夹
+        <strong>拖拽到本页任意位置</strong>。入库后在「知识库」页检索、提问、出题。
         内容重复的文件自动跳过（按内容指纹判重，改名/换位置也不重复入库）；首次导入 PDF /
         DOCX 时会自动下载解析依赖（pymupdf / python-docx）。
         </p>
@@ -398,27 +507,85 @@ function ImportView() {
           </button>
         </div>
 
-        <label className="cfg-label">网页链接入库（每行一个网址，抓取正文后进入下方队列）</label>
+        <label className="cfg-label" htmlFor="webpage-urls">
+          网页链接入库（每行一个网址，抓取正文后进入下方队列）
+        </label>
         <textarea
+          id="webpage-urls"
           className="cfg-input"
           rows={3}
-          placeholder={"https://example.com/article-one\nhttps://example.com/article-two"}
+          placeholder={"https://example.com/article-one\nhttps://example.com/article-two\n（不带 https:// 也会自动补全）"}
           value={urlText}
           disabled={capturing || running}
-          onChange={(event) => setUrlText(event.target.value)}
+          onChange={(event) => {
+            setUrlText(event.target.value);
+            // Stale per-URL outcomes would mislead against edited input.
+            if (captureResults.length > 0) setCaptureResults([]);
+            if (captureNote !== "") setCaptureNote("");
+          }}
         />
+        {(() => {
+          const { valid, invalid } = parseUrlLines(urlText);
+          const failed = captureResults.filter((item) => item.state === "failed").length;
+          const done = captureResults.filter((item) => item.state === "ok").length;
+          return (
+            <p className="hint-text">
+              {urlText.trim() === "" ? (
+                "支持按行或空格分隔；缺 https:// 的网址会自动补全。"
+              ) : (
+                <>
+                  有效网址 {valid.length} 个
+                  {invalid.length > 0 && (
+                    <span className="error-text"> · 无法识别 {invalid.length} 行（如「{invalid[0]}」）</span>
+                  )}
+                  {captureResults.length > 0 && ` · 已完成 ${done}${failed > 0 ? `，失败 ${failed}` : ""}`}
+                </>
+              )}
+            </p>
+          );
+        })()}
+        {captureResults.length > 0 && (
+          <ul className="ws-docs">
+            {captureResults.map((item, index) => (
+              <li key={`${index}-${item.url}`} className="ws-doc">
+                <div className="ws-doc__page">
+                  <span className="ws-doc__page-meta" title={item.error ?? item.url}>
+                    {item.url}
+                  </span>
+                  <span className="ws-doc__page-actions">
+                    <span
+                      className={
+                        item.state === "ok"
+                          ? "status status--ok"
+                          : item.state === "failed"
+                            ? "status status--error"
+                            : "status status--live"
+                      }
+                    >
+                      {item.state === "ok" ? "已抓取" : item.state === "failed" ? "失败" : "抓取中"}
+                    </span>
+                  </span>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
         <div className="card__actions">
           <button
             type="button"
             className="button"
-            disabled={capturing || running}
+            disabled={capturing || running || parseUrlLines(urlText).valid.length === 0}
             title="以浏览器请求头抓取网页并提取正文；被反爬拦截时会给出替代方案"
             onClick={() => void captureWebpages()}
           >
             {capturing ? (
               <>
-                <span className="ingest__spinner" />抓取中
+                <span className="ingest__spinner" />
+                抓取中 {captureResults.filter((item) => item.state !== "pending").length}/
+                {captureResults.length}
               </>
+            ) : parseUrlLines(urlText).valid.length > 0 ? (
+              `抓取网页（${parseUrlLines(urlText).valid.length}）`
             ) : (
               "抓取网页"
             )}
@@ -449,10 +616,18 @@ function ImportView() {
                     </span>
                     <span className="ws-doc__page-meta">
                       {file.ext.toUpperCase()} · {formatBytes(file.size)}
+                      {OCR_IMAGE_EXTS.has(file.ext) && (
+                        <span className="ext-tag" title="该文件走本地 OCR 识别入库">
+                          OCR
+                        </span>
+                      )}
                     </span>
                   </div>
                   <div className="ws-doc__page">
-                    <span className="ws-doc__page-meta">
+                    <span
+                      className="ws-doc__page-meta"
+                      title={run !== undefined && run.state === "failed" ? run.detail : undefined}
+                    >
                       {run !== undefined && run.detail !== "" ? run.detail : file.path}
                     </span>
                     <span className="ws-doc__page-actions">
@@ -536,7 +711,11 @@ function ImportView() {
             className="hint-text"
             style={{ marginLeft: "auto", fontWeight: 400 }}
           >
-            {records !== null ? `${records.length} 个文件` : ""}
+            {records !== null
+              ? query !== ""
+                ? `${filteredRecords?.length ?? 0} / ${records.length} 个文件`
+                : `${records.length} 个文件`
+              : ""}
           </span>
         </h2>
 
@@ -544,12 +723,25 @@ function ImportView() {
           本机文档的入库历史（视频在「知识库」页管理）。删除记录会同时清除其向量；删除后同一文件可重新入库。
         </p>
 
+        {records !== null && records.length > 0 && (
+          <input
+            type="text"
+            className="cfg-input cfg-input--narrow import-filter"
+            placeholder="搜索标题或路径…"
+            value={recordQuery}
+            onChange={(event) => setRecordQuery(event.target.value)}
+          />
+        )}
+
         {records !== null && records.length === 0 && (
           <p className="hint-text">暂无文件入库记录。</p>
         )}
-        {records !== null && records.length > 0 && (
+        {records !== null && records.length > 0 && filteredRecords !== null && filteredRecords.length === 0 && (
+          <p className="hint-text">没有匹配「{recordQuery.trim()}」的记录。</p>
+        )}
+        {filteredRecords !== null && filteredRecords.length > 0 && (
           <ul className="ws-docs">
-            {records.map((row) => (
+            {filteredRecords.map((row) => (
               <li key={row.docId} className="ws-doc">
                 <div className="ws-doc__head">
                   <span className="ws-doc__title" title={row.filePath !== "" ? row.filePath : undefined}>
@@ -558,7 +750,10 @@ function ImportView() {
                   <span className="status status--info">{row.source.toUpperCase()} 文档</span>
                 </div>
                 <div className="ws-doc__page">
-                  <span className="ws-doc__page-meta">
+                  <span
+                    className="ws-doc__page-meta"
+                    title={row.status === "failed" && row.error !== "" ? row.error : undefined}
+                  >
                     {row.chunkCount} 块 · {new Date(row.updatedAt * 1000).toLocaleString()}
                     {row.status === "failed" && row.error !== "" ? ` · ${row.error}` : ""}
                   </span>

--- a/mind-base-desktop/src/lib/file-ingest.ts
+++ b/mind-base-desktop/src/lib/file-ingest.ts
@@ -9,7 +9,8 @@
 
 import { Channel, invoke } from "@tauri-apps/api/core";
 
-/** Extensions accepted by the backend scan (keep in sync with file_ingest.rs). */
+/** Extensions accepted by the backend scan (keep in sync with file_ingest.rs).
+ *  图片（jpg/png/bmp/webp）走本地 OCR 识别入库。 */
 export const IMPORT_EXTENSIONS = [
   "txt",
   "md",
@@ -18,6 +19,11 @@ export const IMPORT_EXTENSIONS = [
   "docx",
   "html",
   "htm",
+  "jpg",
+  "jpeg",
+  "png",
+  "bmp",
+  "webp",
 ] as const;
 
 /** Run kicked off for one selection batch. */


### PR DESCRIPTION
## 变更内容

### 1. OCR 接入文件入库（实际应用）
- **图片入库**：jpg / jpeg / png / bmp / webp 加入导入白名单，整图走本地 OCR（RapidOCR / PP-OCRv4）识别后入库。
- **扫描版 PDF 回退**：PDF 无文本层（`doc_extract.py` 报「没有可提取的文本层」）时自动回退本地 OCR，逐页渲染识别；有文本层的页仍走零损耗的文本提取。
- 新增 `scripts/ocr_extract.py`：加载 0.1.3 已支持下载的本地模型包，`device` 支持 auto（探测 CUDA / DirectML provider）与显式覆盖，GPU 初始化失败自动回退 CPU。
- `ensure_ocr_python`：按需安装 rapidocr-onnxruntime / pymupdf；CUDA 设备时换装 onnxruntime-gpu。
- OCR 不可用时按状态给出引导（未启用 → 指向设置；模型未下载 → 指明下载哪个包）；新增「OCR 识别」进度步骤。

### 2. 文件入库 UI 优化
- **拖拽入库**：文件/文件夹拖到导入页任意位置即可加入队列，拖拽经过时卡片高亮。
- 图片文件显示 **OCR 徽标**；入库记录新增**搜索框**（标题/路径过滤）；截断的失败原因悬停可见完整内容。
- **网页链接输入区**：实时解析反馈（有效/无效行、https 自动补全）、按钮携带网址数量、逐条抓取状态列表（抓取中/已抓取/失败，失败可悬停看原因）。

### 3. macOS 发布适配（第一批）
- 发布流水线扩展为 Windows + macOS（macos-14，Apple Silicon）矩阵；macOS 从 evermeet.cx 拉取 ffmpeg/ffprobe sidecar 按 triple 命名；tag 版本校验改为跨平台 bash+node；macOS job 轮询等待 Release 创建后上传 dmg。
- 嵌入式 Python 运行时（本地 ASR/OCR/文档解析依赖）暂未适配 macOS，已加明确守卫：macOS 上这些功能报错并引导云端模式；纯文本/网页入库不受影响。
- 本批先打通 macOS 产物编译发布链路，后续版本补齐本地功能。

### 4. 版本
- 版本号升至 **0.1.4**。

## 测试
- 真实模型端到端：中英文测试图片识别正确；自制无文本层扫描 PDF 两页全部 OCR 成功。
- `cargo test --lib` 通过（唯一失败为预存的 logging 测试）；`npm run build`（tsc + vite）通过。
- 工作流 YAML 语法经 gh/CI 实际验证（tag 推送后运行）。